### PR TITLE
client: avoid finishing a stream twice when stream creation fails

### DIFF
--- a/internal/idle/idle_e2e_test.go
+++ b/internal/idle/idle_e2e_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -546,4 +547,43 @@ func (s) TestChannelIdleness_Connect(t *testing.T) {
 
 	// Verify that the ClientConn moves back to READY.
 	testutils.AwaitState(ctx, t, cc, connectivity.Ready)
+}
+
+// TestChannelIdleness_RPCFailingBeforeAttempt_FinishesOnce verifies that an
+// RPC which fails during stream creation, before any attempt is started, is
+// reported as finished exactly once.
+func (s) TestChannelIdleness_RPCFailingBeforeAttempt_FinishesOnce(t *testing.T) {
+	backend := stubserver.StartTestService(t, nil)
+	defer backend.Stop()
+
+	cc, err := grpc.NewClient(fmt.Sprintf("dns:///%s", backend.Address), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("grpc.NewClient() failed: %v", err)
+	}
+	defer cc.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	client := testgrpc.NewTestServiceClient(cc)
+
+	// Warm-up RPC: moves the channel to READY and fires the resolver's
+	// first-resolution event, so that the next RPC does not block waiting for
+	// addresses and instead proceeds to fail during stream creation.
+	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
+		t.Fatalf("EmptyCall() failed: %v", err)
+	}
+
+	// Issue an RPC with an already-canceled context so that it fails during
+	// stream creation, before any attempt is started, and count how many times
+	// gRPC reports it as finished. The contract is exactly once.
+	var finishCount atomic.Int32
+	cancel()
+	_, err = client.EmptyCall(ctx, &testpb.Empty{}, grpc.OnFinish(func(error) { finishCount.Add(1) }))
+	if got, want := status.Code(err), codes.Canceled; got != want {
+		t.Fatalf("EmptyCall() with canceled context returned code %v, want %v (err: %v)", got, want, err)
+	}
+	if got := finishCount.Load(); got != 1 {
+		t.Fatalf("OnFinish callback invoked %d times, want exactly 1", got)
+	}
 }

--- a/stream.go
+++ b/stream.go
@@ -1093,7 +1093,8 @@ func (cs *clientStream) finish(err error) {
 	}
 	cs.finished = true
 	cs.commitAttemptLocked()
-	if cs.attempt != nil {
+	attemptCreated := cs.attempt != nil
+	if attemptCreated {
 		cs.attempt.finish(err)
 		// after functions all rely upon having a stream.
 		if cs.attempt.transportStream != nil {
@@ -1131,7 +1132,13 @@ func (cs *clientStream) finish(err error) {
 	if err == nil {
 		cs.retryThrottler.successfulRPC()
 	}
-	endOfClientStream(cs.cc, err, cs.opts...)
+	// If no attempt was ever created, stream creation has failed, and the
+	// cleanup is left to newClientStream, whose deferred cleanup invokes
+	// endOfClientStream if the call fails. Invoking it here as well would
+	// run the cleanup twice for the same call.
+	if attemptCreated {
+		endOfClientStream(cs.cc, err, cs.opts...)
+	}
 	cs.cancel()
 }
 


### PR DESCRIPTION
In `clientStream.withRetry`, when `newAttemptLocked` fails before an attempt is created, `withRetry` called `cs.finish` and then returned the error. `newClientStream` also runs `endOfClientStream` from its deferred cleanup on an error return, so the stream was finished twice and every `grpc.OnFinish` callback ran twice for a single RPC, breaking its documented "called only once" contract.

One of those callbacks is the idleness manager's `OnCallEnd`. The extra `OnCallEnd` pushes the manager's int32 `activeCallsCount` one below its `-math.MaxInt32` idle sentinel and corrupts the counter. After that the channel can get permanently stuck in IDLE, and later RPCs fail with "context deadline exceeded while waiting for connections to become ready" even though the backend is reachable. It happens when RPCs are canceled around the idle-timeout boundary.

On this path no attempt is created, so there is nothing to finish: the context is canceled by `newClientStreamWithParams`'s deferred cleanup, and `newClientStream`'s deferred `endOfClientStream` finishes the stream exactly once. Replace the `cs.finish` call with `cs.commitAttemptLocked` so the stream is still committed, releasing resources held for retries such as the config selector's `OnCommitted` callback, without being finished a second time. This mirrors the `retryLocked` give-up path.

Add a regression test that fails before this change and passes after it.

RELEASE NOTES:
* client: Fix a bug where a ClientConn could get permanently stuck in IDLE after an RPC was canceled while the channel was exiting idle mode
