### PR TITLE
internal/transport: increase test timeout locally in TestAccountCheckWindowSizeWithLargeWindow

### DIFF
--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -1869,8 +1869,7 @@ func (s) TestAccountCheckWindowSizeWithLargeWindow(t *testing.T) {
 	}
 	// This test exercises the largest windows and message sizes of the flow
 	// control account checks, so it can be slow under load (e.g. the race
-	// detector on a busy CI machine). Use a longer timeout for just this test
-	// instead of slowing down all of them.
+	// detector on a busy CI machine).
 	testFlowControlAccountCheck(t, 1024*1024, wc, 30*time.Second)
 }
 

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -1891,6 +1891,7 @@ func (s) TestAccountCheckDynamicWindowLargeMessage(t *testing.T) {
 }
 
 func testFlowControlAccountCheck(t *testing.T, msgSize int, wc windowSizeConfig) {
+	const timeout = 30 * time.Second
 	sc := &ServerConfig{
 		InitialWindowSize:     wc.serverStream,
 		InitialConnWindowSize: wc.serverConn,
@@ -1903,7 +1904,7 @@ func testFlowControlAccountCheck(t *testing.T, msgSize int, wc windowSizeConfig)
 		StaticWindowSize:      true,
 		BufferPool:            mem.DefaultBufferPool(),
 	}
-	server, client, cancel := setUpWithOptionsAndTimeout(t, 0, sc, pingpong, co, 30*time.Second)
+	server, client, cancel := setUpWithOptionsAndTimeout(t, 0, sc, pingpong, co, timeout)
 	defer cancel()
 	defer server.stop()
 	defer client.Close(fmt.Errorf("closed manually by test"))
@@ -1922,7 +1923,7 @@ func testFlowControlAccountCheck(t *testing.T, msgSize int, wc windowSizeConfig)
 	}
 	server.mu.Unlock()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	const numStreams = 5
 	clientStreams := make([]*ClientStream, numStreams)

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -377,6 +377,7 @@ type server struct {
 	ready            chan struct{}
 	channelz         *channelz.Server
 	servingTasksDone chan struct{}
+	timeout          time.Duration
 }
 
 func newTestServer() *server {
@@ -437,7 +438,11 @@ func (s *server) start(t *testing.T, port int, serverConfig *ServerConfig, ht hT
 		h := &testStreamHandler{t: transport.(*http2Server)}
 		s.h = h
 		s.mu.Unlock()
-		ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+		timeout := s.timeout
+		if timeout == 0 {
+			timeout = defaultTestTimeout
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 		wg.Add(1)
 		switch ht {
@@ -580,7 +585,12 @@ func (s *server) addr() string {
 }
 
 func setUpServerOnly(t *testing.T, port int, sc *ServerConfig, ht hType) *server {
+	return setUpServerOnlyWithTimeout(t, port, sc, ht, defaultTestTimeout)
+}
+
+func setUpServerOnlyWithTimeout(t *testing.T, port int, sc *ServerConfig, ht hType, timeout time.Duration) *server {
 	server := newTestServer()
+	server.timeout = timeout
 	sc.ChannelzParent = server.channelz
 	go server.start(t, port, sc, ht)
 	server.wait(t, 2*time.Second)
@@ -595,11 +605,15 @@ func setUp(t *testing.T, port int, ht hType) (*server, *http2Client, func()) {
 }
 
 func setUpWithOptions(t *testing.T, port int, sc *ServerConfig, ht hType, copts ConnectOptions) (*server, *http2Client, func()) {
-	server := setUpServerOnly(t, port, sc, ht)
+	return setUpWithOptionsAndTimeout(t, port, sc, ht, copts, defaultTestTimeout)
+}
+
+func setUpWithOptionsAndTimeout(t *testing.T, port int, sc *ServerConfig, ht hType, copts ConnectOptions, timeout time.Duration) (*server, *http2Client, func()) {
+	server := setUpServerOnlyWithTimeout(t, port, sc, ht, timeout)
 	addr := resolver.Address{Addr: "localhost:" + server.port}
 	copts.ChannelzParent = channelzSubChannel(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	t.Cleanup(cancel)
 	connectCtx, cCancel := context.WithTimeout(context.Background(), 2*time.Second)
 	ct, connErr := NewHTTP2Client(connectCtx, ctx, addr, copts, func(GoAwayInfo) {})
@@ -1889,7 +1903,7 @@ func testFlowControlAccountCheck(t *testing.T, msgSize int, wc windowSizeConfig)
 		StaticWindowSize:      true,
 		BufferPool:            mem.DefaultBufferPool(),
 	}
-	server, client, cancel := setUpWithOptions(t, 0, sc, pingpong, co)
+	server, client, cancel := setUpWithOptionsAndTimeout(t, 0, sc, pingpong, co, 30*time.Second)
 	defer cancel()
 	defer server.stop()
 	defer client.Close(fmt.Errorf("closed manually by test"))
@@ -1908,7 +1922,7 @@ func testFlowControlAccountCheck(t *testing.T, msgSize int, wc windowSizeConfig)
 	}
 	server.mu.Unlock()
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	const numStreams = 5
 	clientStreams := make([]*ClientStream, numStreams)

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -1867,7 +1867,11 @@ func (s) TestAccountCheckWindowSizeWithLargeWindow(t *testing.T) {
 		clientStream: 6 * 1024 * 1024,
 		clientConn:   8 * 1024 * 1024,
 	}
-	testFlowControlAccountCheck(t, 1024*1024, wc)
+	// This test exercises the largest windows and message sizes of the flow
+	// control account checks, so it can be slow under load (e.g. the race
+	// detector on a busy CI machine). Use a longer timeout for just this test
+	// instead of slowing down all of them.
+	testFlowControlAccountCheck(t, 1024*1024, wc, 30*time.Second)
 }
 
 func (s) TestAccountCheckWindowSizeWithSmallWindow(t *testing.T) {
@@ -1879,19 +1883,18 @@ func (s) TestAccountCheckWindowSizeWithSmallWindow(t *testing.T) {
 		clientStream: defaultWindowSize,
 		clientConn:   defaultWindowSize,
 	}
-	testFlowControlAccountCheck(t, 1024*1024, wc)
+	testFlowControlAccountCheck(t, 1024*1024, wc, defaultTestTimeout)
 }
 
 func (s) TestAccountCheckDynamicWindowSmallMessage(t *testing.T) {
-	testFlowControlAccountCheck(t, 1024, windowSizeConfig{})
+	testFlowControlAccountCheck(t, 1024, windowSizeConfig{}, defaultTestTimeout)
 }
 
 func (s) TestAccountCheckDynamicWindowLargeMessage(t *testing.T) {
-	testFlowControlAccountCheck(t, 1024*1024, windowSizeConfig{})
+	testFlowControlAccountCheck(t, 1024*1024, windowSizeConfig{}, defaultTestTimeout)
 }
 
-func testFlowControlAccountCheck(t *testing.T, msgSize int, wc windowSizeConfig) {
-	const timeout = 30 * time.Second
+func testFlowControlAccountCheck(t *testing.T, msgSize int, wc windowSizeConfig, timeout time.Duration) {
 	sc := &ServerConfig{
 		InitialWindowSize:     wc.serverStream,
 		InitialConnWindowSize: wc.serverConn,


### PR DESCRIPTION
Fixes #9061 

## Description
This PR addresses flaky timeout failures in the flow control verification test (`TestAccountCheckWindowSizeWithLargeWindow`).

### Root Cause
The `testFlowControlAccountCheck` helper processes 5 concurrent streams with 5 pingpong cycles of 1 MB messages (total 25 MB payload transfer). On slow or resource-constrained environments, this concurrent network overhead can exceed the hardcoded 10-second `defaultTestTimeout`, causing context timeouts, connection drops, and test failures.

### Fix
Instead of modifying the package-wide `defaultTestTimeout` (which could delay detection of genuine deadlock failures in keepalive tests), this change overrides the timeout locally:
* Added helper functions `setUpServerOnlyWithTimeout` and `setUpWithOptionsAndTimeout` to support custom deadlines.
* Overrode the timeout to `30 * time.Second` locally within `testFlowControlAccountCheck` for both connection setups and stream contexts.

### Verification
* **Reproduction**: Artificially sleeping 3s per pingpong (requiring >15s total) with the original 10s timeout reproduced the identical timeout failures.
* **Fix**: Retaining the 3s delay with the new 30s timeout allowed the test to pass successfully in 15.10s. All other package tests pass successfully.

RELEASE NOTES: none