### PR TITLE
xds: implement HeaderMutator to apply HTTP header mutations (A102)

### DIFF
--- a/internal/xds/httpfilter/headers.go
+++ b/internal/xds/httpfilter/headers.go
@@ -1,0 +1,134 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package httpfilter
+
+import (
+	"fmt"
+	"strings"
+
+	v3mutationpb "github.com/envoyproxy/go-control-plane/envoy/config/common/mutation_rules/v3"
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"google.golang.org/grpc/metadata"
+)
+
+// HeaderMutator compiles and applies mutations on gRPC metadata.
+type HeaderMutator struct {
+	rules HeaderMutationRules
+}
+
+// NewHeaderMutator creates a new compiled HeaderMutator.
+func NewHeaderMutator(rules HeaderMutationRules) *HeaderMutator {
+	return &HeaderMutator{rules: rules}
+}
+
+// NewHeaderMutatorFromProto compiles a HeaderMutator from the proto message.
+func NewHeaderMutatorFromProto(mr *v3mutationpb.HeaderMutationRules) (*HeaderMutator, error) {
+	rules, err := HeaderMutationRulesFromProto(mr)
+	if err != nil {
+		return nil, err
+	}
+	return &HeaderMutator{rules: rules}, nil
+}
+
+// isMutationAllowed checks if a specific header key mutation is allowed.
+func (m *HeaderMutator) isMutationAllowed(key string) (bool, error) {
+	// Standard system/envoy headers are ignored and not allowed to be mutated
+	if strings.HasPrefix(key, ":") || strings.HasPrefix(key, "grpc-") {
+		return false, nil
+	}
+	if key == "host" {
+		return false, nil
+	}
+
+	if m.rules.DisallowAll {
+		if m.rules.DisallowIsError {
+			return false, fmt.Errorf("httpfilter: all header mutations are disallowed by mutation rules")
+		}
+		return false, nil
+	}
+
+	// DisallowExpr has higher priority and overrides AllowExpr.
+	if m.rules.DisallowExpr != nil && m.rules.DisallowExpr.MatchString(key) {
+		if m.rules.DisallowIsError {
+			return false, fmt.Errorf("httpfilter: header mutation for key %q is disallowed by mutation rules", key)
+		}
+		return false, nil
+	}
+
+	if m.rules.AllowExpr != nil {
+		if !m.rules.AllowExpr.MatchString(key) {
+			if m.rules.DisallowIsError {
+				return false, fmt.Errorf("httpfilter: header mutation for key %q is not allowed by mutation rules", key)
+			}
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// Mutate applies HeaderValueOption mutations to the metadata.
+// It returns a modified copy, leaving the original untouched.
+func (m *HeaderMutator) Mutate(md metadata.MD, mutations []*v3corepb.HeaderValueOption) (metadata.MD, error) {
+	res := md.Copy()
+
+	for _, opt := range mutations {
+		h := opt.GetHeader()
+		if h == nil {
+			continue
+		}
+		key := strings.ToLower(h.GetKey())
+		val := h.GetValue()
+
+		allowed, err := m.isMutationAllowed(key)
+		if err != nil {
+			return nil, err
+		}
+		if !allowed {
+			continue
+		}
+
+		action := opt.GetAppendAction()
+		switch action {
+		case v3corepb.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD:
+			res.Append(key, val)
+		case v3corepb.HeaderValueOption_ADD_IF_ABSENT:
+			if len(res.Get(key)) == 0 {
+				res.Set(key, val)
+			}
+		case v3corepb.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD:
+			res.Set(key, val)
+		}
+
+		// Any header mutation resulting in only empty values causes the key to
+		// be removed.
+		vals := res.Get(key)
+		isEmpty := true
+		for _, v := range vals {
+			if v != "" {
+				isEmpty = false
+				break
+			}
+		}
+		if isEmpty {
+			delete(res, key)
+		}
+	}
+	return res, nil
+}

--- a/internal/xds/httpfilter/headers.go
+++ b/internal/xds/httpfilter/headers.go
@@ -122,22 +122,26 @@ func (m *HeaderMutator) Mutate(md metadata.MD, mutations []*v3corepb.HeaderValue
 			continue
 		}
 
+		// key is already lower-cased and, after ensureCopy, res is a non-nil
+		// map whose value slices were deep-copied, so we operate on the map
+		// directly to avoid the redundant strings.ToLower scans and the
+		// variadic allocation in metadata.MD's Get/Set/Append helpers.
 		switch opt.GetAppendAction() {
 		case v3corepb.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD:
 			ensureCopy()
-			res.Append(key, val)
+			res[key] = append(res[key], val)
 		case v3corepb.HeaderValueOption_ADD_IF_ABSENT:
-			if len(res.Get(key)) == 0 {
+			if len(res[key]) == 0 {
 				ensureCopy()
-				res.Set(key, val)
+				res[key] = []string{val}
 			}
 		case v3corepb.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD:
 			ensureCopy()
-			res.Set(key, val)
+			res[key] = []string{val}
 		case v3corepb.HeaderValueOption_OVERWRITE_IF_EXISTS:
-			if len(res.Get(key)) > 0 {
+			if len(res[key]) > 0 {
 				ensureCopy()
-				res.Set(key, val)
+				res[key] = []string{val}
 			}
 		}
 

--- a/internal/xds/httpfilter/headers.go
+++ b/internal/xds/httpfilter/headers.go
@@ -83,10 +83,22 @@ func (m *HeaderMutator) isMutationAllowed(key string) (bool, error) {
 	return true, nil
 }
 
-// Mutate applies HeaderValueOption mutations to the metadata.
-// It returns a modified copy, leaving the original untouched.
+// Mutate applies HeaderValueOption mutations and returns the result, leaving
+// the original metadata untouched. The metadata is copied lazily (copy-on-
+// write): a call that applies no mutations returns the input as-is without
+// allocating a copy.
 func (m *HeaderMutator) Mutate(md metadata.MD, mutations []*v3corepb.HeaderValueOption) (metadata.MD, error) {
-	res := md.Copy()
+	res := md
+	copied := false
+	// ensureCopy copies the metadata the first time an actual mutation is
+	// applied, so reads before that observe the original and no allocation is
+	// made when nothing changes.
+	ensureCopy := func() {
+		if !copied {
+			res = md.Copy()
+			copied = true
+		}
+	}
 
 	for _, opt := range mutations {
 		h := opt.GetHeader()
@@ -95,8 +107,10 @@ func (m *HeaderMutator) Mutate(md metadata.MD, mutations []*v3corepb.HeaderValue
 		}
 		key := strings.ToLower(h.GetKey())
 		// Per gRFC A102, raw_value takes precedence over the legacy value field.
+		// A non-nil raw_value (including an explicitly empty one) is used; only
+		// an unset raw_value falls back to value.
 		val := h.GetValue()
-		if len(h.GetRawValue()) > 0 {
+		if h.GetRawValue() != nil {
 			val = string(h.GetRawValue())
 		}
 
@@ -110,15 +124,19 @@ func (m *HeaderMutator) Mutate(md metadata.MD, mutations []*v3corepb.HeaderValue
 
 		switch opt.GetAppendAction() {
 		case v3corepb.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD:
+			ensureCopy()
 			res.Append(key, val)
 		case v3corepb.HeaderValueOption_ADD_IF_ABSENT:
 			if len(res.Get(key)) == 0 {
+				ensureCopy()
 				res.Set(key, val)
 			}
 		case v3corepb.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD:
+			ensureCopy()
 			res.Set(key, val)
 		case v3corepb.HeaderValueOption_OVERWRITE_IF_EXISTS:
 			if len(res.Get(key)) > 0 {
+				ensureCopy()
 				res.Set(key, val)
 			}
 		}

--- a/internal/xds/httpfilter/headers.go
+++ b/internal/xds/httpfilter/headers.go
@@ -27,6 +27,10 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+// maxHeaderLen is the maximum allowed length, in bytes, of a header key or
+// value, per gRFC A102.
+const maxHeaderLen = 16384
+
 // HeaderMutator compiles and applies mutations on gRPC metadata.
 type HeaderMutator struct {
 	rules HeaderMutationRules
@@ -46,47 +50,47 @@ func NewHeaderMutatorFromProto(mr *v3mutationpb.HeaderMutationRules) (*HeaderMut
 	return &HeaderMutator{rules: rules}, nil
 }
 
-// isMutationAllowed checks if a specific header key mutation is allowed.
-func (m *HeaderMutator) isMutationAllowed(key string) (bool, error) {
-	// Per gRFC A102, gRPC never allows modifying pseudo-headers (keys starting
-	// with ":") or the "host" header, regardless of the configured mutation
-	// rules. Other headers (including "grpc-*") are subject to the
-	// allow/disallow rules below.
-	if strings.HasPrefix(key, ":") || key == "host" {
-		return false, nil
+// isDisallowedHeader reports whether a mutation on this header is
+// unconditionally invalid, regardless of the configured mutation rules, per
+// gRFC A102's HeaderValue validation: an empty, over-length, non-lower-case,
+// "grpc-"-prefixed, ":"-prefixed, or "host" key, or an over-length value.
+func isDisallowedHeader(h *v3corepb.HeaderValue) bool {
+	key := h.GetKey()
+	switch {
+	case key == "", len(key) > maxHeaderLen:
+		return true
+	case key != strings.ToLower(key):
+		return true
+	case strings.HasPrefix(key, ":"), key == "host", strings.HasPrefix(key, "grpc-"):
+		return true
+	case len(h.GetValue()) > maxHeaderLen, len(h.GetRawValue()) > maxHeaderLen:
+		return true
 	}
+	return false
+}
 
-	if m.rules.DisallowAll {
-		if m.rules.DisallowIsError {
-			return false, fmt.Errorf("httpfilter: all header mutations are disallowed by mutation rules")
-		}
-		return false, nil
-	}
-
-	// DisallowExpr has higher priority and overrides AllowExpr.
+// isRuleAllowed reports whether the configured mutation rules permit mutating
+// key. A key matching disallow_expression is rejected; a key matching
+// allow_expression is permitted (even under disallow_all); otherwise it is
+// permitted unless disallow_all is set (gRFC A102).
+func (m *HeaderMutator) isRuleAllowed(key string) bool {
 	if m.rules.DisallowExpr != nil && m.rules.DisallowExpr.MatchString(key) {
-		if m.rules.DisallowIsError {
-			return false, fmt.Errorf("httpfilter: header mutation for key %q is disallowed by mutation rules", key)
-		}
-		return false, nil
+		return false
 	}
-
-	if m.rules.AllowExpr != nil {
-		if !m.rules.AllowExpr.MatchString(key) {
-			if m.rules.DisallowIsError {
-				return false, fmt.Errorf("httpfilter: header mutation for key %q is not allowed by mutation rules", key)
-			}
-			return false, nil
-		}
+	if m.rules.AllowExpr != nil && m.rules.AllowExpr.MatchString(key) {
+		return true
 	}
-
-	return true, nil
+	return !m.rules.DisallowAll
 }
 
 // Mutate applies HeaderValueOption mutations and returns the result, leaving
 // the original metadata untouched. The metadata is copied lazily (copy-on-
 // write): a call that applies no mutations returns the input as-is without
 // allocating a copy.
+//
+// A mutation is applied only if the header is valid and permitted by the
+// mutation rules. A disallowed mutation fails the call with an error when
+// disallow_is_error is set, and is silently ignored otherwise (gRFC A102).
 func (m *HeaderMutator) Mutate(md metadata.MD, mutations []*v3corepb.HeaderValueOption) (metadata.MD, error) {
 	res := md
 	copied := false
@@ -105,24 +109,23 @@ func (m *HeaderMutator) Mutate(md metadata.MD, mutations []*v3corepb.HeaderValue
 		if h == nil {
 			continue
 		}
-		key := strings.ToLower(h.GetKey())
-		// Per gRFC A102, raw_value takes precedence over the legacy value field.
-		// A non-nil raw_value (including an explicitly empty one) is used; only
-		// an unset raw_value falls back to value.
+		key := h.GetKey()
+		// Per gRFC A102, raw_value takes precedence over the legacy value
+		// field. A non-nil raw_value (including an explicitly empty one) is
+		// used; only an unset raw_value falls back to value.
 		val := h.GetValue()
 		if h.GetRawValue() != nil {
 			val = string(h.GetRawValue())
 		}
 
-		allowed, err := m.isMutationAllowed(key)
-		if err != nil {
-			return nil, err
-		}
-		if !allowed {
+		if isDisallowedHeader(h) || !m.isRuleAllowed(key) {
+			if m.rules.DisallowIsError {
+				return nil, fmt.Errorf("httpfilter: header mutation for key %q is disallowed by mutation rules", key)
+			}
 			continue
 		}
 
-		// key is already lower-cased and, after ensureCopy, res is a non-nil
+		// key is validated lower-case and, after ensureCopy, res is a non-nil
 		// map whose value slices were deep-copied, so we operate on the map
 		// directly to avoid the redundant strings.ToLower scans and the
 		// variadic allocation in metadata.MD's Get/Set/Append helpers.
@@ -146,7 +149,7 @@ func (m *HeaderMutator) Mutate(md metadata.MD, mutations []*v3corepb.HeaderValue
 		}
 
 		// Per gRFC A102, gRPC keeps headers even if a mutation results in an
-		// empty value; the keep_empty_value field is intentionally unsupported.
+		// empty value; keep_empty_value is intentionally unsupported.
 	}
 	return res, nil
 }

--- a/internal/xds/httpfilter/headers.go
+++ b/internal/xds/httpfilter/headers.go
@@ -48,11 +48,11 @@ func NewHeaderMutatorFromProto(mr *v3mutationpb.HeaderMutationRules) (*HeaderMut
 
 // isMutationAllowed checks if a specific header key mutation is allowed.
 func (m *HeaderMutator) isMutationAllowed(key string) (bool, error) {
-	// Standard system/envoy headers are ignored and not allowed to be mutated
-	if strings.HasPrefix(key, ":") || strings.HasPrefix(key, "grpc-") {
-		return false, nil
-	}
-	if key == "host" {
+	// Per gRFC A102, gRPC never allows modifying pseudo-headers (keys starting
+	// with ":") or the "host" header, regardless of the configured mutation
+	// rules. Other headers (including "grpc-*") are subject to the
+	// allow/disallow rules below.
+	if strings.HasPrefix(key, ":") || key == "host" {
 		return false, nil
 	}
 
@@ -94,7 +94,11 @@ func (m *HeaderMutator) Mutate(md metadata.MD, mutations []*v3corepb.HeaderValue
 			continue
 		}
 		key := strings.ToLower(h.GetKey())
+		// Per gRFC A102, raw_value takes precedence over the legacy value field.
 		val := h.GetValue()
+		if len(h.GetRawValue()) > 0 {
+			val = string(h.GetRawValue())
+		}
 
 		allowed, err := m.isMutationAllowed(key)
 		if err != nil {
@@ -104,8 +108,7 @@ func (m *HeaderMutator) Mutate(md metadata.MD, mutations []*v3corepb.HeaderValue
 			continue
 		}
 
-		action := opt.GetAppendAction()
-		switch action {
+		switch opt.GetAppendAction() {
 		case v3corepb.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD:
 			res.Append(key, val)
 		case v3corepb.HeaderValueOption_ADD_IF_ABSENT:
@@ -114,21 +117,14 @@ func (m *HeaderMutator) Mutate(md metadata.MD, mutations []*v3corepb.HeaderValue
 			}
 		case v3corepb.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD:
 			res.Set(key, val)
-		}
-
-		// Any header mutation resulting in only empty values causes the key to
-		// be removed.
-		vals := res.Get(key)
-		isEmpty := true
-		for _, v := range vals {
-			if v != "" {
-				isEmpty = false
-				break
+		case v3corepb.HeaderValueOption_OVERWRITE_IF_EXISTS:
+			if len(res.Get(key)) > 0 {
+				res.Set(key, val)
 			}
 		}
-		if isEmpty {
-			delete(res, key)
-		}
+
+		// Per gRFC A102, gRPC keeps headers even if a mutation results in an
+		// empty value; the keep_empty_value field is intentionally unsupported.
 	}
 	return res, nil
 }

--- a/internal/xds/httpfilter/headers_test.go
+++ b/internal/xds/httpfilter/headers_test.go
@@ -24,118 +24,253 @@ import (
 	v3mutationpb "github.com/envoyproxy/go-control-plane/envoy/config/common/mutation_rules/v3"
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v3matcherpb "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-func TestHeaderMutator_Mutate(t *testing.T) {
-	mr := &v3mutationpb.HeaderMutationRules{
-		AllowExpression:    &v3matcherpb.RegexMatcher{Regex: "allowed-.*"},
-		DisallowExpression: &v3matcherpb.RegexMatcher{Regex: ".*-blocked"},
-		DisallowIsError:    wrapperspb.Bool(true),
-	}
+const (
+	appendOrAdd = v3corepb.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD
+	addIfAbsent = v3corepb.HeaderValueOption_ADD_IF_ABSENT
+	overwrite   = v3corepb.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD
+	overwriteIf = v3corepb.HeaderValueOption_OVERWRITE_IF_EXISTS
+)
 
-	mutator, err := NewHeaderMutatorFromProto(mr)
-	if err != nil {
-		t.Fatalf("NewHeaderMutatorFromProto() returned error: %v", err)
-	}
-
-	md := metadata.Pairs("existing-key", "existing-val")
-
-	mutations := []*v3corepb.HeaderValueOption{
-		{
-			Header:       &v3corepb.HeaderValue{Key: "allowed-header", Value: "mutated-val"},
-			AppendAction: v3corepb.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD,
-		},
-	}
-
-	res, err := mutator.Mutate(md, mutations)
-	if err != nil {
-		t.Fatalf("Mutate() returned unexpected error: %v", err)
-	}
-
-	if got := res.Get("allowed-header"); len(got) != 1 || got[0] != "mutated-val" {
-		t.Errorf("Mutate() allowed-header got: %v, want: %v", got, []string{"mutated-val"})
-	}
-
-	disallowedMutations := []*v3corepb.HeaderValueOption{
-		{
-			Header: &v3corepb.HeaderValue{Key: "header-blocked", Value: "val"},
-		},
-	}
-	_, err = mutator.Mutate(md, disallowedMutations)
-	if err == nil {
-		t.Fatal("Mutate() succeeded for disallowed header with DisallowIsError=true, want error")
-	}
-
-	systemMutations := []*v3corepb.HeaderValueOption{
-		{
-			Header: &v3corepb.HeaderValue{Key: ":path", Value: "/new/path"},
-		},
-	}
-	res, err = mutator.Mutate(md, systemMutations)
-	if err != nil {
-		t.Fatalf("Mutate() returned unexpected error for system header: %v", err)
-	}
-	if got := res.Get(":path"); len(got) != 0 {
-		t.Errorf("System header mutation applied; got: %v, want: []", got)
+// hvo builds a HeaderValueOption with the legacy value field.
+func hvo(key, val string, action v3corepb.HeaderValueOption_HeaderAppendAction) *v3corepb.HeaderValueOption {
+	return &v3corepb.HeaderValueOption{
+		Header:       &v3corepb.HeaderValue{Key: key, Value: val},
+		AppendAction: action,
 	}
 }
 
-func TestHeaderMutator_KeepEmptyValue(t *testing.T) {
-	mr := &v3mutationpb.HeaderMutationRules{}
-	mutator, err := NewHeaderMutatorFromProto(mr)
-	if err != nil {
-		t.Fatalf("NewHeaderMutatorFromProto() returned error: %v", err)
+func TestHeaderMutator_Mutate(t *testing.T) {
+	tests := []struct {
+		name      string
+		rules     *v3mutationpb.HeaderMutationRules
+		input     metadata.MD
+		mutations []*v3corepb.HeaderValueOption
+		want      metadata.MD
+		wantErr   bool
+	}{
+		{
+			name:      "append_to_absent_adds",
+			input:     metadata.MD{"existing": {"v"}},
+			mutations: []*v3corepb.HeaderValueOption{hvo("new", "a", appendOrAdd)},
+			want:      metadata.MD{"existing": {"v"}, "new": {"a"}},
+		},
+		{
+			name:      "append_to_existing_appends",
+			input:     metadata.MD{"k": {"a"}},
+			mutations: []*v3corepb.HeaderValueOption{hvo("k", "b", appendOrAdd)},
+			want:      metadata.MD{"k": {"a", "b"}},
+		},
+		{
+			name:      "add_if_absent_when_absent_adds",
+			input:     metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{hvo("k", "a", addIfAbsent)},
+			want:      metadata.MD{"k": {"a"}},
+		},
+		{
+			name:      "add_if_absent_when_present_noop",
+			input:     metadata.MD{"k": {"a"}},
+			mutations: []*v3corepb.HeaderValueOption{hvo("k", "b", addIfAbsent)},
+			want:      metadata.MD{"k": {"a"}},
+		},
+		{
+			name:      "overwrite_or_add_when_present_overwrites",
+			input:     metadata.MD{"k": {"a", "b"}},
+			mutations: []*v3corepb.HeaderValueOption{hvo("k", "c", overwrite)},
+			want:      metadata.MD{"k": {"c"}},
+		},
+		{
+			name:      "overwrite_or_add_when_absent_adds",
+			input:     metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{hvo("k", "c", overwrite)},
+			want:      metadata.MD{"k": {"c"}},
+		},
+		{
+			name:      "overwrite_if_exists_when_present_overwrites",
+			input:     metadata.MD{"k": {"a"}},
+			mutations: []*v3corepb.HeaderValueOption{hvo("k", "c", overwriteIf)},
+			want:      metadata.MD{"k": {"c"}},
+		},
+		{
+			name:      "overwrite_if_exists_when_absent_noop",
+			input:     metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{hvo("k", "c", overwriteIf)},
+			want:      metadata.MD{},
+		},
+		{
+			// gRFC A102: headers are kept even when a mutation yields an empty
+			// value; keep_empty_value is intentionally unsupported.
+			name:      "empty_value_is_kept_on_existing_key",
+			input:     metadata.MD{"k": {"a"}},
+			mutations: []*v3corepb.HeaderValueOption{hvo("k", "", overwrite)},
+			want:      metadata.MD{"k": {""}},
+		},
+		{
+			name:      "empty_value_is_kept_on_new_key",
+			input:     metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{hvo("new", "", appendOrAdd)},
+			want:      metadata.MD{"new": {""}},
+		},
+		{
+			name:  "keep_empty_value_field_is_ignored",
+			input: metadata.MD{"k": {"a"}},
+			mutations: []*v3corepb.HeaderValueOption{{
+				Header:         &v3corepb.HeaderValue{Key: "k", Value: ""},
+				AppendAction:   overwrite,
+				KeepEmptyValue: true,
+			}},
+			want: metadata.MD{"k": {""}},
+		},
+		{
+			name:  "raw_value_takes_precedence_over_value",
+			input: metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{{
+				Header:       &v3corepb.HeaderValue{Key: "k", Value: "legacy", RawValue: []byte("raw")},
+				AppendAction: overwrite,
+			}},
+			want: metadata.MD{"k": {"raw"}},
+		},
+		{
+			name:      "key_is_lowercased",
+			input:     metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{hvo("MixedCase", "a", overwrite)},
+			want:      metadata.MD{"mixedcase": {"a"}},
+		},
+		{
+			name:      "nil_header_is_skipped",
+			input:     metadata.MD{"k": {"a"}},
+			mutations: []*v3corepb.HeaderValueOption{{AppendAction: overwrite}},
+			want:      metadata.MD{"k": {"a"}},
+		},
+		{
+			name:      "pseudo_header_never_mutated",
+			input:     metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{hvo(":path", "/new", overwrite)},
+			want:      metadata.MD{},
+		},
+		{
+			name:      "host_header_never_mutated",
+			input:     metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{hvo("host", "evil", overwrite)},
+			want:      metadata.MD{},
+		},
+		{
+			// gRFC A102 only hard-protects ":"-prefixed and "host"; "grpc-*" is
+			// subject to the allow/disallow rules and may be mutated.
+			name:      "grpc_prefixed_header_is_mutable",
+			input:     metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{hvo("grpc-foo", "a", overwrite)},
+			want:      metadata.MD{"grpc-foo": {"a"}},
+		},
+		{
+			name:      "disallow_all_ignored_when_not_error",
+			rules:     &v3mutationpb.HeaderMutationRules{DisallowAll: wrapperspb.Bool(true)},
+			input:     metadata.MD{"k": {"a"}},
+			mutations: []*v3corepb.HeaderValueOption{hvo("k", "b", overwrite)},
+			want:      metadata.MD{"k": {"a"}},
+		},
+		{
+			name:      "disallow_all_errors_when_is_error",
+			rules:     &v3mutationpb.HeaderMutationRules{DisallowAll: wrapperspb.Bool(true), DisallowIsError: wrapperspb.Bool(true)},
+			input:     metadata.MD{"k": {"a"}},
+			mutations: []*v3corepb.HeaderValueOption{hvo("k", "b", overwrite)},
+			wantErr:   true,
+		},
+		{
+			name: "disallow_expr_ignored_when_not_error",
+			rules: &v3mutationpb.HeaderMutationRules{
+				DisallowExpression: &v3matcherpb.RegexMatcher{Regex: ".*-blocked"},
+			},
+			input:     metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{hvo("k-blocked", "a", overwrite)},
+			want:      metadata.MD{},
+		},
+		{
+			name: "disallow_expr_errors_when_is_error",
+			rules: &v3mutationpb.HeaderMutationRules{
+				DisallowExpression: &v3matcherpb.RegexMatcher{Regex: ".*-blocked"},
+				DisallowIsError:    wrapperspb.Bool(true),
+			},
+			input:     metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{hvo("k-blocked", "a", overwrite)},
+			wantErr:   true,
+		},
+		{
+			name: "allow_expr_blocks_non_matching_when_not_error",
+			rules: &v3mutationpb.HeaderMutationRules{
+				AllowExpression: &v3matcherpb.RegexMatcher{Regex: "allowed-.*"},
+			},
+			input:     metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{hvo("other", "a", overwrite)},
+			want:      metadata.MD{},
+		},
+		{
+			name: "allow_expr_permits_matching",
+			rules: &v3mutationpb.HeaderMutationRules{
+				AllowExpression: &v3matcherpb.RegexMatcher{Regex: "allowed-.*"},
+			},
+			input:     metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{hvo("allowed-k", "a", overwrite)},
+			want:      metadata.MD{"allowed-k": {"a"}},
+		},
+		{
+			name: "disallow_expr_overrides_allow_expr",
+			rules: &v3mutationpb.HeaderMutationRules{
+				AllowExpression:    &v3matcherpb.RegexMatcher{Regex: "allowed-.*"},
+				DisallowExpression: &v3matcherpb.RegexMatcher{Regex: "allowed-secret"},
+			},
+			input:     metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{hvo("allowed-secret", "a", overwrite)},
+			want:      metadata.MD{},
+		},
 	}
 
-	t.Run("KeepEmptyValue = false (default)", func(t *testing.T) {
-		md := metadata.Pairs("existing-key", "existing-val")
-		mutations := []*v3corepb.HeaderValueOption{
-			{
-				Header:       &v3corepb.HeaderValue{Key: "existing-key", Value: ""},
-				AppendAction: v3corepb.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
-			},
-			{
-				Header:       &v3corepb.HeaderValue{Key: "new-key", Value: ""},
-				AppendAction: v3corepb.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD,
-			},
-		}
-		res, err := mutator.Mutate(md, mutations)
-		if err != nil {
-			t.Fatalf("Mutate() returned error: %v", err)
-		}
-		if got := res.Get("existing-key"); len(got) != 0 {
-			t.Errorf("existing-key got: %v, want: []", got)
-		}
-		if got := res.Get("new-key"); len(got) != 0 {
-			t.Errorf("new-key got: %v, want: []", got)
-		}
-	})
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mutator, err := NewHeaderMutatorFromProto(test.rules)
+			if err != nil {
+				t.Fatalf("NewHeaderMutatorFromProto() returned error: %v", err)
+			}
+			got, err := mutator.Mutate(test.input, test.mutations)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("Mutate() error = %v, wantErr = %v", err, test.wantErr)
+			}
+			if test.wantErr {
+				return
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("Mutate() result mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
 
-	t.Run("KeepEmptyValue = true (ignored)", func(t *testing.T) {
-		md := metadata.Pairs("existing-key", "existing-val")
-		mutations := []*v3corepb.HeaderValueOption{
-			{
-				Header:         &v3corepb.HeaderValue{Key: "existing-key", Value: ""},
-				AppendAction:   v3corepb.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
-				KeepEmptyValue: true,
-			},
-			{
-				Header:         &v3corepb.HeaderValue{Key: "new-key", Value: ""},
-				AppendAction:   v3corepb.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD,
-				KeepEmptyValue: true,
-			},
-		}
-		res, err := mutator.Mutate(md, mutations)
-		if err != nil {
-			t.Fatalf("Mutate() returned error: %v", err)
-		}
-		if got := res.Get("existing-key"); len(got) != 0 {
-			t.Errorf("existing-key got: %v, want: []", got)
-		}
-		if got := res.Get("new-key"); len(got) != 0 {
-			t.Errorf("new-key got: %v, want: []", got)
-		}
+// TestHeaderMutator_DoesNotMutateInput verifies that Mutate operates on a copy
+// and leaves the caller's metadata untouched.
+func TestHeaderMutator_DoesNotMutateInput(t *testing.T) {
+	mutator := NewHeaderMutator(HeaderMutationRules{})
+	input := metadata.MD{"k": {"a"}}
+	if _, err := mutator.Mutate(input, []*v3corepb.HeaderValueOption{
+		hvo("k", "b", appendOrAdd),
+		hvo("new", "c", overwrite),
+	}); err != nil {
+		t.Fatalf("Mutate() returned error: %v", err)
+	}
+	want := metadata.MD{"k": {"a"}}
+	if diff := cmp.Diff(want, input); diff != "" {
+		t.Errorf("Mutate() modified the input metadata (-want +got):\n%s", diff)
+	}
+}
+
+func TestNewHeaderMutatorFromProto_InvalidRegex(t *testing.T) {
+	_, err := NewHeaderMutatorFromProto(&v3mutationpb.HeaderMutationRules{
+		AllowExpression: &v3matcherpb.RegexMatcher{Regex: "("},
 	})
+	if err == nil {
+		t.Fatal("NewHeaderMutatorFromProto() succeeded for invalid regex, want error")
+	}
 }

--- a/internal/xds/httpfilter/headers_test.go
+++ b/internal/xds/httpfilter/headers_test.go
@@ -19,6 +19,7 @@
 package httpfilter
 
 import (
+	"reflect"
 	"testing"
 
 	v3mutationpb "github.com/envoyproxy/go-control-plane/envoy/config/common/mutation_rules/v3"
@@ -133,6 +134,17 @@ func TestHeaderMutator_Mutate(t *testing.T) {
 				AppendAction: overwrite,
 			}},
 			want: metadata.MD{"k": {"raw"}},
+		},
+		{
+			// An explicitly empty raw_value is still set (it is non-nil), and
+			// must not fall back to the legacy value field.
+			name:  "empty_raw_value_overrides_legacy_value",
+			input: metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{{
+				Header:       &v3corepb.HeaderValue{Key: "k", Value: "legacy", RawValue: []byte{}},
+				AppendAction: overwrite,
+			}},
+			want: metadata.MD{"k": {""}},
 		},
 		{
 			name:      "key_is_lowercased",
@@ -263,6 +275,30 @@ func TestHeaderMutator_DoesNotMutateInput(t *testing.T) {
 	want := metadata.MD{"k": {"a"}}
 	if diff := cmp.Diff(want, input); diff != "" {
 		t.Errorf("Mutate() modified the input metadata (-want +got):\n%s", diff)
+	}
+}
+
+// TestHeaderMutator_NoOpDoesNotCopy verifies the copy-on-write behavior: a
+// call that applies no mutations returns the input metadata without allocating
+// a copy.
+func TestHeaderMutator_NoOpDoesNotCopy(t *testing.T) {
+	mutator := NewHeaderMutator(HeaderMutationRules{})
+	input := metadata.MD{"k": {"v"}}
+	tests := map[string][]*v3corepb.HeaderValueOption{
+		"no_mutations":      nil,
+		"all_skipped":       {hvo(":path", "/x", overwrite)}, // pseudo-header
+		"nil_header_option": {{AppendAction: overwrite}},
+	}
+	for name, mutations := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := mutator.Mutate(input, mutations)
+			if err != nil {
+				t.Fatalf("Mutate() returned error: %v", err)
+			}
+			if reflect.ValueOf(got).Pointer() != reflect.ValueOf(input).Pointer() {
+				t.Errorf("Mutate() copied the metadata for a no-op call; want the input returned without copying")
+			}
+		})
 	}
 }
 

--- a/internal/xds/httpfilter/headers_test.go
+++ b/internal/xds/httpfilter/headers_test.go
@@ -20,6 +20,7 @@ package httpfilter
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	v3mutationpb "github.com/envoyproxy/go-control-plane/envoy/config/common/mutation_rules/v3"
@@ -45,7 +46,18 @@ func hvo(key, val string, action v3corepb.HeaderValueOption_HeaderAppendAction) 
 	}
 }
 
-func TestHeaderMutator_Mutate(t *testing.T) {
+// hvoRaw builds a HeaderValueOption whose value is carried in raw_value.
+func hvoRaw(key string, raw []byte, action v3corepb.HeaderValueOption_HeaderAppendAction) *v3corepb.HeaderValueOption {
+	return &v3corepb.HeaderValueOption{
+		Header:       &v3corepb.HeaderValue{Key: key, RawValue: raw},
+		AppendAction: action,
+	}
+}
+
+func (s) TestHeaderMutator_Mutate(t *testing.T) {
+	longKey := strings.Repeat("a", maxHeaderLen+1)
+	longVal := strings.Repeat("b", maxHeaderLen+1)
+
 	tests := []struct {
 		name      string
 		rules     *v3mutationpb.HeaderMutationRules
@@ -54,6 +66,7 @@ func TestHeaderMutator_Mutate(t *testing.T) {
 		want      metadata.MD
 		wantErr   bool
 	}{
+		// --- append actions ---
 		{
 			name:      "append_to_absent_adds",
 			input:     metadata.MD{"existing": {"v"}},
@@ -102,9 +115,8 @@ func TestHeaderMutator_Mutate(t *testing.T) {
 			mutations: []*v3corepb.HeaderValueOption{hvo("k", "c", overwriteIf)},
 			want:      metadata.MD{},
 		},
+		// --- empty value retention (keep_empty_value unsupported) ---
 		{
-			// gRFC A102: headers are kept even when a mutation yields an empty
-			// value; keep_empty_value is intentionally unsupported.
 			name:      "empty_value_is_kept_on_existing_key",
 			input:     metadata.MD{"k": {"a"}},
 			mutations: []*v3corepb.HeaderValueOption{hvo("k", "", overwrite)},
@@ -126,6 +138,7 @@ func TestHeaderMutator_Mutate(t *testing.T) {
 			}},
 			want: metadata.MD{"k": {""}},
 		},
+		// --- raw_value handling ---
 		{
 			name:  "raw_value_takes_precedence_over_value",
 			input: metadata.MD{},
@@ -136,8 +149,14 @@ func TestHeaderMutator_Mutate(t *testing.T) {
 			want: metadata.MD{"k": {"raw"}},
 		},
 		{
-			// An explicitly empty raw_value is still set (it is non-nil), and
-			// must not fall back to the legacy value field.
+			name:      "raw_value_applied_for_key",
+			input:     metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{hvoRaw("k", []byte("rv"), appendOrAdd)},
+			want:      metadata.MD{"k": {"rv"}},
+		},
+		{
+			// An explicitly empty raw_value is used (it is non-nil) and must
+			// not fall back to the legacy value field.
 			name:  "empty_raw_value_overrides_legacy_value",
 			input: metadata.MD{},
 			mutations: []*v3corepb.HeaderValueOption{{
@@ -147,53 +166,81 @@ func TestHeaderMutator_Mutate(t *testing.T) {
 			want: metadata.MD{"k": {""}},
 		},
 		{
-			name:      "key_is_lowercased",
-			input:     metadata.MD{},
-			mutations: []*v3corepb.HeaderValueOption{hvo("MixedCase", "a", overwrite)},
-			want:      metadata.MD{"mixedcase": {"a"}},
-		},
-		{
 			name:      "nil_header_is_skipped",
 			input:     metadata.MD{"k": {"a"}},
 			mutations: []*v3corepb.HeaderValueOption{{AppendAction: overwrite}},
 			want:      metadata.MD{"k": {"a"}},
 		},
+		// --- unconditionally invalid headers are ignored (gRFC A102) ---
 		{
-			name:      "pseudo_header_never_mutated",
+			name:      "pseudo_header_disallowed",
 			input:     metadata.MD{},
 			mutations: []*v3corepb.HeaderValueOption{hvo(":path", "/new", overwrite)},
 			want:      metadata.MD{},
 		},
 		{
-			name:      "host_header_never_mutated",
+			name:      "host_header_disallowed",
 			input:     metadata.MD{},
 			mutations: []*v3corepb.HeaderValueOption{hvo("host", "evil", overwrite)},
 			want:      metadata.MD{},
 		},
 		{
-			// gRFC A102 only hard-protects ":"-prefixed and "host"; "grpc-*" is
-			// subject to the allow/disallow rules and may be mutated.
-			name:      "grpc_prefixed_header_is_mutable",
+			name:      "grpc_prefixed_header_disallowed",
 			input:     metadata.MD{},
 			mutations: []*v3corepb.HeaderValueOption{hvo("grpc-foo", "a", overwrite)},
-			want:      metadata.MD{"grpc-foo": {"a"}},
+			want:      metadata.MD{},
 		},
 		{
-			name:      "disallow_all_ignored_when_not_error",
+			name:      "uppercase_key_disallowed",
+			input:     metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{hvo("MixedCase", "a", overwrite)},
+			want:      metadata.MD{},
+		},
+		{
+			name:      "empty_key_disallowed",
+			input:     metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{hvo("", "a", overwrite)},
+			want:      metadata.MD{},
+		},
+		{
+			name:      "overlength_key_disallowed",
+			input:     metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{hvo(longKey, "v", overwrite)},
+			want:      metadata.MD{},
+		},
+		{
+			name:      "overlength_value_disallowed",
+			input:     metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{hvo("k", longVal, overwrite)},
+			want:      metadata.MD{},
+		},
+		{
+			name:      "overlength_raw_value_disallowed",
+			input:     metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{hvoRaw("k", []byte(longVal), overwrite)},
+			want:      metadata.MD{},
+		},
+		// --- mutation rules (allow/disallow/disallow_all) ---
+		{
+			name:      "disallow_all_blocks_unmatched",
 			rules:     &v3mutationpb.HeaderMutationRules{DisallowAll: wrapperspb.Bool(true)},
 			input:     metadata.MD{"k": {"a"}},
 			mutations: []*v3corepb.HeaderValueOption{hvo("k", "b", overwrite)},
 			want:      metadata.MD{"k": {"a"}},
 		},
 		{
-			name:      "disallow_all_errors_when_is_error",
-			rules:     &v3mutationpb.HeaderMutationRules{DisallowAll: wrapperspb.Bool(true), DisallowIsError: wrapperspb.Bool(true)},
-			input:     metadata.MD{"k": {"a"}},
-			mutations: []*v3corepb.HeaderValueOption{hvo("k", "b", overwrite)},
-			wantErr:   true,
+			// allow_expression permits a header even under disallow_all.
+			name: "disallow_all_but_allow_expr_permits",
+			rules: &v3mutationpb.HeaderMutationRules{
+				DisallowAll:     wrapperspb.Bool(true),
+				AllowExpression: &v3matcherpb.RegexMatcher{Regex: "allowed-.*"},
+			},
+			input:     metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{hvo("allowed-k", "b", overwrite)},
+			want:      metadata.MD{"allowed-k": {"b"}},
 		},
 		{
-			name: "disallow_expr_ignored_when_not_error",
+			name: "disallow_expr_blocks",
 			rules: &v3mutationpb.HeaderMutationRules{
 				DisallowExpression: &v3matcherpb.RegexMatcher{Regex: ".*-blocked"},
 			},
@@ -202,26 +249,18 @@ func TestHeaderMutator_Mutate(t *testing.T) {
 			want:      metadata.MD{},
 		},
 		{
-			name: "disallow_expr_errors_when_is_error",
-			rules: &v3mutationpb.HeaderMutationRules{
-				DisallowExpression: &v3matcherpb.RegexMatcher{Regex: ".*-blocked"},
-				DisallowIsError:    wrapperspb.Bool(true),
-			},
-			input:     metadata.MD{},
-			mutations: []*v3corepb.HeaderValueOption{hvo("k-blocked", "a", overwrite)},
-			wantErr:   true,
-		},
-		{
-			name: "allow_expr_blocks_non_matching_when_not_error",
+			// A key not matching allow_expression is still allowed when
+			// disallow_all is not set (allow_expression only adds allows).
+			name: "allow_expr_non_matching_still_allowed",
 			rules: &v3mutationpb.HeaderMutationRules{
 				AllowExpression: &v3matcherpb.RegexMatcher{Regex: "allowed-.*"},
 			},
 			input:     metadata.MD{},
 			mutations: []*v3corepb.HeaderValueOption{hvo("other", "a", overwrite)},
-			want:      metadata.MD{},
+			want:      metadata.MD{"other": {"a"}},
 		},
 		{
-			name: "allow_expr_permits_matching",
+			name: "allow_expr_matching_allowed",
 			rules: &v3mutationpb.HeaderMutationRules{
 				AllowExpression: &v3matcherpb.RegexMatcher{Regex: "allowed-.*"},
 			},
@@ -238,6 +277,36 @@ func TestHeaderMutator_Mutate(t *testing.T) {
 			input:     metadata.MD{},
 			mutations: []*v3corepb.HeaderValueOption{hvo("allowed-secret", "a", overwrite)},
 			want:      metadata.MD{},
+		},
+		// --- disallow_is_error: disallowed mutations fail the call ---
+		{
+			name: "disallow_all_errors_when_is_error",
+			rules: &v3mutationpb.HeaderMutationRules{
+				DisallowAll:     wrapperspb.Bool(true),
+				DisallowIsError: wrapperspb.Bool(true),
+			},
+			input:     metadata.MD{"k": {"a"}},
+			mutations: []*v3corepb.HeaderValueOption{hvo("k", "b", overwrite)},
+			wantErr:   true,
+		},
+		{
+			name: "disallow_expr_errors_when_is_error",
+			rules: &v3mutationpb.HeaderMutationRules{
+				DisallowExpression: &v3matcherpb.RegexMatcher{Regex: ".*-blocked"},
+				DisallowIsError:    wrapperspb.Bool(true),
+			},
+			input:     metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{hvo("k-blocked", "a", overwrite)},
+			wantErr:   true,
+		},
+		{
+			// An unconditionally invalid header also errors under
+			// disallow_is_error.
+			name:      "invalid_header_errors_when_is_error",
+			rules:     &v3mutationpb.HeaderMutationRules{DisallowIsError: wrapperspb.Bool(true)},
+			input:     metadata.MD{},
+			mutations: []*v3corepb.HeaderValueOption{hvo("grpc-foo", "a", overwrite)},
+			wantErr:   true,
 		},
 	}
 
@@ -263,7 +332,7 @@ func TestHeaderMutator_Mutate(t *testing.T) {
 
 // TestHeaderMutator_DoesNotMutateInput verifies that Mutate operates on a copy
 // and leaves the caller's metadata untouched.
-func TestHeaderMutator_DoesNotMutateInput(t *testing.T) {
+func (s) TestHeaderMutator_DoesNotMutateInput(t *testing.T) {
 	mutator := NewHeaderMutator(HeaderMutationRules{})
 	input := metadata.MD{"k": {"a"}}
 	if _, err := mutator.Mutate(input, []*v3corepb.HeaderValueOption{
@@ -281,12 +350,12 @@ func TestHeaderMutator_DoesNotMutateInput(t *testing.T) {
 // TestHeaderMutator_NoOpDoesNotCopy verifies the copy-on-write behavior: a
 // call that applies no mutations returns the input metadata without allocating
 // a copy.
-func TestHeaderMutator_NoOpDoesNotCopy(t *testing.T) {
+func (s) TestHeaderMutator_NoOpDoesNotCopy(t *testing.T) {
 	mutator := NewHeaderMutator(HeaderMutationRules{})
 	input := metadata.MD{"k": {"v"}}
 	tests := map[string][]*v3corepb.HeaderValueOption{
 		"no_mutations":      nil,
-		"all_skipped":       {hvo(":path", "/x", overwrite)}, // pseudo-header
+		"all_disallowed":    {hvo(":path", "/x", overwrite)}, // pseudo-header
 		"nil_header_option": {{AppendAction: overwrite}},
 	}
 	for name, mutations := range tests {
@@ -302,7 +371,7 @@ func TestHeaderMutator_NoOpDoesNotCopy(t *testing.T) {
 	}
 }
 
-func TestNewHeaderMutatorFromProto_InvalidRegex(t *testing.T) {
+func (s) TestNewHeaderMutatorFromProto_InvalidRegex(t *testing.T) {
 	_, err := NewHeaderMutatorFromProto(&v3mutationpb.HeaderMutationRules{
 		AllowExpression: &v3matcherpb.RegexMatcher{Regex: "("},
 	})

--- a/internal/xds/httpfilter/headers_test.go
+++ b/internal/xds/httpfilter/headers_test.go
@@ -1,0 +1,141 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package httpfilter
+
+import (
+	"testing"
+
+	v3mutationpb "github.com/envoyproxy/go-control-plane/envoy/config/common/mutation_rules/v3"
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	v3matcherpb "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestHeaderMutator_Mutate(t *testing.T) {
+	mr := &v3mutationpb.HeaderMutationRules{
+		AllowExpression:    &v3matcherpb.RegexMatcher{Regex: "allowed-.*"},
+		DisallowExpression: &v3matcherpb.RegexMatcher{Regex: ".*-blocked"},
+		DisallowIsError:    wrapperspb.Bool(true),
+	}
+
+	mutator, err := NewHeaderMutatorFromProto(mr)
+	if err != nil {
+		t.Fatalf("NewHeaderMutatorFromProto() returned error: %v", err)
+	}
+
+	md := metadata.Pairs("existing-key", "existing-val")
+
+	mutations := []*v3corepb.HeaderValueOption{
+		{
+			Header:       &v3corepb.HeaderValue{Key: "allowed-header", Value: "mutated-val"},
+			AppendAction: v3corepb.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD,
+		},
+	}
+
+	res, err := mutator.Mutate(md, mutations)
+	if err != nil {
+		t.Fatalf("Mutate() returned unexpected error: %v", err)
+	}
+
+	if got := res.Get("allowed-header"); len(got) != 1 || got[0] != "mutated-val" {
+		t.Errorf("Mutate() allowed-header got: %v, want: %v", got, []string{"mutated-val"})
+	}
+
+	disallowedMutations := []*v3corepb.HeaderValueOption{
+		{
+			Header: &v3corepb.HeaderValue{Key: "header-blocked", Value: "val"},
+		},
+	}
+	_, err = mutator.Mutate(md, disallowedMutations)
+	if err == nil {
+		t.Fatal("Mutate() succeeded for disallowed header with DisallowIsError=true, want error")
+	}
+
+	systemMutations := []*v3corepb.HeaderValueOption{
+		{
+			Header: &v3corepb.HeaderValue{Key: ":path", Value: "/new/path"},
+		},
+	}
+	res, err = mutator.Mutate(md, systemMutations)
+	if err != nil {
+		t.Fatalf("Mutate() returned unexpected error for system header: %v", err)
+	}
+	if got := res.Get(":path"); len(got) != 0 {
+		t.Errorf("System header mutation applied; got: %v, want: []", got)
+	}
+}
+
+func TestHeaderMutator_KeepEmptyValue(t *testing.T) {
+	mr := &v3mutationpb.HeaderMutationRules{}
+	mutator, err := NewHeaderMutatorFromProto(mr)
+	if err != nil {
+		t.Fatalf("NewHeaderMutatorFromProto() returned error: %v", err)
+	}
+
+	t.Run("KeepEmptyValue = false (default)", func(t *testing.T) {
+		md := metadata.Pairs("existing-key", "existing-val")
+		mutations := []*v3corepb.HeaderValueOption{
+			{
+				Header:       &v3corepb.HeaderValue{Key: "existing-key", Value: ""},
+				AppendAction: v3corepb.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
+			},
+			{
+				Header:       &v3corepb.HeaderValue{Key: "new-key", Value: ""},
+				AppendAction: v3corepb.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD,
+			},
+		}
+		res, err := mutator.Mutate(md, mutations)
+		if err != nil {
+			t.Fatalf("Mutate() returned error: %v", err)
+		}
+		if got := res.Get("existing-key"); len(got) != 0 {
+			t.Errorf("existing-key got: %v, want: []", got)
+		}
+		if got := res.Get("new-key"); len(got) != 0 {
+			t.Errorf("new-key got: %v, want: []", got)
+		}
+	})
+
+	t.Run("KeepEmptyValue = true (ignored)", func(t *testing.T) {
+		md := metadata.Pairs("existing-key", "existing-val")
+		mutations := []*v3corepb.HeaderValueOption{
+			{
+				Header:         &v3corepb.HeaderValue{Key: "existing-key", Value: ""},
+				AppendAction:   v3corepb.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
+				KeepEmptyValue: true,
+			},
+			{
+				Header:         &v3corepb.HeaderValue{Key: "new-key", Value: ""},
+				AppendAction:   v3corepb.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD,
+				KeepEmptyValue: true,
+			},
+		}
+		res, err := mutator.Mutate(md, mutations)
+		if err != nil {
+			t.Fatalf("Mutate() returned error: %v", err)
+		}
+		if got := res.Get("existing-key"); len(got) != 0 {
+			t.Errorf("existing-key got: %v, want: []", got)
+		}
+		if got := res.Get("new-key"); len(got) != 0 {
+			t.Errorf("new-key got: %v, want: []", got)
+		}
+	})
+}


### PR DESCRIPTION
## Series Context
This is a **standalone PR** implementing the HTTP header mutation engine for
gRFC A102 (xDS GrpcService Support and Header Representations). It does not
depend on any other pending A102 PRs.

## Overview
Implements the `HeaderMutator` engine in `internal/xds/httpfilter/headers.go`
as specified in gRFC A102. It evaluates Envoy's `HeaderMutationRules` against a
set of `HeaderValueOption` mutations and applies the allowed ones to gRPC
metadata. The mutator operates on a copy of the metadata and holds only
read-only compiled state, so it is safe for concurrent use — intended for the
side-channel call paths (e.g. ext_proc) that A102 enables.

## Key Changes
- **Mutation rules**: Constructed from `HeaderMutationRules` (compiled
  `allow_expression` / `disallow_expression` regexes), honoring `disallow_all`
  and `disallow_is_error`.
- **Security boundaries**: Mutations to pseudo-headers (`:`-prefixed) and the
  `host` header are always blocked, regardless of control-plane settings. Other
  headers (including `grpc-*`) are subject to the allow/disallow rules.
- **Mutation actions**: Supports all four append actions —
  `APPEND_IF_EXISTS_OR_ADD`, `ADD_IF_ABSENT`, `OVERWRITE_IF_EXISTS_OR_ADD`, and
  `OVERWRITE_IF_EXISTS`.
- **Value handling**: `raw_value` takes precedence over the legacy `value`
  field; headers are retained even when a mutation yields an empty value
  (`keep_empty_value` is intentionally unsupported).

## Testing
- Table-driven unit tests in `internal/xds/httpfilter/headers_test.go` covering
  all four actions, empty-value retention, `raw_value` precedence, the
  always-protected headers, the allow/disallow rule combinations, and that the
  input metadata is left unmodified.

RELEASE NOTES: n/a