### PR TITLE
reject alts record frame shorter than message type field

### DIFF
--- a/credentials/alts/internal/conn/record.go
+++ b/credentials/alts/internal/conn/record.go
@@ -257,6 +257,13 @@ func (p *conn) ReadOnReady(bufSize int, pool mem.BufferPool) (*[]byte, int, erro
 		}
 		// Now we have a complete frame, decrypted it.
 		msg := framedMsg[MsgLenFieldSize:]
+		// The frame's length field is attacker-controlled and unauthenticated.
+		// A frame that claims fewer payload bytes than the message type field
+		// requires would otherwise slice past the frame when reading the type
+		// and the ciphertext.
+		if len(msg) < msgTypeFieldSize {
+			return nil, 0, fmt.Errorf("received frame with payload size %d smaller than the message type field size %d", len(msg), msgTypeFieldSize)
+		}
 		msgType := binary.LittleEndian.Uint32(msg[:msgTypeFieldSize])
 		if msgType&0xff != altsRecordMsgType {
 			return nil, 0, fmt.Errorf("received frame with incorrect message type %v, expected lower byte %v",

--- a/credentials/alts/internal/conn/record_test.go
+++ b/credentials/alts/internal/conn/record_test.go
@@ -286,6 +286,32 @@ func (s) TestFrameTooLarge(t *testing.T) {
 	}
 }
 
+func testFrameTooSmall(t *testing.T, rp string) {
+	buf := new(bytes.Buffer)
+	serverConn := newTestALTSRecordConn(buf, nil, core.ServerSide, rp, nil)
+	// Craft a frame whose length field claims fewer bytes than the message
+	// type field requires. The first payload byte is set to the record
+	// message type so the type check passes and decoding proceeds to slice
+	// out the ciphertext.
+	payload := []byte{byte(altsRecordMsgType & 0xff), 0x00}
+	framedMsg := make([]byte, MsgLenFieldSize+len(payload))
+	binary.LittleEndian.PutUint32(framedMsg[:MsgLenFieldSize], uint32(len(payload)))
+	copy(framedMsg[MsgLenFieldSize:], payload)
+	if _, err := buf.Write(framedMsg); err != nil {
+		t.Fatalf("Unexpected error writing to buffer: %v", err)
+	}
+	b := make([]byte, 1)
+	if n, err := serverConn.Read(b); n != 0 || err == nil {
+		t.Fatalf("Read() = %v, %v; want 0, error", n, err)
+	}
+}
+
+func (s) TestFrameTooSmall(t *testing.T) {
+	for _, rp := range recordProtocols {
+		testFrameTooSmall(t, rp)
+	}
+}
+
 func testWriteLargeData(t *testing.T, rp string) {
 	// Test sending and receiving messages larger than the maximum write
 	// buffer size.


### PR DESCRIPTION
ReadOnReady in the ALTS record layer trusts the 4-byte frame length field, which is part of the unauthenticated framing around the encrypted payload. After slicing off the length prefix it reads a 4-byte message type and then the trailing ciphertext without checking the payload is at least that large. A peer or on-path attacker that sends a frame whose length field is 1 to 3 with the first payload byte set to the record message type clears the type check and then hits `msg[msgTypeFieldSize:]` with the low bound past the high bound, panicking the reader (and reading a few bytes beyond the frame when interpreting the type).

Reject frames whose payload is shorter than the message type field before the type and ciphertext are sliced out. The check belongs here because this is the layer that owns the frame layout, so the read returns an error like any other malformed frame instead of crashing.