### PR TITLE
credentials/google: make a non-blocking and context-aware call to fetch token.

### DIFF
--- a/credentials/google/gcp_service_account_identity_credentials.go
+++ b/credentials/google/gcp_service_account_identity_credentials.go
@@ -53,6 +53,7 @@ const (
 type gcpServiceAccountIdentityCallCreds struct {
 	// The following fields are initialized at creation time and are read-only
 	// after that.
+	ctx      context.Context
 	audience string
 	creds    *auth.Credentials
 	backoff  backoff.Strategy
@@ -83,11 +84,17 @@ func init() {
 // only valid for use in environments running on GCP. The audience parameter
 // cannot be empty.
 //
+// The credentials object starts asynchronous background token fetches to
+// refresh expired tokens. The provided context propagates cancellation to
+// these background tasks. Users should not pass an RPC-scoped context here,
+// but rather a context that is valid for the entire lifetime of the
+// credentials and should cancel the context when they are done.
+//
 // # Experimental
 //
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a
 // later release.
-func NewServiceAccountIdentityCredentials(audience string) (credentials.PerRPCCredentials, error) {
+func NewServiceAccountIdentityCredentials(ctx context.Context, audience string) (credentials.PerRPCCredentials, error) {
 	if audience == "" {
 		return nil, fmt.Errorf("credentials: audience cannot be empty")
 	}
@@ -98,6 +105,7 @@ func NewServiceAccountIdentityCredentials(audience string) (credentials.PerRPCCr
 	}
 
 	return &gcpServiceAccountIdentityCallCreds{
+		ctx:      ctx,
 		audience: audience,
 		creds:    creds,
 		backoff:  internal.BackoffStrategy,
@@ -185,7 +193,7 @@ func (c *gcpServiceAccountIdentityCallCreds) isTokenValidLocked() bool {
 // startFetch initiates a token fetch and updates the credential
 // state upon completion.
 func (c *gcpServiceAccountIdentityCallCreds) startFetch() {
-	ctx, cancel := context.WithTimeout(context.Background(), metadataTimeout)
+	ctx, cancel := context.WithTimeout(c.ctx, metadataTimeout)
 	defer cancel()
 	token, err := c.creds.TokenProvider.Token(ctx)
 

--- a/credentials/google/gcp_service_account_identity_credentials.go
+++ b/credentials/google/gcp_service_account_identity_credentials.go
@@ -81,8 +81,8 @@ func init() {
 // audience.
 //
 // This credential fetches the ID token from the GCE metadata server and is
-// only valid for use in environments running on GCP. The audience parameter
-// cannot be empty.
+// only valid for use in environments running on GCP. The ctx and audience
+// parameters cannot be empty.
 //
 // The credentials object starts asynchronous background token fetches to
 // refresh expired tokens. The provided context propagates cancellation to
@@ -95,6 +95,10 @@ func init() {
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a
 // later release.
 func NewServiceAccountIdentityCredentials(ctx context.Context, audience string) (credentials.PerRPCCredentials, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("credentials: ctx cannot be nil")
+	}
+
 	if audience == "" {
 		return nil, fmt.Errorf("credentials: audience cannot be empty")
 	}

--- a/credentials/google/gcp_service_account_identity_credentials.go
+++ b/credentials/google/gcp_service_account_identity_credentials.go
@@ -136,15 +136,16 @@ func (c *gcpServiceAccountIdentityCallCreds) GetRequestMetadata(ctx context.Cont
 			go c.startFetch()
 		}
 		token := c.token.Value
-		c.mu.Unlock()
+		defer c.mu.Unlock()
 		return map[string]string{
 			"authorization": "Bearer " + token,
 		}, nil
 	}
 
 	if c.lastErr != nil && time.Now().Before(c.nextRetryTime) {
-		c.mu.Unlock()
-		return nil, c.lastErr
+		lastErr := c.lastErr
+		defer c.mu.Unlock()
+		return nil, lastErr
 	}
 
 	if c.fetching == nil {
@@ -159,12 +160,14 @@ func (c *gcpServiceAccountIdentityCallCreds) GetRequestMetadata(ctx context.Cont
 		c.mu.Lock()
 		defer c.mu.Unlock()
 		if c.token != nil && c.isTokenValidLocked() {
+			token := c.token.Value
 			return map[string]string{
-				"authorization": "Bearer " + c.token.Value,
+				"authorization": "Bearer " + token,
 			}, nil
 		}
 		if c.lastErr != nil {
-			return nil, c.lastErr
+			lastErr := c.lastErr
+			return nil, lastErr
 		}
 		return nil, status.Error(codes.Unavailable, "credentials: fetched token is expired")
 	case <-ctx.Done():

--- a/credentials/google/gcp_service_account_identity_credentials.go
+++ b/credentials/google/gcp_service_account_identity_credentials.go
@@ -126,28 +126,12 @@ func (c *gcpServiceAccountIdentityCallCreds) GetRequestMetadata(ctx context.Cont
 		return nil, fmt.Errorf("credentials: cannot send secure credentials on an insecure connection: %v", err)
 	}
 
+	md, err := c.cachedRequestMetadata(true)
+	if md != nil || err != nil {
+		return md, err
+	}
+
 	c.mu.Lock()
-
-	// If token is valid, return it. If it's also stale, trigger a background
-	// refresh if not already running and return the current token.
-	if c.token != nil && c.isTokenValidLocked() {
-		if c.isTokenStaleLocked() && c.fetching == nil {
-			c.fetching = make(chan struct{})
-			go c.startFetch()
-		}
-		token := c.token.Value
-		defer c.mu.Unlock()
-		return map[string]string{
-			"authorization": "Bearer " + token,
-		}, nil
-	}
-
-	if c.lastErr != nil && time.Now().Before(c.nextRetryTime) {
-		lastErr := c.lastErr
-		defer c.mu.Unlock()
-		return nil, lastErr
-	}
-
 	if c.fetching == nil {
 		c.fetching = make(chan struct{})
 		go c.startFetch()
@@ -157,22 +141,42 @@ func (c *gcpServiceAccountIdentityCallCreds) GetRequestMetadata(ctx context.Cont
 
 	select {
 	case <-wait:
-		c.mu.Lock()
-		defer c.mu.Unlock()
-		if c.token != nil && c.isTokenValidLocked() {
-			token := c.token.Value
-			return map[string]string{
-				"authorization": "Bearer " + token,
-			}, nil
+		md, err := c.cachedRequestMetadata(false)
+		if md == nil && err == nil {
+			return nil, status.Error(codes.Unavailable, "credentials: fetched token is expired")
 		}
-		if c.lastErr != nil {
-			lastErr := c.lastErr
-			return nil, lastErr
-		}
-		return nil, status.Error(codes.Unavailable, "credentials: fetched token is expired")
+		return md, err
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
+}
+
+// cachedRequestMetadata returns the cached token if it is valid, or nil if it is
+// not. If attemptPreemptiveRefresh is true, it will also trigger a background
+// refresh if the token is stale but still valid. It returns the cached error
+// if the last fetch failed and the backoff interval has not expired.
+//
+// Returns (nil, nil) if the token is not valid and a new fetch is required. The
+// caller is responsible for initiating the fetch or waiting for an in-progress
+// fetch to complete.
+func (c *gcpServiceAccountIdentityCallCreds) cachedRequestMetadata(attemptPreemptiveRefresh bool) (map[string]string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.token != nil && c.isTokenValidLocked() {
+		if attemptPreemptiveRefresh && c.isTokenStaleLocked() && c.fetching == nil {
+			c.fetching = make(chan struct{})
+			go c.startFetch()
+		}
+
+		return map[string]string{"authorization": "Bearer " + c.token.Value}, nil
+	}
+
+	if c.lastErr != nil && time.Now().Before(c.nextRetryTime) {
+		return nil, c.lastErr
+	}
+
+	return nil, nil
 }
 
 // RequireTransportSecurity indicates whether the credentials requires

--- a/credentials/google/gcp_service_account_identity_credentials.go
+++ b/credentials/google/gcp_service_account_identity_credentials.go
@@ -63,7 +63,7 @@ type gcpServiceAccountIdentityCallCreds struct {
 	token                  *auth.Token
 	tokenExpiry            time.Time     // timestamp after which the cached token is considered invalid
 	preemptiveTokenRefresh time.Time     // timestamp after which background preemptive refresh is triggered
-	fetching               chan struct{} // used to deduplicate concurrent background token fetches
+	fetching               chan struct{} // used to ensure a single in-progress background token fetch
 	nextRetryTime          time.Time     // timestamp after which we can attempt the next token fetch
 	retryAttempt           int           // consecutive fetch failure count used to compute backoff delay
 	lastErr                error         // cached error returned from the most recent token fetch attempt
@@ -126,12 +126,20 @@ func (c *gcpServiceAccountIdentityCallCreds) GetRequestMetadata(ctx context.Cont
 		return nil, fmt.Errorf("credentials: cannot send secure credentials on an insecure connection: %v", err)
 	}
 
-	md, err := c.cachedRequestMetadata(true)
-	if md != nil || err != nil {
+	if md, err := c.cachedRequestMetadata(true); md != nil || err != nil {
 		return md, err
 	}
 
 	c.mu.Lock()
+	// Now that we have the lock, did someone else finish the fetch while we
+	// were waiting for the lock?
+	md, err := c.cachedRequestMetadataLocked(false)
+	if md != nil || err != nil {
+		c.mu.Unlock()
+		return md, err
+	}
+
+	// If no one is fetching, start it.
 	if c.fetching == nil {
 		c.fetching = make(chan struct{})
 		go c.startFetch()
@@ -141,6 +149,7 @@ func (c *gcpServiceAccountIdentityCallCreds) GetRequestMetadata(ctx context.Cont
 
 	select {
 	case <-wait:
+		// Return the new cached result from the most recent fetch.
 		md, err := c.cachedRequestMetadata(false)
 		if md == nil && err == nil {
 			return nil, status.Error(codes.Unavailable, "credentials: fetched token is expired")
@@ -151,18 +160,25 @@ func (c *gcpServiceAccountIdentityCallCreds) GetRequestMetadata(ctx context.Cont
 	}
 }
 
-// cachedRequestMetadata returns the cached token if it is valid, or nil if it is
-// not. If attemptPreemptiveRefresh is true, it will also trigger a background
-// refresh if the token is stale but still valid. It returns the cached error
-// if the last fetch failed and the backoff interval has not expired.
+// cachedRequestMetadata handles its own locking for the "fast path".
+func (c *gcpServiceAccountIdentityCallCreds) cachedRequestMetadata(attemptPreemptiveRefresh bool) (map[string]string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.cachedRequestMetadataLocked(attemptPreemptiveRefresh)
+}
+
+// cachedRequestMetadataLocked returns the cached token if it is valid, or nil
+// if it is not. If attemptPreemptiveRefresh is true, it will also trigger a
+// background refresh if the token is stale but still valid. It returns the
+// cached error if the last fetch failed and the backoff interval has not
+// expired.
 //
 // Returns (nil, nil) if the token is not valid and a new fetch is required. The
 // caller is responsible for initiating the fetch or waiting for an in-progress
 // fetch to complete.
-func (c *gcpServiceAccountIdentityCallCreds) cachedRequestMetadata(attemptPreemptiveRefresh bool) (map[string]string, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
+//
+// It must be called with mu locked.
+func (c *gcpServiceAccountIdentityCallCreds) cachedRequestMetadataLocked(attemptPreemptiveRefresh bool) (map[string]string, error) {
 	if c.token != nil && c.isTokenValidLocked() {
 		if attemptPreemptiveRefresh && c.isTokenStaleLocked() && c.fetching == nil {
 			c.fetching = make(chan struct{})

--- a/credentials/google/gcp_service_account_identity_credentials.go
+++ b/credentials/google/gcp_service_account_identity_credentials.go
@@ -127,9 +127,10 @@ func (c *gcpServiceAccountIdentityCallCreds) GetRequestMetadata(ctx context.Cont
 			c.fetching = make(chan struct{})
 			go c.startFetch()
 		}
-		defer c.mu.Unlock()
+		token := c.token.Value
+		c.mu.Unlock()
 		return map[string]string{
-			"authorization": "Bearer " + c.token.Value,
+			"authorization": "Bearer " + token,
 		}, nil
 	}
 

--- a/credentials/google/gcp_service_account_identity_credentials.go
+++ b/credentials/google/gcp_service_account_identity_credentials.go
@@ -36,11 +36,19 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// preemptiveRefresh is the window before a token's actual expiration during
-// which the token is considered stale. Requests using a stale but still valid
-// token will trigger a background asynchronous refresh. This avoids blocking
-// the current RPC, preventing periodic latency spikes during token refresh.
-const preemptiveRefresh = 1 * time.Minute
+const (
+	// preemptiveRefresh is the window before a token's actual expiration during
+	// which the token is considered stale. Requests using a stale but still
+	// valid token will trigger a background asynchronous refresh. This avoids
+	// blocking the current RPC, preventing periodic latency spikes during token
+	// refresh.
+	preemptiveRefresh = 1 * time.Minute
+
+	// metadataTimeout is the timeout for the call to the metadata server to
+	// prevent the background token fetch from hanging indefinitely in case
+	// of connection issues.
+	metadataTimeout = 60 * time.Second
+)
 
 type gcpServiceAccountIdentityCallCreds struct {
 	// The following fields are initialized at creation time and are read-only
@@ -52,12 +60,12 @@ type gcpServiceAccountIdentityCallCreds struct {
 	// The following fields are protected by mu.
 	mu                     sync.Mutex
 	token                  *auth.Token
-	tokenExpiry            time.Time // timestamp after which the cached token is considered invalid
-	preemptiveTokenRefresh time.Time // timestamp after which background preemptive refresh is triggered
-	fetching               bool      // true if a background token fetch is in progress
-	nextRetryTime          time.Time // timestamp after which we can attempt the next token fetch
-	retryAttempt           int       // consecutive fetch failure count used to compute backoff delay
-	lastErr                error     // cached error returned from the most recent token fetch attempt
+	tokenExpiry            time.Time     // timestamp after which the cached token is considered invalid
+	preemptiveTokenRefresh time.Time     // timestamp after which background preemptive refresh is triggered
+	fetching               chan struct{} // used to deduplicate concurrent background token fetches
+	nextRetryTime          time.Time     // timestamp after which we can attempt the next token fetch
+	retryAttempt           int           // consecutive fetch failure count used to compute backoff delay
+	lastErr                error         // cached error returned from the most recent token fetch attempt
 }
 
 func init() {
@@ -111,33 +119,48 @@ func (c *gcpServiceAccountIdentityCallCreds) GetRequestMetadata(ctx context.Cont
 	}
 
 	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	// If token is valid, return it. If it's also stale, trigger a background
 	// refresh if not already running and return the current token.
 	if c.token != nil && c.isTokenValidLocked() {
-		if c.isTokenStaleLocked() && !c.fetching {
-			c.fetching = true
+		if c.isTokenStaleLocked() && c.fetching == nil {
+			c.fetching = make(chan struct{})
 			go c.startFetch()
 		}
+		defer c.mu.Unlock()
 		return map[string]string{
 			"authorization": "Bearer " + c.token.Value,
 		}, nil
 	}
 
 	if c.lastErr != nil && time.Now().Before(c.nextRetryTime) {
+		c.mu.Unlock()
 		return nil, c.lastErr
 	}
 
-	token, err := c.creds.TokenProvider.Token(context.Background())
-	c.updateStateLocked(token, err)
-	if err != nil {
-		return nil, c.lastErr
+	if c.fetching == nil {
+		c.fetching = make(chan struct{})
+		go c.startFetch()
 	}
+	wait := c.fetching
+	c.mu.Unlock()
 
-	return map[string]string{
-		"authorization": "Bearer " + c.token.Value,
-	}, nil
+	select {
+	case <-wait:
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if c.token != nil && c.isTokenValidLocked() {
+			return map[string]string{
+				"authorization": "Bearer " + c.token.Value,
+			}, nil
+		}
+		if c.lastErr != nil {
+			return nil, c.lastErr
+		}
+		return nil, status.Error(codes.Unavailable, "credentials: fetched token is expired")
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 // RequireTransportSecurity indicates whether the credentials requires
@@ -161,12 +184,15 @@ func (c *gcpServiceAccountIdentityCallCreds) isTokenValidLocked() bool {
 // startFetch initiates a token fetch and updates the credential
 // state upon completion.
 func (c *gcpServiceAccountIdentityCallCreds) startFetch() {
-	token, err := c.creds.TokenProvider.Token(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), metadataTimeout)
+	defer cancel()
+	token, err := c.creds.TokenProvider.Token(ctx)
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.fetching = false
+	close(c.fetching)
+	c.fetching = nil
 	c.updateStateLocked(token, err)
 }
 

--- a/credentials/google/gcp_service_account_identity_credentials_test.go
+++ b/credentials/google/gcp_service_account_identity_credentials_test.go
@@ -224,9 +224,10 @@ func (s) TestGCPServiceAccountIdentityCallCreds_BackoffExpired(t *testing.T) {
 		wantErr2 = "second attempt to fetch token"
 	)
 
-	// Override the backoff strategy with a 0s delay to expires immediately.
+	// Override the backoff strategy with a short delay.
+	const backoffDelay = 10 * time.Millisecond
 	origBackoff := internal.BackoffStrategy
-	internal.BackoffStrategy = &stubBackoff{backoffDelay: 0}
+	internal.BackoffStrategy = &stubBackoff{backoffDelay: backoffDelay}
 	t.Cleanup(func() { internal.BackoffStrategy = origBackoff })
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
@@ -245,6 +246,13 @@ func (s) TestGCPServiceAccountIdentityCallCreds_BackoffExpired(t *testing.T) {
 
 	if got := stubToken.getCallCount(); got != 1 {
 		t.Fatalf("Unexpected call count to token provider: got %d, want 1", got)
+	}
+
+	// Wait for backoff to expire.
+	select {
+	case <-time.After(2 * backoffDelay):
+	case <-ctx.Done():
+		t.Fatal("Timed out waiting for backoff to expire")
 	}
 
 	// Update token provider with second failure error to distinguish the
@@ -271,9 +279,10 @@ func (s) TestGCPServiceAccountIdentityCallCreds_BackoffExpiredRecovery(t *testin
 		token   = "token"
 	)
 
-	// Override the backoff strategy with a 0s delay to expires immediately.
+	// Override the backoff strategy with a short delay.
+	const backoffDelay = 10 * time.Millisecond
 	origBackoff := internal.BackoffStrategy
-	internal.BackoffStrategy = &stubBackoff{backoffDelay: 0}
+	internal.BackoffStrategy = &stubBackoff{backoffDelay: backoffDelay}
 	t.Cleanup(func() { internal.BackoffStrategy = origBackoff })
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
@@ -294,11 +303,16 @@ func (s) TestGCPServiceAccountIdentityCallCreds_BackoffExpiredRecovery(t *testin
 		t.Fatalf("Unexpected call count to token provider: got %d, want 1", got)
 	}
 
+	// Wait for backoff to expire.
+	select {
+	case <-time.After(2 * backoffDelay):
+	case <-ctx.Done():
+		t.Fatal("Timed out waiting for backoff to expire")
+	}
+
 	// Update token provider to return a valid token and nil error.
 	stubToken.setErr(nil)
 
-	// Since backoff is 0s (already expired), the next request triggers a
-	// new fetch which succeeds
 	md, err := creds.GetRequestMetadata(ctx)
 	if err != nil {
 		t.Fatalf("GetRequestMetadata() failed unexpectedly: %v", err)

--- a/credentials/google/gcp_service_account_identity_credentials_test.go
+++ b/credentials/google/gcp_service_account_identity_credentials_test.go
@@ -120,7 +120,7 @@ func setupStubTokenProvider(token string, err error) *stubTokenProvider {
 //
 // It overrides internal.NewIDTokenCredentials to use the stubTokenProvider,
 // and registers a cleanup function to restore original hook after the test.
-func setupTestGCPServiceAccountIdentityCreds(t *testing.T, stubToken *stubTokenProvider) credentials.PerRPCCredentials {
+func setupTestGCPServiceAccountIdentityCreds(ctx context.Context, t *testing.T, stubToken *stubTokenProvider) credentials.PerRPCCredentials {
 	// Override the ID token credentials to use stub token provider.
 	origNewIDTokenCredentials := internal.NewIDTokenCredentials
 	internal.NewIDTokenCredentials = func(*idtoken.Options) (*auth.Credentials, error) {
@@ -129,8 +129,6 @@ func setupTestGCPServiceAccountIdentityCreds(t *testing.T, stubToken *stubTokenP
 	}
 	t.Cleanup(func() { internal.NewIDTokenCredentials = origNewIDTokenCredentials })
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
 	creds, err := google.NewServiceAccountIdentityCredentials(ctx, "audience")
 	if err != nil {
 		t.Fatalf("NewServiceAccountIdentityCredentials() failed: %v", err)
@@ -157,10 +155,10 @@ func (s) TestNewServiceAccountIdentityCredentials_EmptyAudience(t *testing.T) {
 func (s) TestGCPServiceAccountIdentityCallCreds_GetRequestMetadata(t *testing.T) {
 	const token = "token"
 	stubToken := setupStubTokenProvider(token, nil)
-	creds := setupTestGCPServiceAccountIdentityCreds(t, stubToken)
-
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
+	creds := setupTestGCPServiceAccountIdentityCreds(ctx, t, stubToken)
+
 	ctx = credentials.NewContextWithRequestInfo(ctx, credentials.RequestInfo{
 		AuthInfo: &gcpTestAuthInfo{credentials.CommonAuthInfo{SecurityLevel: credentials.PrivacyAndIntegrity}},
 	})
@@ -189,11 +187,11 @@ func (s) TestGCPServiceAccountIdentityCallCreds_Backoff(t *testing.T) {
 	internal.BackoffStrategy = &stubBackoff{backoffDelay: 2 * defaultTestTimeout}
 	t.Cleanup(func() { internal.BackoffStrategy = origBackoff })
 
-	stubToken := setupStubTokenProvider("token", errors.New(wantErr))
-	creds := setupTestGCPServiceAccountIdentityCreds(t, stubToken)
-
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
+	stubToken := setupStubTokenProvider("token", errors.New(wantErr))
+	creds := setupTestGCPServiceAccountIdentityCreds(ctx, t, stubToken)
+
 	ctx = credentials.NewContextWithRequestInfo(ctx, credentials.RequestInfo{
 		AuthInfo: &gcpTestAuthInfo{credentials.CommonAuthInfo{SecurityLevel: credentials.PrivacyAndIntegrity}},
 	})
@@ -231,11 +229,11 @@ func (s) TestGCPServiceAccountIdentityCallCreds_BackoffExpired(t *testing.T) {
 	internal.BackoffStrategy = &stubBackoff{backoffDelay: 0}
 	t.Cleanup(func() { internal.BackoffStrategy = origBackoff })
 
-	stubToken := setupStubTokenProvider("token", errors.New(wantErr))
-	creds := setupTestGCPServiceAccountIdentityCreds(t, stubToken)
-
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
+	stubToken := setupStubTokenProvider("token", errors.New(wantErr))
+	creds := setupTestGCPServiceAccountIdentityCreds(ctx, t, stubToken)
+
 	ctx = credentials.NewContextWithRequestInfo(ctx, credentials.RequestInfo{
 		AuthInfo: &gcpTestAuthInfo{credentials.CommonAuthInfo{SecurityLevel: credentials.PrivacyAndIntegrity}},
 	})
@@ -278,11 +276,11 @@ func (s) TestGCPServiceAccountIdentityCallCreds_BackoffExpiredRecovery(t *testin
 	internal.BackoffStrategy = &stubBackoff{backoffDelay: 0}
 	t.Cleanup(func() { internal.BackoffStrategy = origBackoff })
 
-	stubToken := setupStubTokenProvider(token, errors.New(wantErr))
-	creds := setupTestGCPServiceAccountIdentityCreds(t, stubToken)
-
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
+	stubToken := setupStubTokenProvider(token, errors.New(wantErr))
+	creds := setupTestGCPServiceAccountIdentityCreds(ctx, t, stubToken)
+
 	ctx = credentials.NewContextWithRequestInfo(ctx, credentials.RequestInfo{
 		AuthInfo: &gcpTestAuthInfo{credentials.CommonAuthInfo{SecurityLevel: credentials.PrivacyAndIntegrity}},
 	})
@@ -321,11 +319,11 @@ func (s) TestGCPServiceAccountIdentityCallCreds_BackoffExpiredRecovery(t *testin
 // only a single fetch is executed and all blocked requests successfully
 // receive the same valid token.
 func (s) TestGCPServiceAccountIdentityCallCreds_ConcurrentCalls_Success(t *testing.T) {
-	stubToken := setupStubTokenProvider("token", nil)
-	creds := setupTestGCPServiceAccountIdentityCreds(t, stubToken)
-
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
+	stubToken := setupStubTokenProvider("token", nil)
+	creds := setupTestGCPServiceAccountIdentityCreds(ctx, t, stubToken)
+
 	ctx = credentials.NewContextWithRequestInfo(ctx, credentials.RequestInfo{
 		AuthInfo: &gcpTestAuthInfo{credentials.CommonAuthInfo{SecurityLevel: credentials.PrivacyAndIntegrity}},
 	})
@@ -358,11 +356,11 @@ func (s) TestGCPServiceAccountIdentityCallCreds_ConcurrentCalls_Success(t *testi
 // error after the fetch.
 func (s) TestGCPServiceAccountIdentityCallCreds_ConcurrentCalls_Failure(t *testing.T) {
 	const wantErr = "failed while fetching idToken"
-	stubToken := setupStubTokenProvider("token", errors.New(wantErr))
-	creds := setupTestGCPServiceAccountIdentityCreds(t, stubToken)
-
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
+	stubToken := setupStubTokenProvider("token", errors.New(wantErr))
+	creds := setupTestGCPServiceAccountIdentityCreds(ctx, t, stubToken)
+
 	ctx = credentials.NewContextWithRequestInfo(ctx, credentials.RequestInfo{
 		AuthInfo: &gcpTestAuthInfo{credentials.CommonAuthInfo{SecurityLevel: credentials.PrivacyAndIntegrity}},
 	})
@@ -393,11 +391,11 @@ func (s) TestGCPServiceAccountIdentityCallCreds_ConcurrentCalls_Failure(t *testi
 // Test verifies that credentials fail to return metadata when the security
 // level of the connection is not secure.
 func (s) TestGCPServiceAccountIdentityCallCreds_SecurityLevelFailure(t *testing.T) {
-	stubToken := setupStubTokenProvider("token", nil)
-	creds := setupTestGCPServiceAccountIdentityCreds(t, stubToken)
-
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
+	stubToken := setupStubTokenProvider("token", nil)
+	creds := setupTestGCPServiceAccountIdentityCreds(ctx, t, stubToken)
+
 	ctx = credentials.NewContextWithRequestInfo(ctx, credentials.RequestInfo{
 		AuthInfo: &gcpTestAuthInfo{credentials.CommonAuthInfo{SecurityLevel: credentials.NoSecurity}},
 	})
@@ -427,10 +425,10 @@ func (s) TestGCPServiceAccountIdentityCallCreds_EarlyExpiry(t *testing.T) {
 			Expiry: time.Now().Add(1 * time.Minute),
 		},
 	)
-	creds := setupTestGCPServiceAccountIdentityCreds(t, stubToken)
-
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
+	creds := setupTestGCPServiceAccountIdentityCreds(ctx, t, stubToken)
+
 	ctx = credentials.NewContextWithRequestInfo(ctx, credentials.RequestInfo{
 		AuthInfo: &gcpTestAuthInfo{credentials.CommonAuthInfo{SecurityLevel: credentials.PrivacyAndIntegrity}},
 	})
@@ -515,12 +513,12 @@ func (s) TestGCPServiceAccountIdentityCallCreds_ErrorMapping(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			stubToken := setupStubTokenProvider("token", nil)
-			creds := setupTestGCPServiceAccountIdentityCreds(t, stubToken)
-			stubToken.setErr(tc.err)
-
 			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 			defer cancel()
+			stubToken := setupStubTokenProvider("token", nil)
+			creds := setupTestGCPServiceAccountIdentityCreds(ctx, t, stubToken)
+			stubToken.setErr(tc.err)
+
 			ctx = credentials.NewContextWithRequestInfo(ctx, credentials.RequestInfo{
 				AuthInfo: &gcpTestAuthInfo{credentials.CommonAuthInfo{SecurityLevel: credentials.PrivacyAndIntegrity}},
 			})

--- a/credentials/google/gcp_service_account_identity_credentials_test.go
+++ b/credentials/google/gcp_service_account_identity_credentials_test.go
@@ -129,7 +129,9 @@ func setupTestGCPServiceAccountIdentityCreds(t *testing.T, stubToken *stubTokenP
 	}
 	t.Cleanup(func() { internal.NewIDTokenCredentials = origNewIDTokenCredentials })
 
-	creds, err := google.NewServiceAccountIdentityCredentials("audience")
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	creds, err := google.NewServiceAccountIdentityCredentials(ctx, "audience")
 	if err != nil {
 		t.Fatalf("NewServiceAccountIdentityCredentials() failed: %v", err)
 	}
@@ -141,7 +143,9 @@ func setupTestGCPServiceAccountIdentityCreds(t *testing.T, stubToken *stubTokenP
 // when called with empty audience.
 func (s) TestNewServiceAccountIdentityCredentials_EmptyAudience(t *testing.T) {
 	const wantErr = "credentials: audience cannot be empty"
-	if _, err := google.NewServiceAccountIdentityCredentials(""); err == nil || !strings.Contains(err.Error(), wantErr) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	if _, err := google.NewServiceAccountIdentityCredentials(ctx, ""); err == nil || !strings.Contains(err.Error(), wantErr) {
 		t.Fatalf("NewServiceAccountIdentityCredentials() returned error = %v, want error containing %q", err, wantErr)
 	}
 }


### PR DESCRIPTION
This PR is a follow-up to [PR #9118](https://github.com/grpc/grpc-go/pull/9118), refactoring the newly added GCP Service Account Identity call credentials to fetch tokens asynchronously and pass a 60 sec context timeout.

Previously, if a valid token was not cached, GetRequestMetadata performed a blocking synchronous call to `creds.TokenProvider.Token(context.Background())`. This block occurred while holding the c.mu mutex lock, which blocked all other concurrent metadata retrievals. Additionally, the token fetch did not have a timeout and relies on the 15 sec timeout that metadata server works with.

This PR refactors the credential to:
* Run the token fetch in a background goroutine, releasing the mutex lock during the network call.
* Deduplicate concurrent fetches using a channel broadcast pattern.
* Allow waiting RPCs to unblock immediately if their context is canceled or expires.
* Bound the background fetch itself with a defensive 60-second timeout.

RELEASE NOTES: N/A