### PR TITLE
xds/internal : Fix Connected metric test

### DIFF
--- a/internal/xds/clients/xdsclient/test/helpers_test.go
+++ b/internal/xds/clients/xdsclient/test/helpers_test.go
@@ -284,6 +284,7 @@ type testMetricsReporter struct {
 
 	mu             sync.Mutex
 	asyncReporters map[clients.AsyncReporter]struct{}
+	onReport       func(any)
 }
 
 // newTestMetricsReporter returns a new testMetricsReporter.
@@ -359,6 +360,12 @@ func (r *testMetricsReporter) Drain() {
 // ReportMetric sends the metrics data to the metricsCh channel.
 func (r *testMetricsReporter) ReportMetric(m any) {
 	r.metricsCh.Put(m)
+	r.mu.Lock()
+	cb := r.onReport
+	r.mu.Unlock()
+	if cb != nil {
+		cb(m)
+	}
 }
 
 func (r *testMetricsReporter) RegisterAsyncReporter(reporter clients.AsyncReporter) func() {
@@ -377,8 +384,12 @@ func (r *testMetricsReporter) RegisterAsyncReporter(reporter clients.AsyncReport
 // async gauge metrics at specific precise points in time for verification.
 func (r *testMetricsReporter) triggerAsyncMetrics() {
 	r.mu.Lock()
-	defer r.mu.Unlock()
+	reporters := make([]clients.AsyncReporter, 0, len(r.asyncReporters))
 	for reporter := range r.asyncReporters {
+		reporters = append(reporters, reporter)
+	}
+	r.mu.Unlock()
+	for _, reporter := range reporters {
 		reporter.Report(r)
 	}
 }

--- a/internal/xds/clients/xdsclient/test/helpers_test.go
+++ b/internal/xds/clients/xdsclient/test/helpers_test.go
@@ -284,7 +284,6 @@ type testMetricsReporter struct {
 
 	mu             sync.Mutex
 	asyncReporters map[clients.AsyncReporter]struct{}
-	onReport       func(any)
 }
 
 // newTestMetricsReporter returns a new testMetricsReporter.
@@ -345,6 +344,19 @@ func (r *testMetricsReporter) Receive(ctx context.Context) (any, error) {
 	}
 }
 
+// receiveNonBlocking returns the next recorded metric, if one is immediately
+// available, without blocking. The second return value is false if no metric
+// is buffered.
+func (r *testMetricsReporter) receiveNonBlocking() (any, bool) {
+	select {
+	case got := <-r.metricsCh.Get():
+		r.metricsCh.Load()
+		return got, true
+	default:
+		return nil, false
+	}
+}
+
 // Drain clears all accumulated metrics from the channel.
 func (r *testMetricsReporter) Drain() {
 	for {
@@ -360,12 +372,6 @@ func (r *testMetricsReporter) Drain() {
 // ReportMetric sends the metrics data to the metricsCh channel.
 func (r *testMetricsReporter) ReportMetric(m any) {
 	r.metricsCh.Put(m)
-	r.mu.Lock()
-	cb := r.onReport
-	r.mu.Unlock()
-	if cb != nil {
-		cb(m)
-	}
 }
 
 func (r *testMetricsReporter) RegisterAsyncReporter(reporter clients.AsyncReporter) func() {
@@ -384,12 +390,8 @@ func (r *testMetricsReporter) RegisterAsyncReporter(reporter clients.AsyncReport
 // async gauge metrics at specific precise points in time for verification.
 func (r *testMetricsReporter) triggerAsyncMetrics() {
 	r.mu.Lock()
-	reporters := make([]clients.AsyncReporter, 0, len(r.asyncReporters))
+	defer r.mu.Unlock()
 	for reporter := range r.asyncReporters {
-		reporters = append(reporters, reporter)
-	}
-	r.mu.Unlock()
-	for _, reporter := range reporters {
 		reporter.Report(r)
 	}
 }

--- a/internal/xds/clients/xdsclient/test/metrics_test.go
+++ b/internal/xds/clients/xdsclient/test/metrics_test.go
@@ -650,12 +650,20 @@ func (s) TestConnectedMetric_Reconnection(t *testing.T) {
 
 	sendResponse := make(chan struct{})
 	streamOpened := make(chan struct{}, 10)
+	requestReceived := make(chan struct{}, 10)
 	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{
 		Listener: lis,
 		OnStreamOpen: func(ctx context.Context, _ int64, _ string) error {
 			select {
 			case streamOpened <- struct{}{}:
 			case <-ctx.Done():
+			}
+			return nil
+		},
+		OnStreamRequest: func(int64, *v3discoverypb.DiscoveryRequest) error {
+			select {
+			case requestReceived <- struct{}{}:
+			default:
 			}
 			return nil
 		},
@@ -768,6 +776,14 @@ func (s) TestConnectedMetric_Reconnection(t *testing.T) {
 	lis.Restart()
 
 	waitForStreamSuccess()
+
+	// Wait for the client's first request to reach the server. This ensures
+	// that the client-side runner has completed stream establishment.
+	select {
+	case <-requestReceived:
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for stream request")
+	}
 
 	tmr.triggerAsyncMetrics()
 	if err := tmr.waitForSpecificMetric(ctx, &metrics.XDSClientConnected{ServerURI: mgmtServer.Address, Value: 1}); err != nil {

--- a/internal/xds/clients/xdsclient/test/metrics_test.go
+++ b/internal/xds/clients/xdsclient/test/metrics_test.go
@@ -22,11 +22,14 @@ import (
 	"context"
 	"errors"
 	"net"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/xds/clients"
 	"google.golang.org/grpc/internal/xds/clients/grpctransport"
@@ -648,29 +651,33 @@ func (s) TestConnectedMetric_Reconnection(t *testing.T) {
 	}
 	lis := testutils.NewRestartableListener(l)
 
-	sendResponse := make(chan struct{})
-	streamOpened := make(chan struct{}, 10)
-	requestReceived := make(chan struct{}, 10)
+	fixture := &reconnectionTestFixture{
+		ctx:         ctx,
+		connectedCh: make(chan int64, 100),
+		tmr:         newTestMetricsReporter(),
+	}
+
+	// Start management server and override callbacks to integrate with our sync events.
 	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{
 		Listener: lis,
-		OnStreamOpen: func(ctx context.Context, _ int64, _ string) error {
-			select {
-			case streamOpened <- struct{}{}:
-			case <-ctx.Done():
-			}
-			return nil
-		},
 		OnStreamRequest: func(int64, *v3discoverypb.DiscoveryRequest) error {
-			select {
-			case requestReceived <- struct{}{}:
-			default:
+			fixture.mu.Lock()
+			rr := fixture.reqRecv
+			fixture.mu.Unlock()
+			if rr != nil {
+				rr.Fire()
 			}
 			return nil
 		},
 		OnStreamResponse: func(ctx context.Context, _ int64, _ *v3discoverypb.DiscoveryRequest, _ *v3discoverypb.DiscoveryResponse) {
-			select {
-			case <-sendResponse:
-			case <-ctx.Done():
+			fixture.mu.Lock()
+			sr := fixture.sendResponse
+			fixture.mu.Unlock()
+			if sr != nil {
+				select {
+				case <-sr:
+				case <-ctx.Done():
+				}
 			}
 		},
 	})
@@ -681,37 +688,24 @@ func (s) TestConnectedMetric_Reconnection(t *testing.T) {
 		ServerURI:  mgmtServer.Address,
 		Extensions: grpctransport.ServerIdentifierExtension{ConfigName: "insecure"},
 	}
-	// streamAttemptCh is used by the interceptor to notify the test that a
-	// stream is attempting to open.
-	streamAttemptCh := testutils.NewChannel()
-	// commandCh is used by the test to tell the interceptor whether to block or pass.
-	commandCh := testutils.NewChannel()
-	// blocked is used by the interceptor to signal the test that it has
-	// successfully blocked the stream creation attempt.
-	blocked := make(chan struct{})
-	// unblock is used by the test to release the interceptor and allow the
-	// stream creation to proceed.
-	unblock := make(chan struct{})
 
-	// customGRPCNewClient overrides the gRPC client creation to inject a stream
-	// interceptor that can block ADS stream creation attempts for testing
-	// reconnection behavior.
+	// Dial interceptor allows us to block outgoing stream attempts on demand.
 	customGRPCNewClient := func(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 		interceptor := func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, cops ...grpc.CallOption) (grpc.ClientStream, error) {
-			streamAttemptCh.Send(struct{}{}) // Notify test
+			fixture.mu.Lock()
+			b := fixture.blocked
+			ub := fixture.unblock
+			fixture.mu.Unlock()
 
-			cmd, err := commandCh.Receive(ctx) // Wait for command
-			if err != nil {
-				return nil, err
-			}
-
-			if cmd.(string) == "block" {
-				select {
-				case blocked <- struct{}{}:
-				case <-ctx.Done():
+			if ub != nil {
+				if b != nil {
+					b.Fire()
 				}
-				// Pause stream creation until released by the test.
-				<-unblock
+				select {
+				case <-ub.Done():
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
 			}
 			return streamer(ctx, desc, cc, method, cops...)
 		}
@@ -719,7 +713,6 @@ func (s) TestConnectedMetric_Reconnection(t *testing.T) {
 		return grpc.NewClient(target, opts...)
 	}
 
-	tmr := newTestMetricsReporter()
 	configs := map[string]grpctransport.Config{"insecure": {Credentials: insecure.NewBundle(), GRPCNewClient: customGRPCNewClient}}
 	xdsClientConfig := xdsclient.Config{
 		Servers:          []xdsclient.ServerConfig{{ServerIdentifier: si}},
@@ -729,24 +722,22 @@ func (s) TestConnectedMetric_Reconnection(t *testing.T) {
 		Authorities: map[string]xdsclient.Authority{
 			"": {XDSServers: []xdsclient.ServerConfig{}},
 		},
-		MetricsReporter: tmr,
+		MetricsReporter: fixture.tmr,
 	}
 
-	waitForStreamSuccess := func() {
-		for {
+	// Set up callback on the metrics reporter to track changes to the connected metric.
+	fixture.tmr.onReport = func(m any) {
+		if cm, ok := m.(*metrics.XDSClientConnected); ok {
 			select {
-			case <-streamOpened:
-				return
-			case <-streamAttemptCh.C:
-				commandCh.Send("pass")
-			case <-ctx.Done():
-				t.Fatalf("Timeout waiting for stream success")
+			case fixture.connectedCh <- cm.Value:
+			default:
 			}
 		}
 	}
 
 	// Stop listener to force initial connection failure.
 	lis.Stop()
+	fixture.blockServerResponse()
 
 	client, err := xdsclient.New(xdsClientConfig)
 	if err != nil {
@@ -767,94 +758,156 @@ func (s) TestConnectedMetric_Reconnection(t *testing.T) {
 	// Initiate watch to trigger connection attempt.
 	client.WatchResource(listenerType.TypeURL, listenerName, noopListenerWatcher{})
 
-	tmr.triggerAsyncMetrics()
-	if err := tmr.waitForSpecificMetric(ctx, &metrics.XDSClientConnected{ServerURI: mgmtServer.Address, Value: 0}); err != nil {
+	// 1. Verify that the initial connected state is 0 (disconnected).
+	fixture.tmr.triggerAsyncMetrics()
+	if err := fixture.tmr.waitForSpecificMetric(ctx, &metrics.XDSClientConnected{ServerURI: mgmtServer.Address, Value: 0}); err != nil {
 		t.Fatalf("XDSClientConnected check failed at start - got: %v, want 0", err)
 	}
 
-	// Verify state transitions to connected (Value: 1) when stream succeeds.
+	// 2. Restart listener and verify transition to 1 (connected) when stream succeeds.
 	lis.Restart()
-
-	waitForStreamSuccess()
-
-	// Wait for the client's first request to reach the server. This ensures
-	// that the client-side runner has completed stream establishment.
-	select {
-	case <-requestReceived:
-	case <-ctx.Done():
-		t.Fatal("Timeout waiting for stream request")
-	}
-
-	tmr.triggerAsyncMetrics()
-	if err := tmr.waitForSpecificMetric(ctx, &metrics.XDSClientConnected{ServerURI: mgmtServer.Address, Value: 1}); err != nil {
-		t.Fatalf("XDSClientConnected check failed after 1st NewStream - got: %v, want 1", err)
+	if err := fixture.waitForConnectedValue(1); err != nil {
+		t.Fatalf("Timeout waiting for connected metric to become 1: %v", err)
 	}
 
 	// Push resource update to confirm the connection is functional.
-	close(sendResponse)
-	if err := tmr.waitForSpecificMetric(ctx, &metrics.ResourceUpdateValid{ServerURI: mgmtServer.Address, ResourceType: "ListenerResource"}); err != nil {
+	fixture.allowServerResponse()
+	if err := fixture.tmr.waitForSpecificMetric(ctx, &metrics.ResourceUpdateValid{ServerURI: mgmtServer.Address, ResourceType: "ListenerResource"}); err != nil {
 		t.Fatal(err)
 	}
 
-	// Verify state remains connected (Value: 1) immediately after failure before
-	// NewStream retry.
+	// 3. Stop listener, verify state remains 1 immediately after failure before NewStream retry.
+	blockedEvent, unblockEvent := fixture.blockStreamAttempts()
 	lis.Stop()
 
-	if _, err := streamAttemptCh.Receive(ctx); err != nil {
-		t.Fatalf("Timeout waiting for 2nd stream attempt (block): %v", err)
+	// Wait for the next stream attempt to get blocked by the interceptor.
+	select {
+	case <-blockedEvent.Done():
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for stream attempt to be blocked")
 	}
-	commandCh.Send("block")
 
-	<-blocked
-
-	tmr.triggerAsyncMetrics()
-	if err := tmr.waitForSpecificMetric(ctx, &metrics.XDSClientConnected{ServerURI: mgmtServer.Address, Value: 1}); err != nil {
+	// State should still remain connected (Value: 1) during the retry phase.
+	fixture.tmr.triggerAsyncMetrics()
+	if err := fixture.tmr.waitForSpecificMetric(ctx, &metrics.XDSClientConnected{ServerURI: mgmtServer.Address, Value: 1}); err != nil {
 		t.Fatalf("XDSClientConnected check failed while NewStream is blocked - got: %v, want 1", err)
 	}
 
-	// Verify state transitions to disconnected (Value: 0) after NewStream attempt
-	// fails.
-	close(unblock)
-
-	if err := tmr.waitForSpecificMetric(ctx, &metrics.ServerFailure{ServerURI: mgmtServer.Address}); err != nil {
+	// 4. Release blocked attempt, let it fail, and verify transition to 0 (disconnected).
+	unblockEvent.Fire()
+	if err := fixture.tmr.waitForSpecificMetric(ctx, &metrics.ServerFailure{ServerURI: mgmtServer.Address}); err != nil {
 		t.Fatal(err)
 	}
 
-	tmr.triggerAsyncMetrics()
-	if err := tmr.waitForSpecificMetric(ctx, &metrics.XDSClientConnected{ServerURI: mgmtServer.Address, Value: 0}); err != nil {
+	fixture.tmr.triggerAsyncMetrics()
+	if err := fixture.tmr.waitForSpecificMetric(ctx, &metrics.XDSClientConnected{ServerURI: mgmtServer.Address, Value: 0}); err != nil {
 		t.Fatalf("XDSClientConnected check failed after NewStream failure - got: %v, want 0", err)
 	}
 
-	sendResponse = make(chan struct{})
+	// 5. Verify state remains 0 while waiting for first response on new stream.
+	reqRecvEvent := grpcsync.NewEvent()
+	fixture.mu.Lock()
+	fixture.reqRecv = reqRecvEvent
+	fixture.mu.Unlock()
+	fixture.allowStreamAttempts()
+	fixture.blockServerResponse()
 
-	// Verify state remains disconnected (Value: 0) while waiting for the first
-	// response on the new stream.
 	lis.Restart()
 
-	// Clear channels to ensure fresh readings.
-	for len(streamOpened) > 0 {
-		<-streamOpened
+	// Wait for the server to receive the request on the new stream.
+	select {
+	case <-reqRecvEvent.Done():
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for request on new stream")
 	}
 
-	waitForStreamSuccess()
-
-	tmr.Drain()
-	tmr.triggerAsyncMetrics()
-	if err := tmr.waitForSpecificMetric(ctx, &metrics.XDSClientConnected{ServerURI: mgmtServer.Address, Value: 0}); err != nil {
+	// Metric should still be 0 before the first response.
+	fixture.tmr.triggerAsyncMetrics()
+	if err := fixture.tmr.waitForSpecificMetric(ctx, &metrics.XDSClientConnected{ServerURI: mgmtServer.Address, Value: 0}); err != nil {
 		t.Fatalf("XDSClientConnected check failed after successful NewStream but before response - got: %v, want 0", err)
 	}
 
-	// Verify state returns to connected (Value: 1) after receiving the first
-	// response on the new stream.
-	close(sendResponse)
-
-	if err := tmr.waitForSpecificMetric(ctx, &metrics.ResourceUpdateValid{ServerURI: mgmtServer.Address, ResourceType: "ListenerResource"}); err != nil {
+	// 6. Verify state returns to 1 after receiving response on the new stream.
+	fixture.allowServerResponse()
+	if err := fixture.tmr.waitForSpecificMetric(ctx, &metrics.ResourceUpdateValid{ServerURI: mgmtServer.Address, ResourceType: "ListenerResource"}); err != nil {
 		t.Fatal(err)
 	}
 
-	tmr.triggerAsyncMetrics()
-	if err := tmr.waitForSpecificMetric(ctx, &metrics.XDSClientConnected{ServerURI: mgmtServer.Address, Value: 1}); err != nil {
+	fixture.tmr.triggerAsyncMetrics()
+	if err := fixture.tmr.waitForSpecificMetric(ctx, &metrics.XDSClientConnected{ServerURI: mgmtServer.Address, Value: 1}); err != nil {
 		t.Fatalf("XDSClientConnected check failed after response- got: %v, want 1", err)
+	}
+}
+
+// reconnectionTestFixture encapsulates the shared synchronization state and helper
+// methods used by TestConnectedMetric_Reconnection to simulate flaky network and
+// control connection flows.
+type reconnectionTestFixture struct {
+	ctx context.Context
+	mu  sync.Mutex
+	// reqRecv fires when the management server receives a new request stream attempt.
+	reqRecv *grpcsync.Event
+	// sendResponse blocks the management server's response when non-nil, allowing
+	// us to pause stream updates until allowed by the test.
+	sendResponse chan struct{}
+	// blocked fires when a new client stream connection attempt is blocked by our custom dialer.
+	blocked *grpcsync.Event
+	// unblock is checked by our custom dialer; it waits for this event to be fired before
+	// allowing blocked connection attempts to proceed.
+	unblock *grpcsync.Event
+	// connectedCh receives values representing updates to the 'grpc.xds_client.connected' metric.
+	connectedCh chan int64
+	// tmr is the metrics reporter used to query metric counts and trigger async pulses.
+	tmr *testMetricsReporter
+}
+
+func (f *reconnectionTestFixture) blockServerResponse() {
+	f.mu.Lock()
+	f.sendResponse = make(chan struct{})
+	f.mu.Unlock()
+}
+
+func (f *reconnectionTestFixture) allowServerResponse() {
+	f.mu.Lock()
+	if f.sendResponse != nil {
+		close(f.sendResponse)
+	}
+	f.mu.Unlock()
+}
+
+func (f *reconnectionTestFixture) blockStreamAttempts() (blockedEvent *grpcsync.Event, unblockEvent *grpcsync.Event) {
+	blockedEvent = grpcsync.NewEvent()
+	unblockEvent = grpcsync.NewEvent()
+	f.mu.Lock()
+	f.blocked = blockedEvent
+	f.unblock = unblockEvent
+	f.mu.Unlock()
+	return
+}
+
+func (f *reconnectionTestFixture) allowStreamAttempts() {
+	f.mu.Lock()
+	f.blocked = nil
+	f.unblock = nil
+	f.mu.Unlock()
+}
+
+func (f *reconnectionTestFixture) waitForConnectedValue(want int64) error {
+	// Drain any existing queued metric readings.
+	for len(f.connectedCh) > 0 {
+		<-f.connectedCh
+	}
+	for {
+		f.tmr.triggerAsyncMetrics()
+		select {
+		case val := <-f.connectedCh:
+			if val == want {
+				return nil
+			}
+		case <-time.After(10 * time.Millisecond):
+		case <-f.ctx.Done():
+			return f.ctx.Err()
+		}
 	}
 }
 

--- a/internal/xds/clients/xdsclient/test/metrics_test.go
+++ b/internal/xds/clients/xdsclient/test/metrics_test.go
@@ -21,6 +21,7 @@ package xdsclient_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"sync"
 	"testing"
@@ -29,10 +30,10 @@ import (
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/xds/clients"
 	"google.golang.org/grpc/internal/xds/clients/grpctransport"
+	"google.golang.org/grpc/internal/xds/clients/internal/syncutil"
 	"google.golang.org/grpc/internal/xds/clients/internal/testutils/e2e"
 	"google.golang.org/grpc/internal/xds/clients/xdsclient"
 	"google.golang.org/grpc/internal/xds/clients/xdsclient/internal/xdsresource"
@@ -635,12 +636,21 @@ func (s) TestResourceMetrics_Extended(t *testing.T) {
 	}
 }
 
-// TestConnectedMetric_Reconnection verifies "grpc.xds_client.connected" metric
-// accuracy during flaky network conditions. It uses a restartable listener and
-// a dial interceptor to pause connection attempts. It asserts that the
-// connected state pulses to 1 when a stream succeeds, remains 1 immediately
-// after failures before retries, transitions to 0 after subsequent failures,
-// and returns to 1 only after successful stream recreation.
+// TestConnectedMetric_Reconnection verifies the behavior of the
+// "grpc.xds_client.connected" metric as the xDS client goes through stream
+// failures and reconnections. It uses a restartable listener to break the
+// stream, a client-side stream interceptor to hold up stream creation
+// attempts, and callbacks on the management server to block responses and to
+// wait for requests received by the server. It verifies that the metric
+// reports:
+//   - 0 before the client connects to the server for the very first time
+//   - 1 as soon as the very first stream is created, even before a response
+//     is received on it
+//   - 1 when a stream on which a response was previously received breaks,
+//     and a new stream creation attempt is still in progress
+//   - 0 when a stream creation attempt fails
+//   - 0 on a newly created stream, until a response is received on it
+//   - 1 once a response is received on the newly created stream
 func (s) TestConnectedMetric_Reconnection(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
@@ -651,35 +661,14 @@ func (s) TestConnectedMetric_Reconnection(t *testing.T) {
 	}
 	lis := testutils.NewRestartableListener(l)
 
-	fixture := &reconnectionTestFixture{
-		ctx:         ctx,
-		connectedCh: make(chan int64, 100),
-		tmr:         newTestMetricsReporter(),
-	}
-
-	// Start management server and override callbacks to integrate with our sync events.
+	// Start a management server whose stream callbacks are wired up to the
+	// fixture. This allows the test to block server responses and to wait
+	// for requests received by the server.
+	fixture := newReconnectionTestFixture(t)
 	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{
-		Listener: lis,
-		OnStreamRequest: func(int64, *v3discoverypb.DiscoveryRequest) error {
-			fixture.mu.Lock()
-			rr := fixture.reqRecv
-			fixture.mu.Unlock()
-			if rr != nil {
-				rr.Fire()
-			}
-			return nil
-		},
-		OnStreamResponse: func(ctx context.Context, _ int64, _ *v3discoverypb.DiscoveryRequest, _ *v3discoverypb.DiscoveryResponse) {
-			fixture.mu.Lock()
-			sr := fixture.sendResponse
-			fixture.mu.Unlock()
-			if sr != nil {
-				select {
-				case <-sr:
-				case <-ctx.Done():
-				}
-			}
-		},
+		Listener:         lis,
+		OnStreamRequest:  fixture.onStreamRequest,
+		OnStreamResponse: fixture.onStreamResponse,
 	})
 	nodeID := uuid.New().String()
 
@@ -689,31 +678,13 @@ func (s) TestConnectedMetric_Reconnection(t *testing.T) {
 		Extensions: grpctransport.ServerIdentifierExtension{ConfigName: "insecure"},
 	}
 
-	// Dial interceptor allows us to block outgoing stream attempts on demand.
-	customGRPCNewClient := func(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-		interceptor := func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, cops ...grpc.CallOption) (grpc.ClientStream, error) {
-			fixture.mu.Lock()
-			b := fixture.blocked
-			ub := fixture.unblock
-			fixture.mu.Unlock()
-
-			if ub != nil {
-				if b != nil {
-					b.Fire()
-				}
-				select {
-				case <-ub.Done():
-				case <-ctx.Done():
-					return nil, ctx.Err()
-				}
-			}
-			return streamer(ctx, desc, cc, method, cops...)
-		}
-		opts = append(opts, grpc.WithStreamInterceptor(interceptor))
+	// Inject a stream interceptor that allows the test to hold up stream
+	// creation attempts from the client.
+	grpcNewClient := func(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+		opts = append(opts, grpc.WithStreamInterceptor(fixture.streamInterceptor))
 		return grpc.NewClient(target, opts...)
 	}
-
-	configs := map[string]grpctransport.Config{"insecure": {Credentials: insecure.NewBundle(), GRPCNewClient: customGRPCNewClient}}
+	configs := map[string]grpctransport.Config{"insecure": {Credentials: insecure.NewBundle(), GRPCNewClient: grpcNewClient}}
 	xdsClientConfig := xdsclient.Config{
 		Servers:          []xdsclient.ServerConfig{{ServerIdentifier: si}},
 		Node:             clients.Node{ID: nodeID},
@@ -725,19 +696,11 @@ func (s) TestConnectedMetric_Reconnection(t *testing.T) {
 		MetricsReporter: fixture.tmr,
 	}
 
-	// Set up callback on the metrics reporter to track changes to the connected metric.
-	fixture.tmr.onReport = func(m any) {
-		if cm, ok := m.(*metrics.XDSClientConnected); ok {
-			select {
-			case fixture.connectedCh <- cm.Value:
-			default:
-			}
-		}
-	}
-
-	// Stop listener to force initial connection failure.
+	// Stop the listener before creating the client to force initial stream
+	// creation attempts to fail, and block server responses so that the test
+	// controls when the first response is sent.
 	lis.Stop()
-	fixture.blockServerResponse()
+	fixture.blockServerResponses()
 
 	client, err := xdsclient.New(xdsClientConfig)
 	if err != nil {
@@ -755,160 +718,292 @@ func (s) TestConnectedMetric_Reconnection(t *testing.T) {
 		t.Fatalf("Failed to update management server: %v", err)
 	}
 
-	// Initiate watch to trigger connection attempt.
+	// Watch a resource to kick off stream creation attempts, which fail
+	// because the listener is stopped, and verify that the metric reports 0.
 	client.WatchResource(listenerType.TypeURL, listenerName, noopListenerWatcher{})
-
-	// 1. Verify that the initial connected state is 0 (disconnected).
-	fixture.tmr.triggerAsyncMetrics()
-	if err := fixture.tmr.waitForSpecificMetric(ctx, &metrics.XDSClientConnected{ServerURI: mgmtServer.Address, Value: 0}); err != nil {
-		t.Fatalf("XDSClientConnected check failed at start - got: %v, want 0", err)
+	if err := fixture.waitForConnectedValue(ctx, 0); err != nil {
+		t.Fatalf("Connected metric check before the first connection: %v", err)
 	}
 
-	// 2. Restart listener and verify transition to 1 (connected) when stream succeeds.
+	// Restart the listener and wait for the server to receive a request,
+	// which guarantees that the client has finished creating the stream. The
+	// very first stream is considered established as soon as it is created,
+	// so the metric must report 1 even before a response is received.
+	fixture.expectNextStreamRequest()
 	lis.Restart()
-	if err := fixture.waitForConnectedValue(1); err != nil {
-		t.Fatalf("Timeout waiting for connected metric to become 1: %v", err)
+	if err := fixture.waitForStreamRequest(ctx); err != nil {
+		t.Fatalf("Waiting for the request on the first stream: %v", err)
+	}
+	if err := fixture.verifyConnectedValue(1); err != nil {
+		t.Fatalf("Connected metric check after first stream creation: %v", err)
 	}
 
-	// Push resource update to confirm the connection is functional.
-	fixture.allowServerResponse()
-	if err := fixture.tmr.waitForSpecificMetric(ctx, &metrics.ResourceUpdateValid{ServerURI: mgmtServer.Address, ResourceType: "ListenerResource"}); err != nil {
-		t.Fatal(err)
+	// Release the pending response and wait for the client to ACK it. The
+	// ACK guarantees that the client has received a response on the stream:
+	// only a stream on which a response was received remains established
+	// when it breaks, until a new stream creation attempt fails.
+	fixture.expectNextStreamRequest()
+	fixture.allowServerResponses()
+	if err := fixture.waitForStreamRequest(ctx); err != nil {
+		t.Fatalf("Waiting for the client to ACK the response: %v", err)
 	}
 
-	// 3. Stop listener, verify state remains 1 immediately after failure before NewStream retry.
-	blockedEvent, unblockEvent := fixture.blockStreamAttempts()
+	// Stop the listener to break the stream, holding up the stream creation
+	// attempt that follows. Verify that the metric still reports 1, since
+	// the new attempt has not failed yet.
+	fixture.blockStreamAttempts()
 	lis.Stop()
-
-	// Wait for the next stream attempt to get blocked by the interceptor.
-	select {
-	case <-blockedEvent.Done():
-	case <-ctx.Done():
-		t.Fatal("Timeout waiting for stream attempt to be blocked")
+	if err := fixture.waitForStreamAttemptBlocked(ctx); err != nil {
+		t.Fatalf("Waiting for a stream creation attempt to be blocked: %v", err)
+	}
+	if err := fixture.verifyConnectedValue(1); err != nil {
+		t.Fatalf("Connected metric check while stream creation is blocked: %v", err)
 	}
 
-	// State should still remain connected (Value: 1) during the retry phase.
-	fixture.tmr.triggerAsyncMetrics()
-	if err := fixture.tmr.waitForSpecificMetric(ctx, &metrics.XDSClientConnected{ServerURI: mgmtServer.Address, Value: 1}); err != nil {
-		t.Fatalf("XDSClientConnected check failed while NewStream is blocked - got: %v, want 1", err)
+	// Release the blocked attempt and let it fail, since the listener is
+	// still stopped. Verify that the metric transitions to 0.
+	fixture.releaseBlockedStreamAttempt()
+	if err := fixture.waitForConnectedValue(ctx, 0); err != nil {
+		t.Fatalf("Connected metric check after stream creation failure: %v", err)
 	}
 
-	// 4. Release blocked attempt, let it fail, and verify transition to 0 (disconnected).
-	unblockEvent.Fire()
-	if err := fixture.tmr.waitForSpecificMetric(ctx, &metrics.ServerFailure{ServerURI: mgmtServer.Address}); err != nil {
-		t.Fatal(err)
-	}
-
-	fixture.tmr.triggerAsyncMetrics()
-	if err := fixture.tmr.waitForSpecificMetric(ctx, &metrics.XDSClientConnected{ServerURI: mgmtServer.Address, Value: 0}); err != nil {
-		t.Fatalf("XDSClientConnected check failed after NewStream failure - got: %v, want 0", err)
-	}
-
-	// 5. Verify state remains 0 while waiting for first response on new stream.
-	reqRecvEvent := grpcsync.NewEvent()
-	fixture.mu.Lock()
-	fixture.reqRecv = reqRecvEvent
-	fixture.mu.Unlock()
-	fixture.allowStreamAttempts()
-	fixture.blockServerResponse()
-
+	// Restart the listener, with server responses blocked, and wait for the
+	// server to receive a request on a new stream. Streams created after the
+	// very first are not considered established until a response is received
+	// on them, so the metric must still report 0.
+	fixture.expectNextStreamRequest()
+	fixture.blockServerResponses()
 	lis.Restart()
-
-	// Wait for the server to receive the request on the new stream.
-	select {
-	case <-reqRecvEvent.Done():
-	case <-ctx.Done():
-		t.Fatal("Timeout waiting for request on new stream")
+	if err := fixture.waitForStreamRequest(ctx); err != nil {
+		t.Fatalf("Waiting for the request on the new stream: %v", err)
+	}
+	if err := fixture.verifyConnectedValue(0); err != nil {
+		t.Fatalf("Connected metric check before response on the new stream: %v", err)
 	}
 
-	// Metric should still be 0 before the first response.
-	fixture.tmr.triggerAsyncMetrics()
-	if err := fixture.tmr.waitForSpecificMetric(ctx, &metrics.XDSClientConnected{ServerURI: mgmtServer.Address, Value: 0}); err != nil {
-		t.Fatalf("XDSClientConnected check failed after successful NewStream but before response - got: %v, want 0", err)
-	}
-
-	// 6. Verify state returns to 1 after receiving response on the new stream.
-	fixture.allowServerResponse()
-	if err := fixture.tmr.waitForSpecificMetric(ctx, &metrics.ResourceUpdateValid{ServerURI: mgmtServer.Address, ResourceType: "ListenerResource"}); err != nil {
-		t.Fatal(err)
-	}
-
-	fixture.tmr.triggerAsyncMetrics()
-	if err := fixture.tmr.waitForSpecificMetric(ctx, &metrics.XDSClientConnected{ServerURI: mgmtServer.Address, Value: 1}); err != nil {
-		t.Fatalf("XDSClientConnected check failed after response- got: %v, want 1", err)
+	// Release the pending response and verify that the metric transitions
+	// back to 1 once the client receives it.
+	fixture.allowServerResponses()
+	if err := fixture.waitForConnectedValue(ctx, 1); err != nil {
+		t.Fatalf("Connected metric check after response on the new stream: %v", err)
 	}
 }
 
-// reconnectionTestFixture encapsulates the shared synchronization state and helper
-// methods used by TestConnectedMetric_Reconnection to simulate flaky network and
-// control connection flows.
+// reconnectionTestFixture contains the synchronization machinery used by
+// TestConnectedMetric_Reconnection to deterministically drive the xDS client
+// through stream failures and reconnections.
 type reconnectionTestFixture struct {
-	ctx context.Context
-	mu  sync.Mutex
-	// reqRecv fires when the management server receives a new request stream attempt.
-	reqRecv *grpcsync.Event
-	// sendResponse blocks the management server's response when non-nil, allowing
-	// us to pause stream updates until allowed by the test.
-	sendResponse chan struct{}
-	// blocked fires when a new client stream connection attempt is blocked by our custom dialer.
-	blocked *grpcsync.Event
-	// unblock is checked by our custom dialer; it waits for this event to be fired before
-	// allowing blocked connection attempts to proceed.
-	unblock *grpcsync.Event
-	// connectedCh receives values representing updates to the 'grpc.xds_client.connected' metric.
-	connectedCh chan int64
-	// tmr is the metrics reporter used to query metric counts and trigger async pulses.
+	// tmr is the metrics reporter registered with the xDS client under test.
 	tmr *testMetricsReporter
+
+	mu sync.Mutex // Guards all fields below.
+	// reqReceived fires when the management server receives a request. It is
+	// armed by expectNextStreamRequest, and is nil until then.
+	reqReceived *syncutil.Event
+	// sendResponse, when non-nil, holds back responses from the management
+	// server until the channel is closed by allowServerResponses.
+	sendResponse chan struct{}
+	// attemptBlocked fires when a stream creation attempt from the client is
+	// held up by the stream interceptor.
+	attemptBlocked *syncutil.Event
+	// attemptUnblock releases held up stream creation attempts when fired.
+	// When nil, stream creation attempts proceed unhindered.
+	attemptUnblock *syncutil.Event
 }
 
-func (f *reconnectionTestFixture) blockServerResponse() {
-	f.mu.Lock()
-	f.sendResponse = make(chan struct{})
-	f.mu.Unlock()
+func newReconnectionTestFixture(t *testing.T) *reconnectionTestFixture {
+	f := &reconnectionTestFixture{tmr: newTestMetricsReporter()}
+	// Guarantee that a blocked server response does not outlive the test: if
+	// the test fails between blockServerResponses and allowServerResponses,
+	// the management server's handler goroutine would otherwise remain
+	// blocked in onStreamResponse and be flagged by the leak checker.
+	t.Cleanup(f.allowServerResponses)
+	return f
 }
 
-func (f *reconnectionTestFixture) allowServerResponse() {
+// onStreamRequest implements the management server's OnStreamRequest
+// callback. It fires the reqReceived event, if armed via
+// expectNextStreamRequest.
+func (f *reconnectionTestFixture) onStreamRequest(int64, *v3discoverypb.DiscoveryRequest) error {
 	f.mu.Lock()
-	if f.sendResponse != nil {
-		close(f.sendResponse)
+	defer f.mu.Unlock()
+	if f.reqReceived != nil {
+		f.reqReceived.Fire()
 	}
-	f.mu.Unlock()
+	return nil
 }
 
-func (f *reconnectionTestFixture) blockStreamAttempts() (blockedEvent *grpcsync.Event, unblockEvent *grpcsync.Event) {
-	blockedEvent = grpcsync.NewEvent()
-	unblockEvent = grpcsync.NewEvent()
+// onStreamResponse implements the management server's OnStreamResponse
+// callback. It holds back the response for as long as server responses are
+// blocked. The given context is not the test's context: it comes from the
+// management server's response, and for responses generated from its cache
+// it is a background context that is never canceled. A test cleanup
+// registered in newReconnectionTestFixture therefore releases blocked
+// responses, guaranteeing that this callback eventually returns.
+func (f *reconnectionTestFixture) onStreamResponse(ctx context.Context, _ int64, _ *v3discoverypb.DiscoveryRequest, _ *v3discoverypb.DiscoveryResponse) {
 	f.mu.Lock()
-	f.blocked = blockedEvent
-	f.unblock = unblockEvent
+	sendResponse := f.sendResponse
 	f.mu.Unlock()
-	return
-}
 
-func (f *reconnectionTestFixture) allowStreamAttempts() {
-	f.mu.Lock()
-	f.blocked = nil
-	f.unblock = nil
-	f.mu.Unlock()
-}
-
-func (f *reconnectionTestFixture) waitForConnectedValue(want int64) error {
-	// Drain any existing queued metric readings.
-	for len(f.connectedCh) > 0 {
-		<-f.connectedCh
+	if sendResponse == nil {
+		return
 	}
-	for {
-		f.tmr.triggerAsyncMetrics()
+	select {
+	case <-sendResponse:
+	case <-ctx.Done():
+	}
+}
+
+// streamInterceptor is a client-side stream interceptor that holds up stream
+// creation attempts for as long as they are blocked via blockStreamAttempts.
+func (f *reconnectionTestFixture) streamInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	f.mu.Lock()
+	blocked, unblock := f.attemptBlocked, f.attemptUnblock
+	f.mu.Unlock()
+
+	if unblock != nil {
+		blocked.Fire()
 		select {
-		case val := <-f.connectedCh:
-			if val == want {
-				return nil
-			}
-		case <-time.After(10 * time.Millisecond):
-		case <-f.ctx.Done():
-			return f.ctx.Err()
+		case <-unblock.Done():
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		}
 	}
+	return streamer(ctx, desc, cc, method, opts...)
+}
+
+// expectNextStreamRequest arms the fixture to signal receipt of the next
+// request by the management server, in a subsequent call to
+// waitForStreamRequest.
+func (f *reconnectionTestFixture) expectNextStreamRequest() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reqReceived = syncutil.NewEvent()
+}
+
+// waitForStreamRequest blocks until the management server receives a request,
+// following the previous call to expectNextStreamRequest.
+func (f *reconnectionTestFixture) waitForStreamRequest(ctx context.Context) error {
+	f.mu.Lock()
+	reqReceived := f.reqReceived
+	f.mu.Unlock()
+
+	if reqReceived == nil {
+		return errors.New("waitForStreamRequest called without a preceding call to expectNextStreamRequest")
+	}
+	select {
+	case <-reqReceived.Done():
+		return nil
+	case <-ctx.Done():
+		return errors.New("timeout waiting for the management server to receive a request")
+	}
+}
+
+// blockServerResponses causes the management server to hold back responses
+// until allowServerResponses is called.
+func (f *reconnectionTestFixture) blockServerResponses() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sendResponse = make(chan struct{})
+}
+
+// allowServerResponses releases responses held back by the management server,
+// and allows subsequent responses to be sent unhindered.
+func (f *reconnectionTestFixture) allowServerResponses() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.sendResponse != nil {
+		close(f.sendResponse)
+		f.sendResponse = nil
+	}
+}
+
+// blockStreamAttempts causes stream creation attempts from the client to be
+// held up in the stream interceptor until releaseBlockedStreamAttempt is
+// called.
+func (f *reconnectionTestFixture) blockStreamAttempts() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.attemptBlocked = syncutil.NewEvent()
+	f.attemptUnblock = syncutil.NewEvent()
+}
+
+// waitForStreamAttemptBlocked blocks until a stream creation attempt from the
+// client is held up in the stream interceptor.
+func (f *reconnectionTestFixture) waitForStreamAttemptBlocked(ctx context.Context) error {
+	f.mu.Lock()
+	blocked := f.attemptBlocked
+	f.mu.Unlock()
+
+	if blocked == nil {
+		return errors.New("waitForStreamAttemptBlocked called without a preceding call to blockStreamAttempts")
+	}
+	select {
+	case <-blocked.Done():
+		return nil
+	case <-ctx.Done():
+		return errors.New("timeout waiting for a stream creation attempt to be blocked")
+	}
+}
+
+// releaseBlockedStreamAttempt releases the stream creation attempt currently
+// held up in the stream interceptor, and allows subsequent attempts to
+// proceed unhindered.
+func (f *reconnectionTestFixture) releaseBlockedStreamAttempt() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.attemptUnblock != nil {
+		f.attemptUnblock.Fire()
+	}
+}
+
+// connectedValue triggers a report of async metrics and returns the reported
+// value of the "grpc.xds_client.connected" metric. The second return value
+// is false if the metric was not reported, which is the case until the
+// client creates a channel to the management server.
+//
+// Metrics reported earlier are discarded before triggering the report. And
+// since this metric is only reported when async metrics reporting is
+// triggered from this test, and reporting happens synchronously, the
+// returned value is guaranteed to reflect the current state of the client.
+func (f *reconnectionTestFixture) connectedValue() (int64, bool) {
+	f.tmr.Drain()
+	f.tmr.triggerAsyncMetrics()
+	for {
+		m, ok := f.tmr.receiveNonBlocking()
+		if !ok {
+			// The metric was not part of the triggered report.
+			return 0, false
+		}
+		if cm, ok := m.(*metrics.XDSClientConnected); ok {
+			return cm.Value, true
+		}
+	}
+}
+
+// verifyConnectedValue verifies that the "grpc.xds_client.connected" metric
+// currently reports want.
+func (f *reconnectionTestFixture) verifyConnectedValue(want int64) error {
+	got, ok := f.connectedValue()
+	if !ok {
+		return errors.New("connected metric was not reported")
+	}
+	if got != want {
+		return fmt.Errorf("connected metric reports %d, want %d", got, want)
+	}
+	return nil
+}
+
+// waitForConnectedValue polls until the "grpc.xds_client.connected" metric
+// reports want, or the given context expires.
+func (f *reconnectionTestFixture) waitForConnectedValue(ctx context.Context, want int64) error {
+	var lastErr error
+	for ; ctx.Err() == nil; <-time.After(defaultTestShortTimeout) {
+		if lastErr = f.verifyConnectedValue(want); lastErr == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("timeout waiting for connected metric to report %d: %v", want, lastErr)
 }
 
 // TestResourceMetrics_AuthorityOldStyle verifies that the xDS client correctly


### PR DESCRIPTION
Fixes #9141 
# Fix flaky TestConnectedMetric_Reconnection in xDS Client metrics test
### Description / Root Cause
A race condition existed in `TestConnectedMetric_Reconnection` between the server-side stream open event and the client-side stream establishment registration:
1. After restarting the listener, the test awaited `waitForStreamSuccess()`, which unblocks when the control plane executes the `OnStreamOpen` callback.
2. Immediately after, the test scraped the client's async metrics, expecting `XDSClientConnected` to be `1`.
3. However, the client-side runner goroutine was still completing the `NewStream` call stack and had not yet set the internal `streamEstablished` flag to `true`.
4. Under CPU contention or slower goroutine scheduling, the scrape captured `0`, causing the test to block indefinitely and time out.

### Solution
Introduced event-based synchronization to guarantee the client has completed stream establishment before scraping the metric value:
1. Registered an `OnStreamRequest` callback on the test's management server that writes to a new `requestReceived` channel.
2. In the test, blocked on `<-requestReceived` after the stream succeeds.
3. Since a discovery request is only sent to the server *after* the client runner has successfully created the stream and set the `streamEstablished` flag, receiving the request on the server guarantees the client-side state is updated.

This completely removes the race condition without relying on periodic polling loops or arbitrary sleeps.

### Verification
* Reproduced the failure by injecting a `100ms` delay on the client runner immediately before registering stream establishment, causing 100% failure rate.
* Verified that the test now compiles and passes successfully (even with the delay active).

RELEASE NOTES: none