### PR TITLE
test/kokoro: add config for regional-td test (v1.81.x backport)

### DIFF
--- a/test/kokoro/psm-regional_td.cfg
+++ b/test/kokoro/psm-regional_td.cfg
@@ -1,0 +1,17 @@
+# Config file for internal CI
+
+# Location of the continuous shell script in repository.
+build_file: "grpc-go/test/kokoro/psm-interop-test-go.sh"
+timeout_mins: 30
+
+action {
+  define_artifacts {
+    regex: "artifacts/**/*sponge_log.xml"
+    regex: "artifacts/**/*.log"
+    strip_prefix: "artifacts"
+  }
+}
+env_vars {
+  key: "PSM_TEST_SUITE"
+  value: "regional_td"
+}


### PR DESCRIPTION
Backport of #9158 to v1.81.x.
---
RELEASE NOTES: N/A