### PR TITLE
xds/internal: fix xds security-config race flaky test

### DIFF
--- a/internal/xds/balancer/clusterimpl/clusterimpl.go
+++ b/internal/xds/balancer/clusterimpl/clusterimpl.go
@@ -65,14 +65,17 @@ const (
 var (
 	// Below function is no-op in actual code, but can be overridden in
 	// tests to give tests visibility into exactly when certain events happen.
-	clientConnUpdateHook = func() {}
-	pickerUpdateHook     = func() {}
-	buildProvider        = buildProviderFunc
+	clientConnUpdateHookMu sync.Mutex
+	clientConnUpdateHook   = func() {}
+	pickerUpdateHook       = func() {}
+	buildProvider          = buildProviderFunc
 )
 
 // SetClientConnUpdateHookForTesting sets the hook called when a client conn
 // update finishes processing.
 func SetClientConnUpdateHookForTesting(f func()) {
+	clientConnUpdateHookMu.Lock()
+	defer clientConnUpdateHookMu.Unlock()
 	clientConnUpdateHook = f
 }
 
@@ -334,7 +337,7 @@ func (b *clusterImplBalancer) handleSecurityConfig(config *xdsresource.SecurityC
 	if config == nil && b.currentSecCfg == nil {
 		return nil
 	}
-	if config != nil && config.Equal(b.currentSecCfg) {
+	if config != nil && b.currentSecCfg != nil && config.Equal(b.currentSecCfg) {
 		return nil
 	}
 	// Security config being nil is a valid case where the management server has
@@ -396,7 +399,10 @@ func (b *clusterImplBalancer) handleSecurityConfig(config *xdsresource.SecurityC
 }
 
 func (b *clusterImplBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
-	defer clientConnUpdateHook()
+	clientConnUpdateHookMu.Lock()
+	hook := clientConnUpdateHook
+	clientConnUpdateHookMu.Unlock()
+	defer hook()
 
 	b.mu.Lock()
 	b.inhibitPickerUpdates = true

--- a/internal/xds/balancer/clusterimpl/clusterimpl.go
+++ b/internal/xds/balancer/clusterimpl/clusterimpl.go
@@ -70,6 +70,12 @@ var (
 	buildProvider        = buildProviderFunc
 )
 
+// SetClientConnUpdateHookForTesting sets the hook called when a client conn
+// update finishes processing.
+func SetClientConnUpdateHookForTesting(f func()) {
+	clientConnUpdateHook = f
+}
+
 func init() {
 	balancer.Register(bb{})
 }
@@ -134,6 +140,7 @@ type clusterImplBalancer struct {
 	// a new provider is to be created.
 	cachedRoot     certprovider.Provider
 	cachedIdentity certprovider.Provider
+	currentSecCfg  *xdsresource.SecurityConfig
 
 	// The following fields are protected by mu, since they are accessed in
 	// balancer API methods and in methods called from the child policy.
@@ -324,7 +331,12 @@ func (b *clusterImplBalancer) handleSecurityConfig(config *xdsresource.SecurityC
 	if !b.xdsCredsInUse {
 		return nil
 	}
-
+	if config == nil && b.currentSecCfg == nil {
+		return nil
+	}
+	if config != nil && config.Equal(b.currentSecCfg) {
+		return nil
+	}
 	// Security config being nil is a valid case where the management server has
 	// not sent any security configuration. The xdsCredentials implementation
 	// handles this by delegating to its fallback credentials.
@@ -333,8 +345,16 @@ func (b *clusterImplBalancer) handleSecurityConfig(config *xdsresource.SecurityC
 		// a case of switching from a good security configuration to an empty
 		// one where fallback credentials are to be used.
 		b.xdsHIPtr.Store(xds.NewHandshakeInfo(nil, nil, nil, false, "", false, false))
+		if b.cachedRoot != nil {
+			b.cachedRoot.Close()
+			b.cachedRoot = nil
+		}
+		if b.cachedIdentity != nil {
+			b.cachedIdentity.Close()
+			b.cachedIdentity = nil
+		}
+		b.currentSecCfg = nil
 		return nil
-
 	}
 
 	// A root provider is required whether we are using TLS or mTLS.
@@ -371,6 +391,7 @@ func (b *clusterImplBalancer) handleSecurityConfig(config *xdsresource.SecurityC
 	b.cachedIdentity = identityProvider
 
 	b.xdsHIPtr.Store(xds.NewHandshakeInfo(rootProvider, identityProvider, config.SubjectAltNameMatchers, false, config.SNI, config.AutoSNISANValidation, config.UseAutoHostSNI))
+	b.currentSecCfg = config
 	return nil
 }
 

--- a/internal/xds/balancer/clusterimpl/tests/clusterimpl_security_test.go
+++ b/internal/xds/balancer/clusterimpl/tests/clusterimpl_security_test.go
@@ -896,6 +896,7 @@ func (s) TestSecurityConfigUpdate_NoRaceOnSameConfig(t *testing.T) {
 
 	muBlockingProviders.Lock()
 	blockingProvidersChan = make(chan *blockingCertProvider, 10)
+	ch := blockingProvidersChan
 	muBlockingProviders.Unlock()
 
 	// Override clientConnUpdateHook to notify when client conn update is done.
@@ -938,7 +939,7 @@ func (s) TestSecurityConfigUpdate_NoRaceOnSameConfig(t *testing.T) {
 	// Wait for the first blocking provider (root) to call KeyMaterial.
 	var bpRoot *blockingCertProvider
 	select {
-	case bpRoot = <-blockingProvidersChan:
+	case bpRoot = <-ch:
 	case <-ctx.Done():
 		t.Fatal("Timeout waiting for root blocking provider to be created")
 	}
@@ -980,7 +981,7 @@ func (s) TestSecurityConfigUpdate_NoRaceOnSameConfig(t *testing.T) {
 	// Wait for the identity provider to call KeyMaterial.
 	var bpIdentity *blockingCertProvider
 	select {
-	case bpIdentity = <-blockingProvidersChan:
+	case bpIdentity = <-ch:
 	case <-ctx.Done():
 		t.Fatal("Timeout waiting for identity blocking provider to be created")
 	}

--- a/internal/xds/balancer/clusterimpl/tests/clusterimpl_security_test.go
+++ b/internal/xds/balancer/clusterimpl/tests/clusterimpl_security_test.go
@@ -17,13 +17,16 @@
 package clusterimpl_test
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
@@ -37,9 +40,14 @@ import (
 	"google.golang.org/grpc/internal/stubserver"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
+	"google.golang.org/grpc/internal/xds/balancer/clusterimpl"
 	iclusterimpl "google.golang.org/grpc/internal/xds/balancer/clusterimpl/internal"
 	"google.golang.org/grpc/internal/xds/bootstrap"
 	"google.golang.org/grpc/peer"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"google.golang.org/grpc/credentials/tls/certprovider/pemfile"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/testdata"
 
@@ -780,4 +788,219 @@ func (s) TestAggregateClusterSecurityConfig(t *testing.T) {
 		t.Fatalf("EmptyCall() failed: %v", err)
 	}
 	verifySecurityInformationFromPeer(t, peer, e2e.SecurityLevelMTLS)
+}
+
+const blockingProviderName = "blocking-cert-provider"
+
+var (
+	muBlockingProviders   sync.Mutex
+	blockingProvidersChan chan *blockingCertProvider
+)
+
+type blockingCertProvider struct {
+	certprovider.Provider
+	mu                      sync.Mutex
+	keyMaterialCalled       chan struct{}
+	keyMaterialCalledClosed bool
+	proceedKeyMaterial      chan struct{}
+}
+
+func (b *blockingCertProvider) KeyMaterial(ctx context.Context) (*certprovider.KeyMaterial, error) {
+	b.mu.Lock()
+	if !b.keyMaterialCalledClosed {
+		close(b.keyMaterialCalled)
+		b.keyMaterialCalledClosed = true
+	}
+	b.mu.Unlock()
+	select {
+	case <-b.proceedKeyMaterial:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return b.Provider.KeyMaterial(ctx)
+}
+
+type blockingProviderBuilder struct{}
+
+func (blockingProviderBuilder) Name() string {
+	return blockingProviderName
+}
+
+func (blockingProviderBuilder) ParseConfig(c any) (*certprovider.BuildableConfig, error) {
+	raw, ok := c.(json.RawMessage)
+	if !ok {
+		return nil, fmt.Errorf("unexpected config type: %T", c)
+	}
+	cfg := &struct {
+		CertificateFile          string          `json:"certificate_file,omitempty"`
+		PrivateKeyFile           string          `json:"private_key_file,omitempty"`
+		CACertificateFile        string          `json:"ca_certificate_file,omitempty"`
+		SPIFFETrustBundleMapFile string          `json:"spiffe_trust_bundle_map_file,omitempty"`
+		RefreshInterval          json.RawMessage `json:"refresh_interval,omitempty"`
+	}{}
+	if err := json.Unmarshal(raw, cfg); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json: %v", err)
+	}
+
+	opts := pemfile.Options{
+		CertFile:            cfg.CertificateFile,
+		KeyFile:             cfg.PrivateKeyFile,
+		RootFile:            cfg.CACertificateFile,
+		SPIFFEBundleMapFile: cfg.SPIFFETrustBundleMapFile,
+	}
+	if cfg.RefreshInterval != nil {
+		dur := &durationpb.Duration{}
+		if err := protojson.Unmarshal(cfg.RefreshInterval, dur); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal refresh_interval: %v", err)
+		}
+		opts.RefreshDuration = dur.AsDuration()
+	}
+
+	return certprovider.NewBuildableConfig(blockingProviderName, raw, func(_ certprovider.BuildOptions) certprovider.Provider {
+		realProvider, err := pemfile.NewProvider(opts)
+		if err != nil {
+			panic(fmt.Sprintf("failed to build real file_watcher provider: %v", err))
+		}
+		bp := &blockingCertProvider{
+			Provider:           realProvider,
+			keyMaterialCalled:  make(chan struct{}, 1),
+			proceedKeyMaterial: make(chan struct{}),
+		}
+		muBlockingProviders.Lock()
+		ch := blockingProvidersChan
+		muBlockingProviders.Unlock()
+		if ch != nil {
+			ch <- bp
+		}
+		return bp
+	}), nil
+}
+
+func init() {
+	certprovider.Register(blockingProviderBuilder{})
+}
+
+// TestSecurityConfigUpdate_NoRaceOnSameConfig verifies that when the balancer
+// receives a configuration update where the security config remains unchanged,
+// it does not close the active certificate providers. This guarantees that
+// asynchronous connection handshakes in progress can complete successfully.
+func (s) TestSecurityConfigUpdate_NoRaceOnSameConfig(t *testing.T) {
+	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{})
+
+	nodeID := uuid.New().String()
+	bc := e2e.DefaultBootstrapContents(t, nodeID, mgmtServer.Address)
+
+	// Replace "file_watcher" plugin with our "blocking-cert-provider".
+	bc = bytes.ReplaceAll(bc, []byte("file_watcher"), []byte("blocking-cert-provider"))
+	t.Logf("Modified Bootstrap Contents:\n%s", string(bc))
+
+	muBlockingProviders.Lock()
+	blockingProvidersChan = make(chan *blockingCertProvider, 10)
+	muBlockingProviders.Unlock()
+
+	// Override clientConnUpdateHook to notify when client conn update is done.
+	updateCh := make(chan struct{}, 1)
+	clusterimpl.SetClientConnUpdateHookForTesting(func() {
+		select {
+		case updateCh <- struct{}{}:
+		default:
+		}
+	})
+	defer clusterimpl.SetClientConnUpdateHookForTesting(func() {})
+
+	// Create a grpc channel with xDS credentials talking to a TLS server.
+	cc, serverAddress := setupForSecurityTests(t, bc, xdsClientCredsWithInsecureFallback(t), tlsServerCreds(t))
+
+	// Configure default resources in the management server. The cluster
+	// resource is configured to return security configuration.
+	resources := e2e.DefaultClientResources(e2e.ResourceParams{
+		DialTarget: "test.service",
+		NodeID:     nodeID,
+		Host:       "localhost",
+		Port:       testutils.ParsePort(t, serverAddress),
+		SecLevel:   e2e.SecurityLevelMTLS,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make an RPC call in a background goroutine. The client's handshake
+	// will run asynchronously, call KeyMaterial(), and block.
+	errChan := make(chan error, 1)
+	client := testgrpc.NewTestServiceClient(cc)
+	go func() {
+		_, err := client.EmptyCall(ctx, &testpb.Empty{})
+		errChan <- err
+	}()
+
+	// Wait for the first blocking provider (root) to call KeyMaterial.
+	var bpRoot *blockingCertProvider
+	select {
+	case bpRoot = <-blockingProvidersChan:
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for root blocking provider to be created")
+	}
+
+	select {
+	case <-bpRoot.keyMaterialCalled:
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for root KeyMaterial to be called")
+	}
+
+	// At this point, the handshake is blocked in KeyMaterial() of the root
+	// provider. Send a configuration update to the balancer with a
+	// different ConnectTimeout but the exact same security config. This
+	// forces xdsClient to propagate the update and trigger
+	// UpdateClientConnState in the balancer.
+	updatedResources := e2e.DefaultClientResources(e2e.ResourceParams{
+		DialTarget: "test.service",
+		NodeID:     nodeID,
+		Host:       "localhost",
+		Port:       testutils.ParsePort(t, serverAddress),
+		SecLevel:   e2e.SecurityLevelMTLS,
+	})
+	updatedResources.Clusters[0].ConnectTimeout = durationpb.New(2 * time.Second)
+
+	if err := mgmtServer.Update(ctx, updatedResources); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the balancer to finish processing the configuration update.
+	select {
+	case <-updateCh:
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for client conn update to complete")
+	}
+
+	// Now unblock the root KeyMaterial() call.
+	close(bpRoot.proceedKeyMaterial)
+
+	// Wait for the identity provider to call KeyMaterial.
+	var bpIdentity *blockingCertProvider
+	select {
+	case bpIdentity = <-blockingProvidersChan:
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for identity blocking provider to be created")
+	}
+
+	select {
+	case <-bpIdentity.keyMaterialCalled:
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for identity KeyMaterial to be called")
+	}
+
+	// Now unblock the identity KeyMaterial() call.
+	close(bpIdentity.proceedKeyMaterial)
+
+	// The RPC should succeed without any error.
+	select {
+	case err := <-errChan:
+		if err != nil {
+			t.Fatalf("EmptyCall() failed: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for RPC to complete")
+	}
 }


### PR DESCRIPTION
Fixes #9015 

### Summary
Avoid recreating and closing xDS certificate provider wrappers when the incoming security configuration has not changed. This fixes a race condition where asynchronous connection handshakes fail because their active certificate provider wrappers are prematurely closed.

### Root Cause
During a client connection handshake, the transport credentials layer retrieves trusted roots and identity certificates using wrappers (`singleCloseWrappedProvider`) around the active certificate providers. 

If the balancer receives an xDS cluster configuration update while a handshake is in progress—even if the security configuration remains unchanged—it unconditionally recreated the provider wrappers and called `Close()` on the old ones. This swapped the active provider reference in the old wrapper to a `closedProvider`, causing the handshake to fail with `provider instance is closed`.

### Fix
* Cache the active `SecurityConfig` in `clusterImplBalancer` as `currentSecCfg`.
* In `handleSecurityConfig`, compare the incoming security configuration with `currentSecCfg` using `config.Equal`. Skip recreating and closing provider wrappers if the configuration has not changed.
* Export a test-only `SetClientConnUpdateHookForTesting` hook setter in `clusterimpl` to allow tests to synchronize on connection state update completion.

### Verification
* Implemented a deterministic regression test `TestSecurityConfigUpdate_NoRaceOnSameConfig` in `clusterimpl_security_test.go` that blocks a handshake mid-flight, updates the configuration, and verifies that the handshake succeeds. The test uses channel-based synchronization and the new update hook rather than arbitrary sleeps.
* Verified that the regression test fails consistently without the fix and passes reliably with the fix.


RELEASE NOTES: none