### PR TITLE
xds: parse allowed_grpc_services from the bootstrap config (A102)

### DIFF
--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -276,6 +276,16 @@ func (scs *ServerConfigs) Equal(other *ServerConfigs) bool {
 func (scs *ServerConfigs) UnmarshalJSON(data []byte) error {
 	servers := []*ServerConfig{}
 	if err := json.Unmarshal(data, &servers); err != nil {
+		// Some servers may have built credentials before the failure;
+		// release them so they don't leak when the slice is dropped.
+		for _, sc := range servers {
+			if sc == nil {
+				continue
+			}
+			for _, cleanup := range sc.Cleanups() {
+				cleanup()
+			}
+		}
 		return fmt.Errorf("xds: failed to JSON unmarshal server configurations during bootstrap: %v, config:\n%s", err, string(data))
 	}
 	*scs = servers
@@ -741,26 +751,33 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 	// even if the bootstrap configuration did not contain the node field, we
 	// will have a node field with client controlled fields alone.
 	config := configJSON{Node: newNode()}
-	if err := json.Unmarshal(data, &config); err != nil {
-		return fmt.Errorf("xds: json.Unmarshal(%s) failed during bootstrap: %v", string(data), err)
-	}
 
-	// Unmarshaling above eagerly built credentials (bundles, file
-	// watchers) for each server config and allowed gRPC service. If
-	// bootstrap parsing fails after this point, release them: the caller
-	// discards this Config without ever calling their cleanups.
+	// json.Unmarshal below eagerly builds credentials (bundles, file
+	// watchers) for server configs (top-level and per-authority) and
+	// allowed gRPC services. Install the cleanup before unmarshaling so
+	// resources built before a mid-way unmarshal failure, or a later
+	// validation error, are released when this Config is discarded.
 	parsedSuccessfully := false
-	defer func() {
-		if parsedSuccessfully {
-			return
-		}
-		for _, sc := range config.XDSServers {
+	releaseServerCreds := func(servers ServerConfigs) {
+		for _, sc := range servers {
 			if sc == nil {
 				continue
 			}
 			for _, cleanup := range sc.Cleanups() {
 				cleanup()
 			}
+		}
+	}
+	defer func() {
+		if parsedSuccessfully {
+			return
+		}
+		releaseServerCreds(config.XDSServers)
+		for _, authority := range config.Authorities {
+			if authority == nil {
+				continue
+			}
+			releaseServerCreds(authority.XDSServers)
 		}
 		for _, svc := range config.AllowedGrpcServices {
 			if svc == nil {
@@ -771,6 +788,10 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 			}
 		}
 	}()
+
+	if err := json.Unmarshal(data, &config); err != nil {
+		return fmt.Errorf("xds: json.Unmarshal(%s) failed during bootstrap: %v", string(data), err)
+	}
 
 	c.xDSServers = config.XDSServers
 	c.cpcs = config.CertificateProviders
@@ -810,6 +831,9 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 	// - if set, it must start with "xdstp://<authority_name>/"
 	// - if not set, it defaults to "xdstp://<authority_name>/envoy.config.listener.v3.Listener/%s"
 	for name, authority := range c.authorities {
+		if authority == nil {
+			return fmt.Errorf("xds: authority %q has no configuration in bootstrap", name)
+		}
 		prefix := fmt.Sprintf("xdstp://%s", url.PathEscape(name))
 		if authority.ClientListenerResourceNameTemplate == "" {
 			authority.ClientListenerResourceNameTemplate = prefix + "/envoy.config.listener.v3.Listener/%s"

--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -181,9 +181,9 @@ func (a *AllowedGrpcService) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &jsonS); err != nil {
 		return err
 	}
-	a.channelCreds = jsonS.ChannelCreds
-	a.callCredsConfigs = jsonS.CallCredsConfigs
 
+	// Build into locals and assign the receiver only on success, so a
+	// mid-parse error never leaves the receiver partially mutated.
 	cleanups := []func(){}
 	dialOptions := []grpc.DialOption{}
 	selectedCallCreds := []credentials.PerRPCCredentials{}
@@ -195,6 +195,7 @@ func (a *AllowedGrpcService) UnmarshalJSON(data []byte) error {
 	}
 
 	var credsDialOption grpc.DialOption
+	var selectedChannelCreds ChannelCreds
 	for _, cc := range jsonS.ChannelCreds {
 		c := bootstrap.GetChannelCredentials(cc.Type)
 		if c == nil {
@@ -205,7 +206,7 @@ func (a *AllowedGrpcService) UnmarshalJSON(data []byte) error {
 			runCleanups()
 			return fmt.Errorf("failed to build credentials bundle from bootstrap for allowed grpc service: type %q, err: %v", cc.Type, err)
 		}
-		a.selectedChannelCreds = cc
+		selectedChannelCreds = cc
 		credsDialOption = grpc.WithCredentialsBundle(bundle)
 		if d, ok := bundle.(extraDialOptions); ok {
 			dialOptions = append(dialOptions, d.DialOptions()...)
@@ -237,6 +238,9 @@ func (a *AllowedGrpcService) UnmarshalJSON(data []byte) error {
 		}
 	}
 
+	a.channelCreds = jsonS.ChannelCreds
+	a.callCredsConfigs = jsonS.CallCredsConfigs
+	a.selectedChannelCreds = selectedChannelCreds
 	a.dialOptions = dialOptions
 	a.selectedCallCreds = selectedCallCreds
 	a.cleanups = cleanups
@@ -741,6 +745,33 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("xds: json.Unmarshal(%s) failed during bootstrap: %v", string(data), err)
 	}
 
+	// Unmarshaling above eagerly built credentials (bundles, file
+	// watchers) for each server config and allowed gRPC service. If
+	// bootstrap parsing fails after this point, release them: the caller
+	// discards this Config without ever calling their cleanups.
+	parsedSuccessfully := false
+	defer func() {
+		if parsedSuccessfully {
+			return
+		}
+		for _, sc := range config.XDSServers {
+			if sc == nil {
+				continue
+			}
+			for _, cleanup := range sc.Cleanups() {
+				cleanup()
+			}
+		}
+		for _, svc := range config.AllowedGrpcServices {
+			if svc == nil {
+				continue
+			}
+			for _, cleanup := range svc.Cleanups() {
+				cleanup()
+			}
+		}
+	}()
+
 	c.xDSServers = config.XDSServers
 	c.cpcs = config.CertificateProviders
 	c.serverListenerResourceNameTemplate = config.ServerListenerResourceNameTemplate
@@ -788,6 +819,7 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("xds: field clientListenerResourceNameTemplate %q of authority %q doesn't start with prefix %q", authority.ClientListenerResourceNameTemplate, name, prefix)
 		}
 	}
+	parsedSuccessfully = true
 	return nil
 }
 

--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -120,6 +120,137 @@ func (ccs CallCredsConfigs) String() string {
 	return strings.Join(creds, ",")
 }
 
+// AllowedGrpcService contains credentials config for an allowed gRPC service.
+type AllowedGrpcService struct {
+	channelCreds         []ChannelCreds
+	callCredsConfigs     []CallCredsConfig
+	selectedChannelCreds ChannelCreds
+	selectedCallCreds    []credentials.PerRPCCredentials
+	dialOptions          []grpc.DialOption
+	cleanups             []func()
+}
+
+// ChannelCreds returns the list of parsed channel credentials.
+func (a *AllowedGrpcService) ChannelCreds() []ChannelCreds {
+	return a.channelCreds
+}
+
+// CallCredsConfigs returns the list of call credentials configurations.
+func (a *AllowedGrpcService) CallCredsConfigs() []CallCredsConfig {
+	return a.callCredsConfigs
+}
+
+// SelectedChannelCreds returns the chosen supported channel credentials.
+func (a *AllowedGrpcService) SelectedChannelCreds() ChannelCreds {
+	return a.selectedChannelCreds
+}
+
+// DialOptions returns dial options built from these credentials.
+func (a *AllowedGrpcService) DialOptions() []grpc.DialOption {
+	return a.dialOptions
+}
+
+// Cleanups returns cleanups to run when the service is no longer needed.
+func (a *AllowedGrpcService) Cleanups() []func() {
+	return a.cleanups
+}
+
+// Equal reports whether a and other are considered equal.
+func (a *AllowedGrpcService) Equal(other *AllowedGrpcService) bool {
+	switch {
+	case a == nil && other == nil:
+		return true
+	case (a != nil) != (other != nil):
+		return false
+	case !slices.EqualFunc(a.channelCreds, other.channelCreds, func(x, y ChannelCreds) bool { return x.Equal(y) }):
+		return false
+	case !slices.EqualFunc(a.callCredsConfigs, other.callCredsConfigs, func(x, y CallCredsConfig) bool { return x.Equal(y) }):
+		return false
+	}
+	return true
+}
+
+type allowedGrpcServiceJSON struct {
+	ChannelCreds     []ChannelCreds    `json:"channel_creds,omitempty"`
+	CallCredsConfigs []CallCredsConfig `json:"call_creds,omitempty"`
+}
+
+// UnmarshalJSON parses the JSON data and validates its credentials.
+func (a *AllowedGrpcService) UnmarshalJSON(data []byte) error {
+	var jsonS allowedGrpcServiceJSON
+	if err := json.Unmarshal(data, &jsonS); err != nil {
+		return err
+	}
+	a.channelCreds = jsonS.ChannelCreds
+	a.callCredsConfigs = jsonS.CallCredsConfigs
+
+	cleanups := []func(){}
+	dialOptions := []grpc.DialOption{}
+	selectedCallCreds := []credentials.PerRPCCredentials{}
+
+	runCleanups := func() {
+		for _, f := range cleanups {
+			f()
+		}
+	}
+
+	var credsDialOption grpc.DialOption
+	for _, cc := range jsonS.ChannelCreds {
+		c := bootstrap.GetChannelCredentials(cc.Type)
+		if c == nil {
+			continue
+		}
+		bundle, cancel, err := c.Build(cc.Config)
+		if err != nil {
+			runCleanups()
+			return fmt.Errorf("failed to build credentials bundle from bootstrap for allowed grpc service: type %q, err: %v", cc.Type, err)
+		}
+		a.selectedChannelCreds = cc
+		credsDialOption = grpc.WithCredentialsBundle(bundle)
+		if d, ok := bundle.(extraDialOptions); ok {
+			dialOptions = append(dialOptions, d.DialOptions()...)
+		}
+		cleanups = append(cleanups, cancel)
+		break
+	}
+
+	if credsDialOption == nil {
+		runCleanups()
+		return fmt.Errorf("xds: no supported channel credentials found for allowed grpc service in config:\n%s", string(data))
+	}
+	dialOptions = append(dialOptions, credsDialOption)
+
+	if envconfig.XDSBootstrapCallCredsEnabled {
+		for _, cfg := range jsonS.CallCredsConfigs {
+			c := bootstrap.GetCallCredentials(cfg.Type)
+			if c == nil {
+				continue
+			}
+			callCreds, cancel, err := c.Build(cfg.Config)
+			if err != nil {
+				runCleanups()
+				return fmt.Errorf("failed to build call credentials from bootstrap for allowed grpc service: type %q, err: %v", cfg.Type, err)
+			}
+			selectedCallCreds = append(selectedCallCreds, callCreds)
+			dialOptions = append(dialOptions, grpc.WithPerRPCCredentials(callCreds))
+			cleanups = append(cleanups, cancel)
+		}
+	}
+
+	a.dialOptions = dialOptions
+	a.selectedCallCreds = selectedCallCreds
+	a.cleanups = cleanups
+	return nil
+}
+
+// MarshalJSON marshals the allowed gRPC service into JSON format.
+func (a *AllowedGrpcService) MarshalJSON() ([]byte, error) {
+	return json.Marshal(allowedGrpcServiceJSON{
+		ChannelCreds:     a.channelCreds,
+		CallCredsConfigs: a.callCredsConfigs,
+	})
+}
+
 // ServerConfigs represents a collection of server configurations.
 type ServerConfigs []*ServerConfig
 
@@ -461,6 +592,14 @@ type Config struct {
 
 	// A map from certprovider instance names to parsed buildable configs.
 	certProviderConfigs map[string]*certprovider.BuildableConfig
+
+	allowedGrpcServices map[string]*AllowedGrpcService
+}
+
+// AllowedGrpcServices returns the allowlist of gRPC services.
+// Callers must not modify the returned map.
+func (c *Config) AllowedGrpcServices() map[string]*AllowedGrpcService {
+	return c.allowedGrpcServices
 }
 
 // XDSServers returns the top-level list of management servers to connect to,
@@ -552,6 +691,8 @@ func (c *Config) Equal(other *Config) bool {
 		return false
 	case !maps.EqualFunc(c.authorities, other.authorities, func(a, b *Authority) bool { return a.Equal(b) }):
 		return false
+	case !maps.EqualFunc(c.allowedGrpcServices, other.allowedGrpcServices, func(a, b *AllowedGrpcService) bool { return a.Equal(b) }):
+		return false
 	case !c.node.Equal(other.node):
 		return false
 	}
@@ -572,6 +713,7 @@ type configJSON struct {
 	ClientDefaultListenerResourceNameTemplate string                               `json:"client_default_listener_resource_name_template,omitempty"`
 	Authorities                               map[string]*Authority                `json:"authorities,omitempty"`
 	Node                                      node                                 `json:"node,omitempty"`
+	AllowedGrpcServices                       map[string]*AllowedGrpcService       `json:"allowed_grpc_services,omitempty"`
 }
 
 // MarshalJSON returns marshaled JSON bytes corresponding to this config.
@@ -583,6 +725,7 @@ func (c *Config) MarshalJSON() ([]byte, error) {
 		ClientDefaultListenerResourceNameTemplate: c.clientDefaultListenerResourceNameTemplate,
 		Authorities:                               c.authorities,
 		Node:                                      c.node,
+		AllowedGrpcServices:                       c.allowedGrpcServices,
 	}
 	return json.MarshalIndent(config, " ", " ")
 }
@@ -604,6 +747,7 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 	c.clientDefaultListenerResourceNameTemplate = config.ClientDefaultListenerResourceNameTemplate
 	c.authorities = config.Authorities
 	c.node = config.Node
+	c.allowedGrpcServices = config.AllowedGrpcServices
 
 	// Build the certificate providers configuration to ensure that it is valid.
 	cpcCfgs := make(map[string]*certprovider.BuildableConfig)
@@ -723,6 +867,8 @@ type ConfigOptionsForTesting struct {
 	// Node identifies the gRPC client/server node in the
 	// proxyless service mesh.
 	Node json.RawMessage
+	// AllowedGrpcServices is the allowlist of gRPC services.
+	AllowedGrpcServices json.RawMessage
 }
 
 // NewContentsForTesting creates a new bootstrap configuration from the passed in
@@ -754,6 +900,12 @@ func NewContentsForTesting(opts ConfigOptionsForTesting) ([]byte, error) {
 	if err := json.Unmarshal(opts.Node, &node); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal node configuration %s: %v", string(opts.Node), err)
 	}
+	allowedGrpcServices := make(map[string]*AllowedGrpcService)
+	if len(opts.AllowedGrpcServices) > 0 {
+		if err := json.Unmarshal(opts.AllowedGrpcServices, &allowedGrpcServices); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal allowed grpc services configuration: %v", err)
+		}
+	}
 	cfgJSON := configJSON{
 		XDSServers:                                servers,
 		CertificateProviders:                      certProviders,
@@ -761,6 +913,7 @@ func NewContentsForTesting(opts ConfigOptionsForTesting) ([]byte, error) {
 		ClientDefaultListenerResourceNameTemplate: opts.ClientDefaultListenerResourceNameTemplate,
 		Authorities:                               authorities,
 		Node:                                      node,
+		AllowedGrpcServices:                       allowedGrpcServices,
 	}
 	contents, err := json.MarshalIndent(cfgJSON, " ", " ")
 	if err != nil {

--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -122,30 +122,34 @@ func (ccs CallCredsConfigs) String() string {
 
 // AllowedGrpcService contains credentials config for an allowed gRPC service.
 type AllowedGrpcService struct {
-	channelCreds         []ChannelCreds
-	callCredsConfigs     []CallCredsConfig
+	// targetURI is the fully-qualified side-channel target this entry
+	// applies to. It is the map key under which the service is stored,
+	// copied in during parsing so the service is self-describing.
+	targetURI string
+	// channelCreds is the list of channel-credential configs from the
+	// bootstrap JSON. Retained for Equal and JSON round-tripping.
+	channelCreds []ChannelCreds
+	// callCredsConfigs is the list of call-credential configs from the
+	// bootstrap JSON. Retained for Equal and JSON round-tripping.
+	callCredsConfigs []CallCredsConfig
+	// selectedChannelCreds is the first channel-creds entry whose type the
+	// client supports; it is the one used to build the side channel.
 	selectedChannelCreds ChannelCreds
-	selectedCallCreds    []credentials.PerRPCCredentials
-	dialOptions          []grpc.DialOption
-	cleanups             []func()
+	// dialOptions are built from the selected channel and call credentials
+	// and passed to grpc.NewClient when creating the side channel.
+	dialOptions []grpc.DialOption
+	// cleanups release resources (credential bundles, file watchers) built
+	// for this service; run when the owning Config is no longer needed.
+	cleanups []func()
 }
 
-// ChannelCreds returns the list of parsed channel credentials.
-func (a *AllowedGrpcService) ChannelCreds() []ChannelCreds {
-	return a.channelCreds
+// TargetURI returns the fully-qualified target URI this service applies to.
+func (a *AllowedGrpcService) TargetURI() string {
+	return a.targetURI
 }
 
-// CallCredsConfigs returns the list of call credentials configurations.
-func (a *AllowedGrpcService) CallCredsConfigs() []CallCredsConfig {
-	return a.callCredsConfigs
-}
-
-// SelectedChannelCreds returns the chosen supported channel credentials.
-func (a *AllowedGrpcService) SelectedChannelCreds() ChannelCreds {
-	return a.selectedChannelCreds
-}
-
-// DialOptions returns dial options built from these credentials.
+// DialOptions returns the dial options built from this service's selected
+// channel and call credentials, for use when creating the side channel.
 func (a *AllowedGrpcService) DialOptions() []grpc.DialOption {
 	return a.dialOptions
 }
@@ -157,17 +161,19 @@ func (a *AllowedGrpcService) Cleanups() []func() {
 
 // Equal reports whether a and other are considered equal.
 func (a *AllowedGrpcService) Equal(other *AllowedGrpcService) bool {
-	switch {
-	case a == nil && other == nil:
+	if a == nil && other == nil {
 		return true
-	case (a != nil) != (other != nil):
-		return false
-	case !slices.EqualFunc(a.channelCreds, other.channelCreds, func(x, y ChannelCreds) bool { return x.Equal(y) }):
-		return false
-	case !slices.EqualFunc(a.callCredsConfigs, other.callCredsConfigs, func(x, y CallCredsConfig) bool { return x.Equal(y) }):
+	}
+	if a == nil || other == nil {
 		return false
 	}
-	return true
+	if a.targetURI != other.targetURI {
+		return false
+	}
+	if !slices.EqualFunc(a.channelCreds, other.channelCreds, ChannelCreds.Equal) {
+		return false
+	}
+	return slices.EqualFunc(a.callCredsConfigs, other.callCredsConfigs, CallCredsConfig.Equal)
 }
 
 type allowedGrpcServiceJSON struct {
@@ -184,9 +190,8 @@ func (a *AllowedGrpcService) UnmarshalJSON(data []byte) error {
 
 	// Build into locals and assign the receiver only on success, so a
 	// mid-parse error never leaves the receiver partially mutated.
-	cleanups := []func(){}
-	dialOptions := []grpc.DialOption{}
-	selectedCallCreds := []credentials.PerRPCCredentials{}
+	var cleanups []func()
+	var dialOptions []grpc.DialOption
 
 	runCleanups := func() {
 		for _, f := range cleanups {
@@ -232,7 +237,6 @@ func (a *AllowedGrpcService) UnmarshalJSON(data []byte) error {
 				runCleanups()
 				return fmt.Errorf("failed to build call credentials from bootstrap for allowed grpc service: type %q, err: %v", cfg.Type, err)
 			}
-			selectedCallCreds = append(selectedCallCreds, callCreds)
 			dialOptions = append(dialOptions, grpc.WithPerRPCCredentials(callCreds))
 			cleanups = append(cleanups, cancel)
 		}
@@ -242,7 +246,6 @@ func (a *AllowedGrpcService) UnmarshalJSON(data []byte) error {
 	a.callCredsConfigs = jsonS.CallCredsConfigs
 	a.selectedChannelCreds = selectedChannelCreds
 	a.dialOptions = dialOptions
-	a.selectedCallCreds = selectedCallCreds
 	a.cleanups = cleanups
 	return nil
 }
@@ -607,6 +610,9 @@ type Config struct {
 	// A map from certprovider instance names to parsed buildable configs.
 	certProviderConfigs map[string]*certprovider.BuildableConfig
 
+	// allowedGrpcServices maps a fully-qualified target URI to the
+	// credentials gRPC may use for that side channel when the xDS server
+	// that configured it is untrusted (gRFC A102).
 	allowedGrpcServices map[string]*AllowedGrpcService
 }
 
@@ -703,9 +709,9 @@ func (c *Config) Equal(other *Config) bool {
 		return false
 	case c.clientDefaultListenerResourceNameTemplate != other.clientDefaultListenerResourceNameTemplate:
 		return false
-	case !maps.EqualFunc(c.authorities, other.authorities, func(a, b *Authority) bool { return a.Equal(b) }):
+	case !maps.EqualFunc(c.authorities, other.authorities, (*Authority).Equal):
 		return false
-	case !maps.EqualFunc(c.allowedGrpcServices, other.allowedGrpcServices, func(a, b *AllowedGrpcService) bool { return a.Equal(b) }):
+	case !maps.EqualFunc(c.allowedGrpcServices, other.allowedGrpcServices, (*AllowedGrpcService).Equal):
 		return false
 	case !c.node.Equal(other.node):
 		return false
@@ -800,6 +806,19 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 	c.authorities = config.Authorities
 	c.node = config.Node
 	c.allowedGrpcServices = config.AllowedGrpcServices
+
+	// A null allowed_grpc_services entry (e.g. {"target": null}) is decoded by
+	// encoding/json as a nil value without invoking UnmarshalJSON, which would
+	// bypass the required-channel-creds validation and leave a nil entry that
+	// consumers could dereference. gRFC A102 requires channel_creds on every
+	// entry, so reject nil entries here.
+	for target, svc := range c.allowedGrpcServices {
+		if svc == nil {
+			return fmt.Errorf("xds: allowed_grpc_services entry %q has no configuration in bootstrap config", target)
+		}
+		// Copy the map key into the service so it is self-describing.
+		svc.targetURI = target
+	}
 
 	// Build the certificate providers configuration to ensure that it is valid.
 	cpcCfgs := make(map[string]*certprovider.BuildableConfig)
@@ -960,6 +979,17 @@ func NewContentsForTesting(opts ConfigOptionsForTesting) ([]byte, error) {
 	if len(opts.AllowedGrpcServices) > 0 {
 		if err := json.Unmarshal(opts.AllowedGrpcServices, &allowedGrpcServices); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal allowed grpc services configuration: %v", err)
+		}
+		// Only the parsed config is needed to marshal the bootstrap JSON below;
+		// release the credentials built during unmarshal so this test helper
+		// does not leak file watchers.
+		for _, svc := range allowedGrpcServices {
+			if svc == nil {
+				continue
+			}
+			for _, cleanup := range svc.Cleanups() {
+				cleanup()
+			}
 		}
 	}
 	cfgJSON := configJSON{

--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -127,10 +127,10 @@ type AllowedGrpcService struct {
 	// copied in during parsing so the service is self-describing.
 	targetURI string
 	// channelCreds is the list of channel-credential configs from the
-	// bootstrap JSON. Retained for Equal and JSON round-tripping.
+	// bootstrap JSON. Kept for Equal and MarshalJSON.
 	channelCreds []ChannelCreds
 	// callCredsConfigs is the list of call-credential configs from the
-	// bootstrap JSON. Retained for Equal and JSON round-tripping.
+	// bootstrap JSON. Kept for Equal and MarshalJSON.
 	callCredsConfigs []CallCredsConfig
 	// selectedChannelCreds is the first channel-creds entry whose type the
 	// client supports; it is the one used to build the side channel.

--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -219,22 +219,23 @@ func (s *AllowedGRPCServices) UnmarshalJSON(data []byte) error {
 }
 
 // UnmarshalJSON parses the JSON data and validates its credentials.
-func (a *AllowedGRPCService) UnmarshalJSON(data []byte) error {
+func (a *AllowedGRPCService) UnmarshalJSON(data []byte) (err error) {
 	var jsonS allowedGRPCServiceJSON
 	if err := json.Unmarshal(data, &jsonS); err != nil {
 		return err
 	}
 
 	// Build into locals and assign the receiver only on success, so a
-	// mid-parse error never leaves the receiver partially mutated.
+	// mid-parse error never leaves the receiver partially mutated. Credentials
+	// built before a failure are released by this deferred cleanup.
 	var cleanups []func()
-	var dialOptions []grpc.DialOption
-
-	runCleanups := func() {
-		for _, f := range cleanups {
-			f()
+	defer func() {
+		if err != nil {
+			for _, f := range cleanups {
+				f()
+			}
 		}
-	}
+	}()
 
 	var credsDialOption grpc.DialOption
 	var selectedChannelCreds ChannelCreds
@@ -245,7 +246,6 @@ func (a *AllowedGRPCService) UnmarshalJSON(data []byte) error {
 		}
 		bundle, cancel, err := c.Build(cc.Config)
 		if err != nil {
-			runCleanups()
 			return fmt.Errorf("xds: failed to build credentials bundle from bootstrap for allowed grpc service: type %q, err: %v", cc.Type, err)
 		}
 		selectedChannelCreds = cc
@@ -257,10 +257,9 @@ func (a *AllowedGRPCService) UnmarshalJSON(data []byte) error {
 	// If no channel-creds type in the list was supported, credsDialOption is
 	// still nil after the loop; that is a validation error.
 	if credsDialOption == nil {
-		runCleanups()
 		return fmt.Errorf("xds: no supported channel credentials found for allowed grpc service in config:\n%s", string(data))
 	}
-	dialOptions = append(dialOptions, credsDialOption)
+	dialOptions := []grpc.DialOption{credsDialOption}
 
 	for _, cfg := range jsonS.CallCredsConfigs {
 		c := bootstrap.GetCallCredentials(cfg.Type)
@@ -269,7 +268,6 @@ func (a *AllowedGRPCService) UnmarshalJSON(data []byte) error {
 		}
 		callCreds, cancel, err := c.Build(cfg.Config)
 		if err != nil {
-			runCleanups()
 			return fmt.Errorf("xds: failed to build call credentials from bootstrap for allowed grpc service: type %q, err: %v", cfg.Type, err)
 		}
 		dialOptions = append(dialOptions, grpc.WithPerRPCCredentials(callCreds))

--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -120,8 +120,8 @@ func (ccs CallCredsConfigs) String() string {
 	return strings.Join(creds, ",")
 }
 
-// AllowedGrpcService contains credentials config for an allowed gRPC service.
-type AllowedGrpcService struct {
+// AllowedGRPCService contains credentials config for an allowed gRPC service.
+type AllowedGRPCService struct {
 	// targetURI is the fully-qualified side-channel target this entry
 	// applies to. It is the map key under which the service is stored,
 	// copied in during parsing so the service is self-describing.
@@ -144,23 +144,23 @@ type AllowedGrpcService struct {
 }
 
 // TargetURI returns the fully-qualified target URI this service applies to.
-func (a *AllowedGrpcService) TargetURI() string {
+func (a *AllowedGRPCService) TargetURI() string {
 	return a.targetURI
 }
 
 // DialOptions returns the dial options built from this service's selected
 // channel and call credentials, for use when creating the side channel.
-func (a *AllowedGrpcService) DialOptions() []grpc.DialOption {
+func (a *AllowedGRPCService) DialOptions() []grpc.DialOption {
 	return a.dialOptions
 }
 
 // Cleanups returns cleanups to run when the service is no longer needed.
-func (a *AllowedGrpcService) Cleanups() []func() {
+func (a *AllowedGRPCService) Cleanups() []func() {
 	return a.cleanups
 }
 
 // Equal reports whether a and other are considered equal.
-func (a *AllowedGrpcService) Equal(other *AllowedGrpcService) bool {
+func (a *AllowedGRPCService) Equal(other *AllowedGRPCService) bool {
 	if a == nil && other == nil {
 		return true
 	}
@@ -176,14 +176,51 @@ func (a *AllowedGrpcService) Equal(other *AllowedGrpcService) bool {
 	return slices.EqualFunc(a.callCredsConfigs, other.callCredsConfigs, CallCredsConfig.Equal)
 }
 
-type allowedGrpcServiceJSON struct {
+type allowedGRPCServiceJSON struct {
 	ChannelCreds     []ChannelCreds    `json:"channel_creds,omitempty"`
 	CallCredsConfigs []CallCredsConfig `json:"call_creds,omitempty"`
 }
 
+// allowedGRPCServicesEnabled reports whether any feature that consumes the
+// allowed_grpc_services field is enabled. Per gRFC A102 the field has no
+// dedicated env var; it is guarded by the env vars of its consuming features
+// (currently only ext_proc on the client; OR in ext_authz/RLQS guards as
+// those features are implemented).
+func allowedGRPCServicesEnabled() bool {
+	return envconfig.XDSClientExtProcEnabled
+}
+
+// AllowedGRPCServices maps a target URI to the credentials gRPC may use for
+// that side channel when the xDS server that configured it is untrusted
+// (gRFC A102).
+type AllowedGRPCServices map[string]*AllowedGRPCService
+
+// UnmarshalJSON parses and validates the allowed_grpc_services field. The
+// field is parsed only when a consuming feature is enabled, so a disabled
+// feature can neither build credentials nor fail bootstrap.
+func (s *AllowedGRPCServices) UnmarshalJSON(data []byte) error {
+	if !allowedGRPCServicesEnabled() {
+		return nil
+	}
+	services := make(map[string]*AllowedGRPCService)
+	if err := json.Unmarshal(data, &services); err != nil {
+		return err
+	}
+	// A JSON null decodes to a nil entry without calling UnmarshalJSON; reject
+	// it since channel_creds is required, and stamp the target on each service.
+	for target, svc := range services {
+		if svc == nil {
+			return fmt.Errorf("xds: allowed_grpc_services entry %q has no configuration in bootstrap config", target)
+		}
+		svc.targetURI = target
+	}
+	*s = services
+	return nil
+}
+
 // UnmarshalJSON parses the JSON data and validates its credentials.
-func (a *AllowedGrpcService) UnmarshalJSON(data []byte) error {
-	var jsonS allowedGrpcServiceJSON
+func (a *AllowedGRPCService) UnmarshalJSON(data []byte) error {
+	var jsonS allowedGRPCServiceJSON
 	if err := json.Unmarshal(data, &jsonS); err != nil {
 		return err
 	}
@@ -213,9 +250,6 @@ func (a *AllowedGrpcService) UnmarshalJSON(data []byte) error {
 		}
 		selectedChannelCreds = cc
 		credsDialOption = grpc.WithCredentialsBundle(bundle)
-		if d, ok := bundle.(extraDialOptions); ok {
-			dialOptions = append(dialOptions, d.DialOptions()...)
-		}
 		cleanups = append(cleanups, cancel)
 		break
 	}
@@ -229,20 +263,18 @@ func (a *AllowedGrpcService) UnmarshalJSON(data []byte) error {
 	}
 	dialOptions = append(dialOptions, credsDialOption)
 
-	if envconfig.XDSBootstrapCallCredsEnabled {
-		for _, cfg := range jsonS.CallCredsConfigs {
-			c := bootstrap.GetCallCredentials(cfg.Type)
-			if c == nil {
-				continue
-			}
-			callCreds, cancel, err := c.Build(cfg.Config)
-			if err != nil {
-				runCleanups()
-				return fmt.Errorf("xds: failed to build call credentials from bootstrap for allowed grpc service: type %q, err: %v", cfg.Type, err)
-			}
-			dialOptions = append(dialOptions, grpc.WithPerRPCCredentials(callCreds))
-			cleanups = append(cleanups, cancel)
+	for _, cfg := range jsonS.CallCredsConfigs {
+		c := bootstrap.GetCallCredentials(cfg.Type)
+		if c == nil {
+			continue
 		}
+		callCreds, cancel, err := c.Build(cfg.Config)
+		if err != nil {
+			runCleanups()
+			return fmt.Errorf("xds: failed to build call credentials from bootstrap for allowed grpc service: type %q, err: %v", cfg.Type, err)
+		}
+		dialOptions = append(dialOptions, grpc.WithPerRPCCredentials(callCreds))
+		cleanups = append(cleanups, cancel)
 	}
 
 	a.channelCreds = jsonS.ChannelCreds
@@ -254,8 +286,8 @@ func (a *AllowedGrpcService) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalJSON marshals the allowed gRPC service into JSON format.
-func (a *AllowedGrpcService) MarshalJSON() ([]byte, error) {
-	return json.Marshal(allowedGrpcServiceJSON{
+func (a *AllowedGRPCService) MarshalJSON() ([]byte, error) {
+	return json.Marshal(allowedGRPCServiceJSON{
 		ChannelCreds:     a.channelCreds,
 		CallCredsConfigs: a.callCredsConfigs,
 	})
@@ -277,29 +309,11 @@ func (scs *ServerConfigs) Equal(other *ServerConfigs) bool {
 	return true
 }
 
-// releaseServerConfigsCleanups releases the credential cleanups built for each
-// server config in servers, skipping nil entries. It is used to free
-// credentials (bundles, file watchers) eagerly built during unmarshaling when
-// the resulting configuration is discarded.
-func releaseServerConfigsCleanups(servers ServerConfigs) {
-	for _, sc := range servers {
-		if sc == nil {
-			continue
-		}
-		for _, cleanup := range sc.Cleanups() {
-			cleanup()
-		}
-	}
-}
-
 // UnmarshalJSON takes the json data (a list of server configurations) and
 // unmarshals it to the struct.
 func (scs *ServerConfigs) UnmarshalJSON(data []byte) error {
 	servers := []*ServerConfig{}
 	if err := json.Unmarshal(data, &servers); err != nil {
-		// Some servers may have built credentials before the failure;
-		// release them so they don't leak when the slice is dropped.
-		releaseServerConfigsCleanups(servers)
 		return fmt.Errorf("xds: failed to JSON unmarshal server configurations during bootstrap: %v, config:\n%s", err, string(data))
 	}
 	*scs = servers
@@ -621,16 +635,15 @@ type Config struct {
 	// A map from certprovider instance names to parsed buildable configs.
 	certProviderConfigs map[string]*certprovider.BuildableConfig
 
-	// allowedGrpcServices maps a target URI to the
-	// credentials gRPC may use for that side channel when the xDS server
-	// that configured it is untrusted (gRFC A102).
-	allowedGrpcServices map[string]*AllowedGrpcService
+	// allowedGRPCServices is the side-channel allowlist parsed from the
+	// allowed_grpc_services field (gRFC A102).
+	allowedGRPCServices AllowedGRPCServices
 }
 
-// AllowedGrpcServices returns the allowlist of gRPC services.
+// AllowedGRPCServices returns the allowlist of gRPC services.
 // Callers must not modify the returned map.
-func (c *Config) AllowedGrpcServices() map[string]*AllowedGrpcService {
-	return c.allowedGrpcServices
+func (c *Config) AllowedGRPCServices() AllowedGRPCServices {
+	return c.allowedGRPCServices
 }
 
 // XDSServers returns the top-level list of management servers to connect to,
@@ -722,7 +735,7 @@ func (c *Config) Equal(other *Config) bool {
 		return false
 	case !maps.EqualFunc(c.authorities, other.authorities, (*Authority).Equal):
 		return false
-	case !maps.EqualFunc(c.allowedGrpcServices, other.allowedGrpcServices, (*AllowedGrpcService).Equal):
+	case !maps.EqualFunc(c.allowedGRPCServices, other.allowedGRPCServices, (*AllowedGRPCService).Equal):
 		return false
 	case !c.node.Equal(other.node):
 		return false
@@ -744,7 +757,7 @@ type configJSON struct {
 	ClientDefaultListenerResourceNameTemplate string                               `json:"client_default_listener_resource_name_template,omitempty"`
 	Authorities                               map[string]*Authority                `json:"authorities,omitempty"`
 	Node                                      node                                 `json:"node,omitempty"`
-	AllowedGrpcServices                       map[string]*AllowedGrpcService       `json:"allowed_grpc_services,omitempty"`
+	AllowedGRPCServices                       AllowedGRPCServices                  `json:"allowed_grpc_services,omitempty"`
 }
 
 // MarshalJSON returns marshaled JSON bytes corresponding to this config.
@@ -756,7 +769,7 @@ func (c *Config) MarshalJSON() ([]byte, error) {
 		ClientDefaultListenerResourceNameTemplate: c.clientDefaultListenerResourceNameTemplate,
 		Authorities:                               c.authorities,
 		Node:                                      c.node,
-		AllowedGrpcServices:                       c.allowedGrpcServices,
+		AllowedGRPCServices:                       c.allowedGRPCServices,
 	}
 	return json.MarshalIndent(config, " ", " ")
 }
@@ -769,33 +782,11 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 	// will have a node field with client controlled fields alone.
 	config := configJSON{Node: newNode()}
 
-	// json.Unmarshal below eagerly builds credentials (bundles, file
-	// watchers) for server configs (top-level and per-authority) and
-	// allowed gRPC services. Install the cleanup before unmarshaling so
-	// resources built before a mid-way unmarshal failure, or a later
-	// validation error, are released when this Config is discarded.
-	parsedSuccessfully := false
-	defer func() {
-		if parsedSuccessfully {
-			return
-		}
-		releaseServerConfigsCleanups(config.XDSServers)
-		for _, authority := range config.Authorities {
-			if authority == nil {
-				continue
-			}
-			releaseServerConfigsCleanups(authority.XDSServers)
-		}
-		for _, svc := range config.AllowedGrpcServices {
-			if svc == nil {
-				continue
-			}
-			for _, cleanup := range svc.Cleanups() {
-				cleanup()
-			}
-		}
-	}()
-
+	// Credentials (bundles, file watchers) eagerly built during unmarshaling
+	// are intentionally not released if parsing fails below: a failed
+	// bootstrap is parsed once per process (the xDS client pool memoizes
+	// GetConfiguration via sync.OnceValues) and is treated as fatal, so the
+	// leak is bounded and one-time.
 	if err := json.Unmarshal(data, &config); err != nil {
 		return fmt.Errorf("xds: json.Unmarshal(%s) failed during bootstrap: %v", string(data), err)
 	}
@@ -806,16 +797,7 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 	c.clientDefaultListenerResourceNameTemplate = config.ClientDefaultListenerResourceNameTemplate
 	c.authorities = config.Authorities
 	c.node = config.Node
-	c.allowedGrpcServices = config.AllowedGrpcServices
-
-	// A JSON null decodes to a nil entry without calling UnmarshalJSON; reject
-	// it since channel_creds is required, and stamp the target on each service.
-	for target, svc := range c.allowedGrpcServices {
-		if svc == nil {
-			return fmt.Errorf("xds: allowed_grpc_services entry %q has no configuration in bootstrap config", target)
-		}
-		svc.targetURI = target
-	}
+	c.allowedGRPCServices = config.AllowedGRPCServices
 
 	// Build the certificate providers configuration to ensure that it is valid.
 	cpcCfgs := make(map[string]*certprovider.BuildableConfig)
@@ -859,7 +841,6 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("xds: field clientListenerResourceNameTemplate %q of authority %q doesn't start with prefix %q", authority.ClientListenerResourceNameTemplate, name, prefix)
 		}
 	}
-	parsedSuccessfully = true
 	return nil
 }
 
@@ -939,8 +920,8 @@ type ConfigOptionsForTesting struct {
 	// Node identifies the gRPC client/server node in the
 	// proxyless service mesh.
 	Node json.RawMessage
-	// AllowedGrpcServices is the allowlist of gRPC services.
-	AllowedGrpcServices json.RawMessage
+	// AllowedGRPCServices is the allowlist of gRPC services.
+	AllowedGRPCServices json.RawMessage
 }
 
 // NewContentsForTesting creates a new bootstrap configuration from the passed in
@@ -972,15 +953,15 @@ func NewContentsForTesting(opts ConfigOptionsForTesting) ([]byte, error) {
 	if err := json.Unmarshal(opts.Node, &node); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal node configuration %s: %v", string(opts.Node), err)
 	}
-	allowedGrpcServices := make(map[string]*AllowedGrpcService)
-	if len(opts.AllowedGrpcServices) > 0 {
-		if err := json.Unmarshal(opts.AllowedGrpcServices, &allowedGrpcServices); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal allowed grpc services configuration: %v", err)
+	allowedGRPCServices := make(AllowedGRPCServices)
+	if len(opts.AllowedGRPCServices) > 0 {
+		if err := json.Unmarshal(opts.AllowedGRPCServices, &allowedGRPCServices); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal allowed_grpc_services configuration: %v", err)
 		}
 		// Only the parsed config is needed to marshal the bootstrap JSON below;
 		// release the credentials built during unmarshal so this test helper
 		// does not leak file watchers.
-		for _, svc := range allowedGrpcServices {
+		for _, svc := range allowedGRPCServices {
 			if svc == nil {
 				continue
 			}
@@ -996,7 +977,7 @@ func NewContentsForTesting(opts ConfigOptionsForTesting) ([]byte, error) {
 		ClientDefaultListenerResourceNameTemplate: opts.ClientDefaultListenerResourceNameTemplate,
 		Authorities:                               authorities,
 		Node:                                      node,
-		AllowedGrpcServices:                       allowedGrpcServices,
+		AllowedGRPCServices:                       allowedGRPCServices,
 	}
 	contents, err := json.MarshalIndent(cfgJSON, " ", " ")
 	if err != nil {

--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -209,7 +209,7 @@ func (a *AllowedGrpcService) UnmarshalJSON(data []byte) error {
 		bundle, cancel, err := c.Build(cc.Config)
 		if err != nil {
 			runCleanups()
-			return fmt.Errorf("failed to build credentials bundle from bootstrap for allowed grpc service: type %q, err: %v", cc.Type, err)
+			return fmt.Errorf("xds: failed to build credentials bundle from bootstrap for allowed grpc service: type %q, err: %v", cc.Type, err)
 		}
 		selectedChannelCreds = cc
 		credsDialOption = grpc.WithCredentialsBundle(bundle)
@@ -220,6 +220,9 @@ func (a *AllowedGrpcService) UnmarshalJSON(data []byte) error {
 		break
 	}
 
+	// If no channel-creds type in the list was supported, credsDialOption is
+	// still nil after the loop; that is a validation error (mirrors
+	// ServerConfig.UnmarshalJSON).
 	if credsDialOption == nil {
 		runCleanups()
 		return fmt.Errorf("xds: no supported channel credentials found for allowed grpc service in config:\n%s", string(data))
@@ -235,7 +238,7 @@ func (a *AllowedGrpcService) UnmarshalJSON(data []byte) error {
 			callCreds, cancel, err := c.Build(cfg.Config)
 			if err != nil {
 				runCleanups()
-				return fmt.Errorf("failed to build call credentials from bootstrap for allowed grpc service: type %q, err: %v", cfg.Type, err)
+				return fmt.Errorf("xds: failed to build call credentials from bootstrap for allowed grpc service: type %q, err: %v", cfg.Type, err)
 			}
 			dialOptions = append(dialOptions, grpc.WithPerRPCCredentials(callCreds))
 			cleanups = append(cleanups, cancel)
@@ -618,7 +621,7 @@ type Config struct {
 	// A map from certprovider instance names to parsed buildable configs.
 	certProviderConfigs map[string]*certprovider.BuildableConfig
 
-	// allowedGrpcServices maps a fully-qualified target URI to the
+	// allowedGrpcServices maps a target URI to the
 	// credentials gRPC may use for that side channel when the xDS server
 	// that configured it is untrusted (gRFC A102).
 	allowedGrpcServices map[string]*AllowedGrpcService
@@ -805,16 +808,12 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 	c.node = config.Node
 	c.allowedGrpcServices = config.AllowedGrpcServices
 
-	// A null allowed_grpc_services entry (e.g. {"target": null}) is decoded by
-	// encoding/json as a nil value without invoking UnmarshalJSON, which would
-	// bypass the required-channel-creds validation and leave a nil entry that
-	// consumers could dereference. gRFC A102 requires channel_creds on every
-	// entry, so reject nil entries here.
+	// A JSON null decodes to a nil entry without calling UnmarshalJSON; reject
+	// it since channel_creds is required, and stamp the target on each service.
 	for target, svc := range c.allowedGrpcServices {
 		if svc == nil {
 			return fmt.Errorf("xds: allowed_grpc_services entry %q has no configuration in bootstrap config", target)
 		}
-		// Copy the map key into the service so it is self-describing.
 		svc.targetURI = target
 	}
 

--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -255,8 +255,7 @@ func (a *AllowedGRPCService) UnmarshalJSON(data []byte) error {
 	}
 
 	// If no channel-creds type in the list was supported, credsDialOption is
-	// still nil after the loop; that is a validation error (mirrors
-	// ServerConfig.UnmarshalJSON).
+	// still nil after the loop; that is a validation error.
 	if credsDialOption == nil {
 		runCleanups()
 		return fmt.Errorf("xds: no supported channel credentials found for allowed grpc service in config:\n%s", string(data))
@@ -829,9 +828,6 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 	// - if set, it must start with "xdstp://<authority_name>/"
 	// - if not set, it defaults to "xdstp://<authority_name>/envoy.config.listener.v3.Listener/%s"
 	for name, authority := range c.authorities {
-		if authority == nil {
-			return fmt.Errorf("xds: authority %q has no configuration in bootstrap", name)
-		}
 		prefix := fmt.Sprintf("xdstp://%s", url.PathEscape(name))
 		if authority.ClientListenerResourceNameTemplate == "" {
 			authority.ClientListenerResourceNameTemplate = prefix + "/envoy.config.listener.v3.Listener/%s"

--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -274,6 +274,21 @@ func (scs *ServerConfigs) Equal(other *ServerConfigs) bool {
 	return true
 }
 
+// releaseServerConfigsCleanups releases the credential cleanups built for each
+// server config in servers, skipping nil entries. It is used to free
+// credentials (bundles, file watchers) eagerly built during unmarshaling when
+// the resulting configuration is discarded.
+func releaseServerConfigsCleanups(servers ServerConfigs) {
+	for _, sc := range servers {
+		if sc == nil {
+			continue
+		}
+		for _, cleanup := range sc.Cleanups() {
+			cleanup()
+		}
+	}
+}
+
 // UnmarshalJSON takes the json data (a list of server configurations) and
 // unmarshals it to the struct.
 func (scs *ServerConfigs) UnmarshalJSON(data []byte) error {
@@ -281,14 +296,7 @@ func (scs *ServerConfigs) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &servers); err != nil {
 		// Some servers may have built credentials before the failure;
 		// release them so they don't leak when the slice is dropped.
-		for _, sc := range servers {
-			if sc == nil {
-				continue
-			}
-			for _, cleanup := range sc.Cleanups() {
-				cleanup()
-			}
-		}
+		releaseServerConfigsCleanups(servers)
 		return fmt.Errorf("xds: failed to JSON unmarshal server configurations during bootstrap: %v, config:\n%s", err, string(data))
 	}
 	*scs = servers
@@ -764,26 +772,16 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 	// resources built before a mid-way unmarshal failure, or a later
 	// validation error, are released when this Config is discarded.
 	parsedSuccessfully := false
-	releaseServerCreds := func(servers ServerConfigs) {
-		for _, sc := range servers {
-			if sc == nil {
-				continue
-			}
-			for _, cleanup := range sc.Cleanups() {
-				cleanup()
-			}
-		}
-	}
 	defer func() {
 		if parsedSuccessfully {
 			return
 		}
-		releaseServerCreds(config.XDSServers)
+		releaseServerConfigsCleanups(config.XDSServers)
 		for _, authority := range config.Authorities {
 			if authority == nil {
 				continue
 			}
-			releaseServerCreds(authority.XDSServers)
+			releaseServerConfigsCleanups(authority.XDSServers)
 		}
 		for _, svc := range config.AllowedGrpcServices {
 			if svc == nil {

--- a/internal/xds/bootstrap/bootstrap_test.go
+++ b/internal/xds/bootstrap/bootstrap_test.go
@@ -1032,6 +1032,13 @@ func (s) TestGetConfiguration_Federation(t *testing.T) {
 						"server_features" : ["xds_v3"]
 					}]
 				}
+			},
+			"allowed_grpc_services": {
+				"dns:///whitelisted-ext-proc:443": {
+					"channel_creds": [
+						{ "type": "insecure" }
+					]
+				}
 			}
 		}`,
 		// If client_default_listener_resource_name_template is not set, it
@@ -1129,6 +1136,15 @@ func (s) TestGetConfiguration_Federation(t *testing.T) {
 						}},
 					},
 				},
+				allowedGrpcServices: func() map[string]*AllowedGrpcService {
+					var svc AllowedGrpcService
+					if err := json.Unmarshal([]byte(`{"channel_creds": [{"type": "insecure"}]}`), &svc); err != nil {
+						panic(err)
+					}
+					return map[string]*AllowedGrpcService{
+						"dns:///whitelisted-ext-proc:443": &svc,
+					}
+				}(),
 			},
 		},
 		{
@@ -1709,4 +1725,231 @@ func (s) TestBootstrap_SelectedCallCreds_WhenNotCCNotEnabled(t *testing.T) {
 	if len(dialOpts) != 0 {
 		t.Errorf("Call creds count = %d, want %d", len(dialOpts), 0)
 	}
+}
+
+func (s) TestBootstrap_AllowedGrpcServices(t *testing.T) {
+	testutils.SetEnvConfig(t, &envconfig.XDSBootstrapCallCredsEnabled, true)
+	bootstrapFileMap := map[string]string{
+		"allowedGrpcServicesGood": `
+		{
+			"node": {
+				"id": "ENVOY_NODE_ID"
+			},
+			"xds_servers" : [{
+				"server_uri": "trafficdirector.googleapis.com:443",
+				"channel_creds": [
+					{ "type": "insecure" }
+				]
+			}],
+			"allowed_grpc_services": {
+				"dns:///sharding-service:443": {
+					"channel_creds": [
+						{ "type": "insecure" }
+					]
+				}
+			}
+		}`,
+		"allowedGrpcServicesWithCallCreds": `
+		{
+			"node": {
+				"id": "ENVOY_NODE_ID"
+			},
+			"xds_servers" : [{
+				"server_uri": "trafficdirector.googleapis.com:443",
+				"channel_creds": [
+					{ "type": "insecure" }
+				]
+			}],
+			"allowed_grpc_services": {
+				"dns:///sharding-service:443": {
+					"channel_creds": [
+						{ "type": "insecure" }
+					],
+					"call_creds": [
+						{ "type": "jwt_token_file", "config": {"jwt_token_file": "/var/run/secrets/tokens/istio-token"} }
+					]
+				}
+			}
+		}`,
+		"allowedGrpcServicesBadCreds": `
+		{
+			"node": {
+				"id": "ENVOY_NODE_ID"
+			},
+			"xds_servers" : [{
+				"server_uri": "trafficdirector.googleapis.com:443",
+				"channel_creds": [
+					{ "type": "insecure" }
+				]
+			}],
+			"allowed_grpc_services": {
+				"dns:///sharding-service:443": {
+					"channel_creds": [
+						{ "type": "unsupported_cred_type" }
+					]
+				}
+			}
+		}`,
+	}
+	cancel := setupBootstrapOverride(bootstrapFileMap)
+	defer cancel()
+
+	tests := []struct {
+		name                string
+		fileName            string
+		wantErr             bool
+		wantChannelCredType string
+		wantCallCredTypes   []string
+	}{
+		{
+			name:                "good allowed_grpc_services",
+			fileName:            "allowedGrpcServicesGood",
+			wantChannelCredType: "insecure",
+		},
+		{
+			name:                "allowed_grpc_services with call creds",
+			fileName:            "allowedGrpcServicesWithCallCreds",
+			wantChannelCredType: "insecure",
+			wantCallCredTypes:   []string{"jwt_token_file"},
+		},
+		{
+			name:     "bad allowed_grpc_services",
+			fileName: "allowedGrpcServicesBadCreds",
+			wantErr:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			origBootstrapFileName := envconfig.XDSBootstrapFileName
+			envconfig.XDSBootstrapFileName = test.fileName
+			defer func() { envconfig.XDSBootstrapFileName = origBootstrapFileName }()
+
+			cfg, err := GetConfiguration()
+			if err != nil && !test.wantErr {
+				t.Fatalf("GetConfiguration() got unexpected error: %v, want: success", err)
+			}
+			if err == nil && test.wantErr {
+				t.Fatalf("GetConfiguration() got: success, want: error")
+			}
+			if test.wantErr {
+				return
+			}
+			allowed := cfg.AllowedGrpcServices()
+			if len(allowed) != 1 {
+				t.Fatalf("AllowedGrpcServices count got: %d, want: 1", len(allowed))
+			}
+			svc, ok := allowed["dns:///sharding-service:443"]
+			if !ok {
+				t.Fatalf("AllowedGrpcServices missing key \"dns:///sharding-service:443\"")
+			}
+			if got := svc.SelectedChannelCreds().Type; got != test.wantChannelCredType {
+				t.Errorf("SelectedChannelCreds type got: %q, want: %q", got, test.wantChannelCredType)
+			}
+			if len(svc.CallCredsConfigs()) != len(test.wantCallCredTypes) {
+				t.Fatalf("CallCredsConfigs count got: %d, want: %d", len(svc.CallCredsConfigs()), len(test.wantCallCredTypes))
+			}
+			for i, wantType := range test.wantCallCredTypes {
+				if got := svc.CallCredsConfigs()[i].Type; got != wantType {
+					t.Errorf("CallCredsConfig[%d] type got: %q, want: %q", i, got, wantType)
+				}
+			}
+		})
+	}
+}
+
+// TestBootstrap_AllowedGrpcServices_CredentialIteration verifies that the
+// channel-credential selection skips unsupported types and stops at the first
+// supported one, and that call credentials are only built when the call-creds
+// env var is enabled.
+func (s) TestBootstrap_AllowedGrpcServices_CredentialIteration(t *testing.T) {
+	const target = "dns:///sharding-service:443"
+	bootstrapFileMap := map[string]string{
+		// First channel-creds entry is an unsupported type; the supported
+		// "insecure" entry follows and must be selected.
+		"channelCredsIteration": `
+		{
+			"node": { "id": "ENVOY_NODE_ID" },
+			"xds_servers" : [{
+				"server_uri": "trafficdirector.googleapis.com:443",
+				"channel_creds": [{ "type": "insecure" }]
+			}],
+			"allowed_grpc_services": {
+				"dns:///sharding-service:443": {
+					"channel_creds": [
+						{ "type": "unsupported_cred_type" },
+						{ "type": "insecure" }
+					]
+				}
+			}
+		}`,
+		"withCallCreds": `
+		{
+			"node": { "id": "ENVOY_NODE_ID" },
+			"xds_servers" : [{
+				"server_uri": "trafficdirector.googleapis.com:443",
+				"channel_creds": [{ "type": "insecure" }]
+			}],
+			"allowed_grpc_services": {
+				"dns:///sharding-service:443": {
+					"channel_creds": [{ "type": "insecure" }],
+					"call_creds": [
+						{ "type": "jwt_token_file", "config": {"jwt_token_file": "/var/run/secrets/tokens/istio-token"} }
+					]
+				}
+			}
+		}`,
+	}
+	cancel := setupBootstrapOverride(bootstrapFileMap)
+	defer cancel()
+
+	getService := func(t *testing.T) *AllowedGrpcService {
+		t.Helper()
+		cfg, err := GetConfiguration()
+		if err != nil {
+			t.Fatalf("GetConfiguration() failed: %v", err)
+		}
+		svc, ok := cfg.AllowedGrpcServices()[target]
+		if !ok {
+			t.Fatalf("AllowedGrpcServices() missing key %q", target)
+		}
+		return svc
+	}
+
+	t.Run("channel_creds_skips_unsupported", func(t *testing.T) {
+		testutils.SetEnvConfig(t, &envconfig.XDSBootstrapCallCredsEnabled, true)
+		testutils.SetEnvConfig(t, &envconfig.XDSBootstrapFileName, "channelCredsIteration")
+		svc := getService(t)
+		if got := svc.SelectedChannelCreds().Type; got != "insecure" {
+			t.Errorf("SelectedChannelCreds().Type got: %q, want: %q", got, "insecure")
+		}
+		// Only the channel-creds dial option is expected (no call creds).
+		if got := len(svc.DialOptions()); got != 1 {
+			t.Errorf("len(DialOptions()) got: %d, want: 1", got)
+		}
+	})
+
+	t.Run("call_creds_applied_when_enabled", func(t *testing.T) {
+		testutils.SetEnvConfig(t, &envconfig.XDSBootstrapCallCredsEnabled, true)
+		testutils.SetEnvConfig(t, &envconfig.XDSBootstrapFileName, "withCallCreds")
+		svc := getService(t)
+		// One channel-creds dial option plus one per-RPC call-creds option.
+		if got := len(svc.DialOptions()); got != 2 {
+			t.Errorf("len(DialOptions()) got: %d, want: 2", got)
+		}
+	})
+
+	t.Run("call_creds_ignored_when_disabled", func(t *testing.T) {
+		testutils.SetEnvConfig(t, &envconfig.XDSBootstrapCallCredsEnabled, false)
+		testutils.SetEnvConfig(t, &envconfig.XDSBootstrapFileName, "withCallCreds")
+		svc := getService(t)
+		// Call creds must not be built, so only the channel-creds option remains.
+		if got := len(svc.DialOptions()); got != 1 {
+			t.Errorf("len(DialOptions()) got: %d, want: 1", got)
+		}
+		// The parsed call-creds config is still retained for round-tripping.
+		if got := len(svc.CallCredsConfigs()); got != 1 {
+			t.Errorf("len(CallCredsConfigs()) got: %d, want: 1", got)
+		}
+	})
 }

--- a/internal/xds/bootstrap/bootstrap_test.go
+++ b/internal/xds/bootstrap/bootstrap_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/credentials/jwt"
 	"google.golang.org/grpc/credentials/tls/certprovider"
 	"google.golang.org/grpc/internal"
@@ -1952,4 +1953,62 @@ func (s) TestBootstrap_AllowedGrpcServices_CredentialIteration(t *testing.T) {
 			t.Errorf("len(CallCredsConfigs()) got: %d, want: 1", got)
 		}
 	})
+}
+
+// observableChannelCreds is a fake bootstrap channel-credentials builder whose
+// teardown is observable, used to verify cleanup-on-error behavior.
+type observableChannelCreds struct{ onCancel func() }
+
+func (o observableChannelCreds) Build(json.RawMessage) (credentials.Bundle, func(), error) {
+	return insecure.NewBundle(), o.onCancel, nil
+}
+
+func (observableChannelCreds) Name() string { return "test_observable_channel_creds" }
+
+// TestBootstrap_CleanupOnUnmarshalError verifies that credentials built while
+// unmarshaling allowed gRPC services (and server configs) are torn down if
+// bootstrap parsing fails afterwards, rather than leaking.
+func (s) TestBootstrap_CleanupOnUnmarshalError(t *testing.T) {
+	cancels := 0
+	bootstrap.RegisterChannelCredentials(observableChannelCreds{onCancel: func() { cancels++ }})
+
+	// allowed_grpc_services builds the observable creds, then parsing fails
+	// because xds_servers is empty. The built creds must be cleaned up.
+	const failCfg = `{
+		"xds_servers": [],
+		"allowed_grpc_services": {
+			"dns:///side-channel:443": {
+				"channel_creds": [{"type": "test_observable_channel_creds"}]
+			}
+		}
+	}`
+	var failed Config
+	if err := failed.UnmarshalJSON([]byte(failCfg)); err == nil {
+		t.Fatal("Config.UnmarshalJSON() succeeded, want error for empty xds_servers")
+	}
+	if cancels != 1 {
+		t.Errorf("cleanup ran %d times after a failed bootstrap parse, want 1", cancels)
+	}
+
+	// On a successful parse, cleanups are retained for the Config's lifetime
+	// and must NOT run during parsing.
+	cancels = 0
+	const okCfg = `{
+		"xds_servers": [{
+			"server_uri": "trafficdirector.googleapis.com:443",
+			"channel_creds": [{"type": "insecure"}]
+		}],
+		"allowed_grpc_services": {
+			"dns:///side-channel:443": {
+				"channel_creds": [{"type": "test_observable_channel_creds"}]
+			}
+		}
+	}`
+	var ok Config
+	if err := ok.UnmarshalJSON([]byte(okCfg)); err != nil {
+		t.Fatalf("Config.UnmarshalJSON() failed: %v", err)
+	}
+	if cancels != 0 {
+		t.Errorf("cleanup ran %d times on a successful parse, want 0", cancels)
+	}
 }

--- a/internal/xds/bootstrap/bootstrap_test.go
+++ b/internal/xds/bootstrap/bootstrap_test.go
@@ -1944,7 +1944,8 @@ func (s) TestBootstrap_AllowedGrpcServices_CredentialIteration(t *testing.T) {
 		testutils.SetEnvConfig(t, &envconfig.XDSBootstrapCallCredsEnabled, false)
 		testutils.SetEnvConfig(t, &envconfig.XDSBootstrapFileName, "withCallCreds")
 		svc := getService(t)
-		// Call creds must not be built, so only the channel-creds option remains.
+		// Call creds must not be built, so only the channel-creds
+		// option remains.
 		if got := len(svc.DialOptions()); got != 1 {
 			t.Errorf("len(DialOptions()) got: %d, want: 1", got)
 		}
@@ -1966,49 +1967,149 @@ func (o observableChannelCreds) Build(json.RawMessage) (credentials.Bundle, func
 func (observableChannelCreds) Name() string { return "test_observable_channel_creds" }
 
 // TestBootstrap_CleanupOnUnmarshalError verifies that credentials built while
-// unmarshaling allowed gRPC services (and server configs) are torn down if
-// bootstrap parsing fails afterwards, rather than leaking.
+// unmarshaling server configs (top-level and per-authority) and allowed gRPC
+// services are released if bootstrap parsing fails, rather than leaking. It
+// covers failures during later validation, in nested authorities, and mid-way
+// through json.Unmarshal itself.
 func (s) TestBootstrap_CleanupOnUnmarshalError(t *testing.T) {
 	cancels := 0
 	bootstrap.RegisterChannelCredentials(observableChannelCreds{onCancel: func() { cancels++ }})
 
-	// allowed_grpc_services builds the observable creds, then parsing fails
-	// because xds_servers is empty. The built creds must be cleaned up.
-	const failCfg = `{
-		"xds_servers": [],
-		"allowed_grpc_services": {
-			"dns:///side-channel:443": {
-				"channel_creds": [{"type": "test_observable_channel_creds"}]
-			}
-		}
-	}`
-	var failed Config
-	if err := failed.UnmarshalJSON([]byte(failCfg)); err == nil {
-		t.Fatal("Config.UnmarshalJSON() succeeded, want error for empty xds_servers")
-	}
-	if cancels != 1 {
-		t.Errorf("cleanup ran %d times after a failed bootstrap parse, want 1", cancels)
+	tests := []struct {
+		name        string
+		cfg         string
+		wantErr     bool
+		wantCancels int
+	}{
+		{
+			// allowed_grpc_services builds creds, then validation
+			// fails on the empty xds_servers list.
+			name: "validation_error_releases_allowed_service_creds",
+			cfg: `{
+				"xds_servers": [],
+				"allowed_grpc_services": {
+					"dns:///side-channel:443": {
+						"channel_creds": [{"type": "test_observable_channel_creds"}]
+					}
+				}
+			}`,
+			wantErr:     true,
+			wantCancels: 1,
+		},
+		{
+			// A per-authority server builds creds, then validation
+			// fails on the invalid authority listener template.
+			name: "validation_error_releases_authority_server_creds",
+			cfg: `{
+				"xds_servers": [{
+					"server_uri": "trafficdirector.googleapis.com:443",
+					"channel_creds": [{"type": "insecure"}]
+				}],
+				"authorities": {
+					"auth1": {
+						"client_listener_resource_name_template": "invalid-no-prefix",
+						"xds_servers": [{
+							"server_uri": "authority-server:443",
+							"channel_creds": [{"type": "test_observable_channel_creds"}]
+						}]
+					}
+				}
+			}`,
+			wantErr:     true,
+			wantCancels: 1,
+		},
+		{
+			// allowed_grpc_services (decoded first) builds creds,
+			// then json.Unmarshal fails on a malformed field.
+			name: "midway_unmarshal_failure_releases_creds",
+			cfg: `{
+				"allowed_grpc_services": {
+					"dns:///side-channel:443": {
+						"channel_creds": [{"type": "test_observable_channel_creds"}]
+					}
+				},
+				"authorities": "should-be-an-object"
+			}`,
+			wantErr:     true,
+			wantCancels: 1,
+		},
+		{
+			// A later server in the list fails to unmarshal; the
+			// earlier server's built creds must be released.
+			name: "intra_list_server_failure_releases_earlier_creds",
+			cfg: `{
+				"xds_servers": [
+					{"server_uri": "s1:443", "channel_creds": [{"type": "test_observable_channel_creds"}]},
+					{"server_uri": "s2:443", "channel_creds": [{"type": "unsupported_cred_type"}]}
+				]
+			}`,
+			wantErr:     true,
+			wantCancels: 1,
+		},
+		{
+			// Same leak, but inside an authority's server list.
+			name: "intra_authority_server_failure_releases_creds",
+			cfg: `{
+				"xds_servers": [{
+					"server_uri": "trafficdirector.googleapis.com:443",
+					"channel_creds": [{"type": "insecure"}]
+				}],
+				"authorities": {
+					"auth1": {
+						"xds_servers": [
+							{"server_uri": "a1:443", "channel_creds": [{"type": "test_observable_channel_creds"}]},
+							{"server_uri": "a2:443", "channel_creds": [{"type": "unsupported_cred_type"}]}
+						]
+					}
+				}
+			}`,
+			wantErr:     true,
+			wantCancels: 1,
+		},
+		{
+			// A null authority must be rejected, not panic.
+			name: "null_authority_is_rejected_without_panic",
+			cfg: `{
+				"xds_servers": [{
+					"server_uri": "trafficdirector.googleapis.com:443",
+					"channel_creds": [{"type": "insecure"}]
+				}],
+				"authorities": {"foo": null}
+			}`,
+			wantErr:     true,
+			wantCancels: 0,
+		},
+		{
+			// On success, cleanups are retained for the Config's
+			// lifetime and must not run during parsing.
+			name: "success_retains_cleanups",
+			cfg: `{
+				"xds_servers": [{
+					"server_uri": "trafficdirector.googleapis.com:443",
+					"channel_creds": [{"type": "insecure"}]
+				}],
+				"allowed_grpc_services": {
+					"dns:///side-channel:443": {
+						"channel_creds": [{"type": "test_observable_channel_creds"}]
+					}
+				}
+			}`,
+			wantErr:     false,
+			wantCancels: 0,
+		},
 	}
 
-	// On a successful parse, cleanups are retained for the Config's lifetime
-	// and must NOT run during parsing.
-	cancels = 0
-	const okCfg = `{
-		"xds_servers": [{
-			"server_uri": "trafficdirector.googleapis.com:443",
-			"channel_creds": [{"type": "insecure"}]
-		}],
-		"allowed_grpc_services": {
-			"dns:///side-channel:443": {
-				"channel_creds": [{"type": "test_observable_channel_creds"}]
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cancels = 0
+			var c Config
+			err := c.UnmarshalJSON([]byte(test.cfg))
+			if (err != nil) != test.wantErr {
+				t.Fatalf("Config.UnmarshalJSON() error = %v, wantErr %v", err, test.wantErr)
 			}
-		}
-	}`
-	var ok Config
-	if err := ok.UnmarshalJSON([]byte(okCfg)); err != nil {
-		t.Fatalf("Config.UnmarshalJSON() failed: %v", err)
-	}
-	if cancels != 0 {
-		t.Errorf("cleanup ran %d times on a successful parse, want 0", cancels)
+			if cancels != test.wantCancels {
+				t.Errorf("cleanups ran %d times, want %d", cancels, test.wantCancels)
+			}
+		})
 	}
 }

--- a/internal/xds/bootstrap/bootstrap_test.go
+++ b/internal/xds/bootstrap/bootstrap_test.go
@@ -1800,18 +1800,18 @@ func (s) TestBootstrap_AllowedGrpcServices(t *testing.T) {
 		wantCallCredTypes   []string
 	}{
 		{
-			name:                "good allowed_grpc_services",
+			name:                "good_allowed_grpc_services",
 			fileName:            "allowedGrpcServicesGood",
 			wantChannelCredType: "insecure",
 		},
 		{
-			name:                "allowed_grpc_services with call creds",
+			name:                "allowed_grpc_services_with_call_creds",
 			fileName:            "allowedGrpcServicesWithCallCreds",
 			wantChannelCredType: "insecure",
 			wantCallCredTypes:   []string{"jwt_token_file"},
 		},
 		{
-			name:     "bad allowed_grpc_services",
+			name:     "bad_allowed_grpc_services",
 			fileName: "allowedGrpcServicesBadCreds",
 			wantErr:  true,
 		},
@@ -2117,8 +2117,7 @@ func (s) TestBootstrap_CleanupOnUnmarshalError(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			cancels = 0
 			var c Config
-			err := c.UnmarshalJSON([]byte(test.cfg))
-			if (err != nil) != test.wantErr {
+			if err := c.UnmarshalJSON([]byte(test.cfg)); (err != nil) != test.wantErr {
 				t.Fatalf("Config.UnmarshalJSON() error = %v, wantErr %v", err, test.wantErr)
 			}
 			if cancels != test.wantCancels {

--- a/internal/xds/bootstrap/bootstrap_test.go
+++ b/internal/xds/bootstrap/bootstrap_test.go
@@ -1137,15 +1137,12 @@ func (s) TestGetConfiguration_Federation(t *testing.T) {
 						}},
 					},
 				},
-				allowedGrpcServices: func() map[string]*AllowedGrpcService {
-					var svc AllowedGrpcService
-					if err := json.Unmarshal([]byte(`{"channel_creds": [{"type": "insecure"}]}`), &svc); err != nil {
-						panic(err)
-					}
-					return map[string]*AllowedGrpcService{
-						"dns:///whitelisted-ext-proc:443": &svc,
-					}
-				}(),
+				allowedGrpcServices: map[string]*AllowedGrpcService{
+					"dns:///whitelisted-ext-proc:443": {
+						targetURI:    "dns:///whitelisted-ext-proc:443",
+						channelCreds: []ChannelCreds{{Type: "insecure"}},
+					},
+				},
 			},
 		},
 		{
@@ -1844,14 +1841,14 @@ func (s) TestBootstrap_AllowedGrpcServices(t *testing.T) {
 			if !ok {
 				t.Fatalf("AllowedGrpcServices missing key \"dns:///sharding-service:443\"")
 			}
-			if got := svc.SelectedChannelCreds().Type; got != test.wantChannelCredType {
+			if got := svc.selectedChannelCreds.Type; got != test.wantChannelCredType {
 				t.Errorf("SelectedChannelCreds type got: %q, want: %q", got, test.wantChannelCredType)
 			}
-			if len(svc.CallCredsConfigs()) != len(test.wantCallCredTypes) {
-				t.Fatalf("CallCredsConfigs count got: %d, want: %d", len(svc.CallCredsConfigs()), len(test.wantCallCredTypes))
+			if len(svc.callCredsConfigs) != len(test.wantCallCredTypes) {
+				t.Fatalf("CallCredsConfigs count got: %d, want: %d", len(svc.callCredsConfigs), len(test.wantCallCredTypes))
 			}
 			for i, wantType := range test.wantCallCredTypes {
-				if got := svc.CallCredsConfigs()[i].Type; got != wantType {
+				if got := svc.callCredsConfigs[i].Type; got != wantType {
 					t.Errorf("CallCredsConfig[%d] type got: %q, want: %q", i, got, wantType)
 				}
 			}
@@ -1859,16 +1856,49 @@ func (s) TestBootstrap_AllowedGrpcServices(t *testing.T) {
 	}
 }
 
-// TestBootstrap_AllowedGrpcServices_CredentialIteration verifies that the
+// allowedGrpcServiceForTarget parses the bootstrap config and returns the
+// AllowedGrpcService for the given target URI, failing the test if absent.
+func allowedGrpcServiceForTarget(t *testing.T, target string) *AllowedGrpcService {
+	t.Helper()
+	cfg, err := GetConfiguration()
+	if err != nil {
+		t.Fatalf("GetConfiguration() failed: %v", err)
+	}
+	svc, ok := cfg.AllowedGrpcServices()[target]
+	if !ok {
+		t.Fatalf("AllowedGrpcServices() missing key %q", target)
+	}
+	return svc
+}
+
+// allowedGrpcServiceWithCallCreds is a bootstrap config whose allowed gRPC
+// service has both a channel-creds and a call-creds entry.
+const allowedGrpcServiceWithCallCreds = `
+{
+	"node": { "id": "ENVOY_NODE_ID" },
+	"xds_servers" : [{
+		"server_uri": "trafficdirector.googleapis.com:443",
+		"channel_creds": [{ "type": "insecure" }]
+	}],
+	"allowed_grpc_services": {
+		"dns:///sharding-service:443": {
+			"channel_creds": [{ "type": "insecure" }],
+			"call_creds": [
+				{ "type": "jwt_token_file", "config": {"jwt_token_file": "/var/run/secrets/tokens/istio-token"} }
+			]
+		}
+	}
+}`
+
+// TestBootstrap_AllowedGrpcServices_ChannelCredsSkipsUnsupported verifies that
 // channel-credential selection skips unsupported types and stops at the first
-// supported one, and that call credentials are only built when the call-creds
-// env var is enabled.
-func (s) TestBootstrap_AllowedGrpcServices_CredentialIteration(t *testing.T) {
+// supported one.
+func (s) TestBootstrap_AllowedGrpcServices_ChannelCredsSkipsUnsupported(t *testing.T) {
 	const target = "dns:///sharding-service:443"
-	bootstrapFileMap := map[string]string{
+	cancel := setupBootstrapOverride(map[string]string{
 		// First channel-creds entry is an unsupported type; the supported
 		// "insecure" entry follows and must be selected.
-		"channelCredsIteration": `
+		"config": `
 		{
 			"node": { "id": "ENVOY_NODE_ID" },
 			"xds_servers" : [{
@@ -1884,76 +1914,56 @@ func (s) TestBootstrap_AllowedGrpcServices_CredentialIteration(t *testing.T) {
 				}
 			}
 		}`,
-		"withCallCreds": `
-		{
-			"node": { "id": "ENVOY_NODE_ID" },
-			"xds_servers" : [{
-				"server_uri": "trafficdirector.googleapis.com:443",
-				"channel_creds": [{ "type": "insecure" }]
-			}],
-			"allowed_grpc_services": {
-				"dns:///sharding-service:443": {
-					"channel_creds": [{ "type": "insecure" }],
-					"call_creds": [
-						{ "type": "jwt_token_file", "config": {"jwt_token_file": "/var/run/secrets/tokens/istio-token"} }
-					]
-				}
-			}
-		}`,
-	}
-	cancel := setupBootstrapOverride(bootstrapFileMap)
+	})
 	defer cancel()
+	testutils.SetEnvConfig(t, &envconfig.XDSBootstrapFileName, "config")
 
-	getService := func(t *testing.T) *AllowedGrpcService {
-		t.Helper()
-		cfg, err := GetConfiguration()
-		if err != nil {
-			t.Fatalf("GetConfiguration() failed: %v", err)
-		}
-		svc, ok := cfg.AllowedGrpcServices()[target]
-		if !ok {
-			t.Fatalf("AllowedGrpcServices() missing key %q", target)
-		}
-		return svc
+	svc := allowedGrpcServiceForTarget(t, target)
+	if got := svc.selectedChannelCreds.Type; got != "insecure" {
+		t.Errorf("selectedChannelCreds.Type = %q, want %q", got, "insecure")
 	}
+	// Only the channel-creds dial option is expected (no call creds).
+	if got := len(svc.DialOptions()); got != 1 {
+		t.Errorf("len(DialOptions()) = %d, want 1", got)
+	}
+}
 
-	t.Run("channel_creds_skips_unsupported", func(t *testing.T) {
-		testutils.SetEnvConfig(t, &envconfig.XDSBootstrapCallCredsEnabled, true)
-		testutils.SetEnvConfig(t, &envconfig.XDSBootstrapFileName, "channelCredsIteration")
-		svc := getService(t)
-		if got := svc.SelectedChannelCreds().Type; got != "insecure" {
-			t.Errorf("SelectedChannelCreds().Type got: %q, want: %q", got, "insecure")
-		}
-		// Only the channel-creds dial option is expected (no call creds).
-		if got := len(svc.DialOptions()); got != 1 {
-			t.Errorf("len(DialOptions()) got: %d, want: 1", got)
-		}
-	})
+// TestBootstrap_AllowedGrpcServices_CallCredsAppliedWhenEnabled verifies that
+// call credentials are built and added as a dial option when the call-creds
+// env var is enabled.
+func (s) TestBootstrap_AllowedGrpcServices_CallCredsAppliedWhenEnabled(t *testing.T) {
+	const target = "dns:///sharding-service:443"
+	testutils.SetEnvConfig(t, &envconfig.XDSBootstrapCallCredsEnabled, true)
+	cancel := setupBootstrapOverride(map[string]string{"config": allowedGrpcServiceWithCallCreds})
+	defer cancel()
+	testutils.SetEnvConfig(t, &envconfig.XDSBootstrapFileName, "config")
 
-	t.Run("call_creds_applied_when_enabled", func(t *testing.T) {
-		testutils.SetEnvConfig(t, &envconfig.XDSBootstrapCallCredsEnabled, true)
-		testutils.SetEnvConfig(t, &envconfig.XDSBootstrapFileName, "withCallCreds")
-		svc := getService(t)
-		// One channel-creds dial option plus one per-RPC call-creds option.
-		if got := len(svc.DialOptions()); got != 2 {
-			t.Errorf("len(DialOptions()) got: %d, want: 2", got)
-		}
-	})
+	svc := allowedGrpcServiceForTarget(t, target)
+	// One channel-creds dial option plus one per-RPC call-creds option.
+	if got := len(svc.DialOptions()); got != 2 {
+		t.Errorf("len(DialOptions()) = %d, want 2", got)
+	}
+}
 
-	t.Run("call_creds_ignored_when_disabled", func(t *testing.T) {
-		testutils.SetEnvConfig(t, &envconfig.XDSBootstrapCallCredsEnabled, false)
-		testutils.SetEnvConfig(t, &envconfig.XDSBootstrapFileName, "withCallCreds")
-		svc := getService(t)
-		// Call creds must not be built, so only the channel-creds
-		// option remains.
-		if got := len(svc.DialOptions()); got != 1 {
-			t.Errorf("len(DialOptions()) got: %d, want: 1", got)
-		}
-		// The parsed call-creds config is still retained for round-tripping.
-		if got := len(svc.CallCredsConfigs()); got != 1 {
-			t.Errorf("len(CallCredsConfigs()) got: %d, want: 1", got)
-		}
-	})
+// TestBootstrap_AllowedGrpcServices_CallCredsIgnoredWhenDisabled verifies that
+// call credentials are not built when the call-creds env var is disabled, while
+// the parsed config is still retained.
+func (s) TestBootstrap_AllowedGrpcServices_CallCredsIgnoredWhenDisabled(t *testing.T) {
+	const target = "dns:///sharding-service:443"
+	testutils.SetEnvConfig(t, &envconfig.XDSBootstrapCallCredsEnabled, false)
+	cancel := setupBootstrapOverride(map[string]string{"config": allowedGrpcServiceWithCallCreds})
+	defer cancel()
+	testutils.SetEnvConfig(t, &envconfig.XDSBootstrapFileName, "config")
+
+	svc := allowedGrpcServiceForTarget(t, target)
+	// Call creds must not be built, so only the channel-creds option remains.
+	if got := len(svc.DialOptions()); got != 1 {
+		t.Errorf("len(DialOptions()) = %d, want 1", got)
+	}
+	// The parsed call-creds config is still retained for round-tripping.
+	if got := len(svc.callCredsConfigs); got != 1 {
+		t.Errorf("len(callCredsConfigs) = %d, want 1", got)
+	}
 }
 
 // observableChannelCreds is a fake bootstrap channel-credentials builder whose
@@ -1973,6 +1983,10 @@ func (observableChannelCreds) Name() string { return "test_observable_channel_cr
 // through json.Unmarshal itself.
 func (s) TestBootstrap_CleanupOnUnmarshalError(t *testing.T) {
 	cancels := 0
+	// Registers a test-only channel-creds type in the process-global registry
+	// (there is no unregister API). The unique type name avoids colliding with
+	// real credentials, and the shared cancels counter is safe because the
+	// subtests below run sequentially.
 	bootstrap.RegisterChannelCredentials(observableChannelCreds{onCancel: func() { cancels++ }})
 
 	tests := []struct {
@@ -2111,5 +2125,77 @@ func (s) TestBootstrap_CleanupOnUnmarshalError(t *testing.T) {
 				t.Errorf("cleanups ran %d times, want %d", cancels, test.wantCancels)
 			}
 		})
+	}
+}
+
+// TestBootstrap_AllowedGrpcServices_NullEntryRejected verifies that a null
+// allowed_grpc_services entry is rejected rather than silently accepted as a
+// credential-less allowlisted target. gRFC A102 requires channel_creds on
+// every entry, but a JSON null map value is decoded without invoking
+// UnmarshalJSON, so it would otherwise bypass that validation.
+func (s) TestBootstrap_AllowedGrpcServices_NullEntryRejected(t *testing.T) {
+	cfg := `{
+		"xds_servers": [{
+			"server_uri": "trafficdirector.googleapis.com:443",
+			"channel_creds": [{"type": "insecure"}]
+		}],
+		"allowed_grpc_services": {"dns:///side-channel:443": null}
+	}`
+	var c Config
+	if err := c.UnmarshalJSON([]byte(cfg)); err == nil {
+		t.Fatalf("Config.UnmarshalJSON() succeeded; want error for null allowed_grpc_services entry")
+	}
+}
+
+// TestBootstrap_AllowedGrpcService_Accessors exercises TargetURI, MarshalJSON,
+// and Equal, including inequality when only the target URI differs.
+func (s) TestBootstrap_AllowedGrpcService_Accessors(t *testing.T) {
+	testutils.SetEnvConfig(t, &envconfig.XDSBootstrapCallCredsEnabled, true)
+	const target = "dns:///sharding-service:443"
+	cfg := `{
+		"node": { "id": "ENVOY_NODE_ID" },
+		"xds_servers": [{
+			"server_uri": "trafficdirector.googleapis.com:443",
+			"channel_creds": [{ "type": "insecure" }]
+		}],
+		"allowed_grpc_services": {
+			"dns:///sharding-service:443": {
+				"channel_creds": [{ "type": "insecure" }],
+				"call_creds": [
+					{ "type": "jwt_token_file", "config": {"jwt_token_file": "/tmp/token"} }
+				]
+			}
+		}
+	}`
+	var c1, c2 Config
+	if err := c1.UnmarshalJSON([]byte(cfg)); err != nil {
+		t.Fatalf("Config.UnmarshalJSON() failed: %v", err)
+	}
+	if err := c2.UnmarshalJSON([]byte(cfg)); err != nil {
+		t.Fatalf("Config.UnmarshalJSON() failed: %v", err)
+	}
+	svc := c1.AllowedGrpcServices()[target]
+	if svc == nil {
+		t.Fatalf("AllowedGrpcServices() missing %q", target)
+	}
+	if got := svc.TargetURI(); got != target {
+		t.Errorf("TargetURI() = %q, want %q", got, target)
+	}
+
+	// Two independent parses of the same config must compare equal.
+	if !svc.Equal(c2.AllowedGrpcServices()[target]) {
+		t.Errorf("Equal() = false for identical configs, want true")
+	}
+
+	// MarshalJSON must succeed and produce non-empty output.
+	if data, err := c1.MarshalJSON(); err != nil || len(data) == 0 {
+		t.Errorf("MarshalJSON() = (%d bytes, %v), want (non-empty, nil)", len(data), err)
+	}
+
+	// Two services identical except for target URI must not be equal.
+	diff := *svc
+	diff.targetURI = "dns:///different:443"
+	if svc.Equal(&diff) {
+		t.Errorf("Equal() = true for services with different target URIs, want false")
 	}
 }

--- a/internal/xds/bootstrap/bootstrap_test.go
+++ b/internal/xds/bootstrap/bootstrap_test.go
@@ -1769,7 +1769,7 @@ func (s) TestBootstrap_AllowedGrpcServices(t *testing.T) {
 				}
 			}
 		}`,
-		"allowedGrpcServicesBadCreds": `
+		"allowedGrpcServicesTLS": `
 		{
 			"node": {
 				"id": "ENVOY_NODE_ID"
@@ -1783,7 +1783,7 @@ func (s) TestBootstrap_AllowedGrpcServices(t *testing.T) {
 			"allowed_grpc_services": {
 				"dns:///sharding-service:443": {
 					"channel_creds": [
-						{ "type": "unsupported_cred_type" }
+						{ "type": "tls", "config": {} }
 					]
 				}
 			}
@@ -1795,7 +1795,6 @@ func (s) TestBootstrap_AllowedGrpcServices(t *testing.T) {
 	tests := []struct {
 		name                string
 		fileName            string
-		wantErr             bool
 		wantChannelCredType string
 		wantCallCredTypes   []string
 	}{
@@ -1811,9 +1810,9 @@ func (s) TestBootstrap_AllowedGrpcServices(t *testing.T) {
 			wantCallCredTypes:   []string{"jwt_token_file"},
 		},
 		{
-			name:     "bad_allowed_grpc_services",
-			fileName: "allowedGrpcServicesBadCreds",
-			wantErr:  true,
+			name:                "tls_channel_creds",
+			fileName:            "allowedGrpcServicesTLS",
+			wantChannelCredType: "tls",
 		},
 	}
 
@@ -1824,14 +1823,8 @@ func (s) TestBootstrap_AllowedGrpcServices(t *testing.T) {
 			defer func() { envconfig.XDSBootstrapFileName = origBootstrapFileName }()
 
 			cfg, err := GetConfiguration()
-			if err != nil && !test.wantErr {
-				t.Fatalf("GetConfiguration() got unexpected error: %v, want: success", err)
-			}
-			if err == nil && test.wantErr {
-				t.Fatalf("GetConfiguration() got: success, want: error")
-			}
-			if test.wantErr {
-				return
+			if err != nil {
+				t.Fatalf("GetConfiguration() failed: %v", err)
 			}
 			allowed := cfg.AllowedGrpcServices()
 			if len(allowed) != 1 {
@@ -1839,7 +1832,7 @@ func (s) TestBootstrap_AllowedGrpcServices(t *testing.T) {
 			}
 			svc, ok := allowed["dns:///sharding-service:443"]
 			if !ok {
-				t.Fatalf("AllowedGrpcServices missing key \"dns:///sharding-service:443\"")
+				t.Fatalf("AllowedGrpcServices missing key %q", "dns:///sharding-service:443")
 			}
 			if got := svc.selectedChannelCreds.Type; got != test.wantChannelCredType {
 				t.Errorf("SelectedChannelCreds type got: %q, want: %q", got, test.wantChannelCredType)
@@ -1853,6 +1846,31 @@ func (s) TestBootstrap_AllowedGrpcServices(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestBootstrap_AllowedGrpcServices_UnsupportedChannelCreds verifies that a
+// bootstrap fails to load when an allowed_grpc_services entry has no supported
+// channel-creds type.
+func (s) TestBootstrap_AllowedGrpcServices_UnsupportedChannelCreds(t *testing.T) {
+	cfg := `{
+		"node": { "id": "ENVOY_NODE_ID" },
+		"xds_servers": [{
+			"server_uri": "trafficdirector.googleapis.com:443",
+			"channel_creds": [{ "type": "insecure" }]
+		}],
+		"allowed_grpc_services": {
+			"dns:///sharding-service:443": {
+				"channel_creds": [{ "type": "unsupported_cred_type" }]
+			}
+		}
+	}`
+	cancel := setupBootstrapOverride(map[string]string{"config": cfg})
+	defer cancel()
+	testutils.SetEnvConfig(t, &envconfig.XDSBootstrapFileName, "config")
+
+	if _, err := GetConfiguration(); err == nil {
+		t.Fatal("GetConfiguration() succeeded; want error for unsupported channel creds")
 	}
 }
 
@@ -1991,14 +2009,14 @@ func (s) TestBootstrap_CleanupOnUnmarshalError(t *testing.T) {
 
 	tests := []struct {
 		name        string
+		desc        string
 		cfg         string
 		wantErr     bool
 		wantCancels int
 	}{
 		{
-			// allowed_grpc_services builds creds, then validation
-			// fails on the empty xds_servers list.
 			name: "validation_error_releases_allowed_service_creds",
+			desc: "allowed_grpc_services builds creds, then validation fails on the empty xds_servers list",
 			cfg: `{
 				"xds_servers": [],
 				"allowed_grpc_services": {
@@ -2011,9 +2029,8 @@ func (s) TestBootstrap_CleanupOnUnmarshalError(t *testing.T) {
 			wantCancels: 1,
 		},
 		{
-			// A per-authority server builds creds, then validation
-			// fails on the invalid authority listener template.
 			name: "validation_error_releases_authority_server_creds",
+			desc: "a per-authority server builds creds, then validation fails on the invalid authority listener template",
 			cfg: `{
 				"xds_servers": [{
 					"server_uri": "trafficdirector.googleapis.com:443",
@@ -2033,9 +2050,8 @@ func (s) TestBootstrap_CleanupOnUnmarshalError(t *testing.T) {
 			wantCancels: 1,
 		},
 		{
-			// allowed_grpc_services (decoded first) builds creds,
-			// then json.Unmarshal fails on a malformed field.
 			name: "midway_unmarshal_failure_releases_creds",
+			desc: "allowed_grpc_services (decoded first) builds creds, then json.Unmarshal fails on a malformed field",
 			cfg: `{
 				"allowed_grpc_services": {
 					"dns:///side-channel:443": {
@@ -2048,9 +2064,8 @@ func (s) TestBootstrap_CleanupOnUnmarshalError(t *testing.T) {
 			wantCancels: 1,
 		},
 		{
-			// A later server in the list fails to unmarshal; the
-			// earlier server's built creds must be released.
 			name: "intra_list_server_failure_releases_earlier_creds",
+			desc: "a later server in the list fails to unmarshal; the earlier server's built creds must be released",
 			cfg: `{
 				"xds_servers": [
 					{"server_uri": "s1:443", "channel_creds": [{"type": "test_observable_channel_creds"}]},
@@ -2061,8 +2076,8 @@ func (s) TestBootstrap_CleanupOnUnmarshalError(t *testing.T) {
 			wantCancels: 1,
 		},
 		{
-			// Same leak, but inside an authority's server list.
 			name: "intra_authority_server_failure_releases_creds",
+			desc: "same credential release as the intra-list case, but inside an authority's server list",
 			cfg: `{
 				"xds_servers": [{
 					"server_uri": "trafficdirector.googleapis.com:443",
@@ -2081,8 +2096,8 @@ func (s) TestBootstrap_CleanupOnUnmarshalError(t *testing.T) {
 			wantCancels: 1,
 		},
 		{
-			// A null authority must be rejected, not panic.
 			name: "null_authority_is_rejected_without_panic",
+			desc: "a null authority must be rejected, not panic",
 			cfg: `{
 				"xds_servers": [{
 					"server_uri": "trafficdirector.googleapis.com:443",
@@ -2094,9 +2109,8 @@ func (s) TestBootstrap_CleanupOnUnmarshalError(t *testing.T) {
 			wantCancels: 0,
 		},
 		{
-			// On success, cleanups are retained for the Config's
-			// lifetime and must not run during parsing.
 			name: "success_retains_cleanups",
+			desc: "on success, cleanups are retained for the Config's lifetime and must not run during parsing",
 			cfg: `{
 				"xds_servers": [{
 					"server_uri": "trafficdirector.googleapis.com:443",
@@ -2118,10 +2132,10 @@ func (s) TestBootstrap_CleanupOnUnmarshalError(t *testing.T) {
 			cancels = 0
 			var c Config
 			if err := c.UnmarshalJSON([]byte(test.cfg)); (err != nil) != test.wantErr {
-				t.Fatalf("Config.UnmarshalJSON() error = %v, wantErr %v", err, test.wantErr)
+				t.Fatalf("%s: Config.UnmarshalJSON() error = %v, wantErr %v", test.desc, err, test.wantErr)
 			}
 			if cancels != test.wantCancels {
-				t.Errorf("cleanups ran %d times, want %d", cancels, test.wantCancels)
+				t.Errorf("%s: cleanups ran %d times, want %d", test.desc, cancels, test.wantCancels)
 			}
 		})
 	}

--- a/internal/xds/bootstrap/bootstrap_test.go
+++ b/internal/xds/bootstrap/bootstrap_test.go
@@ -1846,23 +1846,6 @@ func (s) TestAllowedGRPCServices_UnmarshalJSON_Errors(t *testing.T) {
 	}
 }
 
-// TestBootstrap_NullAuthorityRejected verifies that a null authority entry in
-// the bootstrap configuration is rejected with an error rather than causing a
-// panic during authority post-processing.
-func (s) TestBootstrap_NullAuthorityRejected(t *testing.T) {
-	cfg := `{
-		"xds_servers": [{
-			"server_uri": "trafficdirector.googleapis.com:443",
-			"channel_creds": [{"type": "insecure"}]
-		}],
-		"authorities": {"foo": null}
-	}`
-	var c Config
-	if err := c.UnmarshalJSON([]byte(cfg)); err == nil {
-		t.Fatal("Config.UnmarshalJSON() succeeded; want error for null authority")
-	}
-}
-
 // TestBootstrap_AllowedGRPCServices_NullEntryRejected verifies that a null
 // allowed_grpc_services entry is rejected rather than silently accepted as a
 // credential-less allowlisted target. gRFC A102 requires channel_creds on

--- a/internal/xds/bootstrap/bootstrap_test.go
+++ b/internal/xds/bootstrap/bootstrap_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/credentials/jwt"
 	"google.golang.org/grpc/credentials/tls/certprovider"
 	"google.golang.org/grpc/internal"
@@ -983,6 +982,7 @@ func (s) TestGetConfiguration_ServerListenerResourceNameTemplate(t *testing.T) {
 }
 
 func (s) TestGetConfiguration_Federation(t *testing.T) {
+	testutils.SetEnvConfig(t, &envconfig.XDSClientExtProcEnabled, true)
 	cancel := setupBootstrapOverride(map[string]string{
 		"badclientListenerResourceNameTemplate": `
 		{
@@ -1038,6 +1038,9 @@ func (s) TestGetConfiguration_Federation(t *testing.T) {
 				"dns:///whitelisted-ext-proc:443": {
 					"channel_creds": [
 						{ "type": "insecure" }
+					],
+					"call_creds": [
+						{ "type": "jwt_token_file", "config": {"jwt_token_file":"/var/run/secrets/tokens/istio-token"} }
 					]
 				}
 			}
@@ -1137,10 +1140,14 @@ func (s) TestGetConfiguration_Federation(t *testing.T) {
 						}},
 					},
 				},
-				allowedGrpcServices: map[string]*AllowedGrpcService{
+				allowedGRPCServices: map[string]*AllowedGRPCService{
 					"dns:///whitelisted-ext-proc:443": {
 						targetURI:    "dns:///whitelisted-ext-proc:443",
 						channelCreds: []ChannelCreds{{Type: "insecure"}},
+						callCredsConfigs: []CallCredsConfig{{
+							Type:   "jwt_token_file",
+							Config: json.RawMessage("{\n\"jwt_token_file\": \"/var/run/secrets/tokens/istio-token\"\n}"),
+						}},
 					},
 				},
 			},
@@ -1725,428 +1732,144 @@ func (s) TestBootstrap_SelectedCallCreds_WhenNotCCNotEnabled(t *testing.T) {
 	}
 }
 
-func (s) TestBootstrap_AllowedGrpcServices(t *testing.T) {
-	testutils.SetEnvConfig(t, &envconfig.XDSBootstrapCallCredsEnabled, true)
-	bootstrapFileMap := map[string]string{
-		"allowedGrpcServicesGood": `
-		{
-			"node": {
-				"id": "ENVOY_NODE_ID"
-			},
-			"xds_servers" : [{
-				"server_uri": "trafficdirector.googleapis.com:443",
-				"channel_creds": [
-					{ "type": "insecure" }
-				]
-			}],
-			"allowed_grpc_services": {
-				"dns:///sharding-service:443": {
-					"channel_creds": [
-						{ "type": "insecure" }
-					]
-				}
-			}
-		}`,
-		"allowedGrpcServicesWithCallCreds": `
-		{
-			"node": {
-				"id": "ENVOY_NODE_ID"
-			},
-			"xds_servers" : [{
-				"server_uri": "trafficdirector.googleapis.com:443",
-				"channel_creds": [
-					{ "type": "insecure" }
-				]
-			}],
-			"allowed_grpc_services": {
-				"dns:///sharding-service:443": {
-					"channel_creds": [
-						{ "type": "insecure" }
-					],
-					"call_creds": [
-						{ "type": "jwt_token_file", "config": {"jwt_token_file": "/var/run/secrets/tokens/istio-token"} }
-					]
-				}
-			}
-		}`,
-		"allowedGrpcServicesTLS": `
-		{
-			"node": {
-				"id": "ENVOY_NODE_ID"
-			},
-			"xds_servers" : [{
-				"server_uri": "trafficdirector.googleapis.com:443",
-				"channel_creds": [
-					{ "type": "insecure" }
-				]
-			}],
-			"allowed_grpc_services": {
-				"dns:///sharding-service:443": {
-					"channel_creds": [
-						{ "type": "tls", "config": {} }
-					]
-				}
-			}
-		}`,
-	}
-	cancel := setupBootstrapOverride(bootstrapFileMap)
-	defer cancel()
-
+// TestAllowedGRPCServices_UnmarshalJSON verifies parsing of the
+// allowed_grpc_services field, operating directly on the AllowedGRPCServices
+// type.
+func (s) TestAllowedGRPCServices_UnmarshalJSON(t *testing.T) {
+	testutils.SetEnvConfig(t, &envconfig.XDSClientExtProcEnabled, true)
+	const target = "dns:///sharding-service:443"
 	tests := []struct {
-		name                string
-		fileName            string
-		wantChannelCredType string
-		wantCallCredTypes   []string
+		name string
+		json string
+		want *AllowedGRPCService
+		// Fields deliberately excluded from Equal: the selected channel
+		// creds and the dial options built from the credentials.
+		wantSelectedChannelCredsType string
+		wantDialOptions              int
 	}{
 		{
-			name:                "good_allowed_grpc_services",
-			fileName:            "allowedGrpcServicesGood",
-			wantChannelCredType: "insecure",
+			name: "insecure_channel_creds",
+			json: `{"dns:///sharding-service:443": {"channel_creds": [{"type": "insecure"}]}}`,
+			want: &AllowedGRPCService{
+				targetURI:    target,
+				channelCreds: []ChannelCreds{{Type: "insecure"}},
+			},
+			wantSelectedChannelCredsType: "insecure",
+			wantDialOptions:              1,
 		},
 		{
-			name:                "allowed_grpc_services_with_call_creds",
-			fileName:            "allowedGrpcServicesWithCallCreds",
-			wantChannelCredType: "insecure",
-			wantCallCredTypes:   []string{"jwt_token_file"},
+			name: "with_call_creds",
+			json: `{"dns:///sharding-service:443": {"channel_creds": [{"type": "insecure"}], "call_creds": [{"type": "jwt_token_file", "config": {"jwt_token_file": "/var/run/secrets/tokens/istio-token"}}]}}`,
+			want: &AllowedGRPCService{
+				targetURI:    target,
+				channelCreds: []ChannelCreds{{Type: "insecure"}},
+				callCredsConfigs: []CallCredsConfig{{
+					Type:   "jwt_token_file",
+					Config: json.RawMessage(`{"jwt_token_file": "/var/run/secrets/tokens/istio-token"}`),
+				}},
+			},
+			wantSelectedChannelCredsType: "insecure",
+			// One channel-creds dial option plus one per-RPC call-creds
+			// option.
+			wantDialOptions: 2,
 		},
 		{
-			name:                "tls_channel_creds",
-			fileName:            "allowedGrpcServicesTLS",
-			wantChannelCredType: "tls",
+			name: "tls_channel_creds",
+			json: `{"dns:///sharding-service:443": {"channel_creds": [{"type": "tls", "config": {}}]}}`,
+			want: &AllowedGRPCService{
+				targetURI:    target,
+				channelCreds: []ChannelCreds{{Type: "tls", Config: json.RawMessage("{}")}},
+			},
+			wantSelectedChannelCredsType: "tls",
+			wantDialOptions:              1,
+		},
+		{
+			name: "skips_unsupported_channel_creds",
+			json: `{"dns:///sharding-service:443": {"channel_creds": [{"type": "unsupported_cred_type"}, {"type": "insecure"}]}}`,
+			want: &AllowedGRPCService{
+				targetURI:    target,
+				channelCreds: []ChannelCreds{{Type: "unsupported_cred_type"}, {Type: "insecure"}},
+			},
+			wantSelectedChannelCredsType: "insecure",
+			wantDialOptions:              1,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			origBootstrapFileName := envconfig.XDSBootstrapFileName
-			envconfig.XDSBootstrapFileName = test.fileName
-			defer func() { envconfig.XDSBootstrapFileName = origBootstrapFileName }()
-
-			cfg, err := GetConfiguration()
-			if err != nil {
-				t.Fatalf("GetConfiguration() failed: %v", err)
+			var got AllowedGRPCServices
+			if err := json.Unmarshal([]byte(test.json), &got); err != nil {
+				t.Fatalf("AllowedGRPCServices unmarshal failed: %v", err)
 			}
-			allowed := cfg.AllowedGrpcServices()
-			if len(allowed) != 1 {
-				t.Fatalf("AllowedGrpcServices count got: %d, want: 1", len(allowed))
-			}
-			svc, ok := allowed["dns:///sharding-service:443"]
+			svc, ok := got[target]
 			if !ok {
-				t.Fatalf("AllowedGrpcServices missing key %q", "dns:///sharding-service:443")
+				t.Fatalf("AllowedGRPCServices missing key %q", target)
 			}
-			if got := svc.selectedChannelCreds.Type; got != test.wantChannelCredType {
-				t.Errorf("SelectedChannelCreds type got: %q, want: %q", got, test.wantChannelCredType)
+			if !svc.Equal(test.want) {
+				t.Errorf("parsed service = %+v, want %+v", svc, test.want)
 			}
-			if len(svc.callCredsConfigs) != len(test.wantCallCredTypes) {
-				t.Fatalf("CallCredsConfigs count got: %d, want: %d", len(svc.callCredsConfigs), len(test.wantCallCredTypes))
+			if got := svc.selectedChannelCreds.Type; got != test.wantSelectedChannelCredsType {
+				t.Errorf("selectedChannelCreds.Type = %q, want %q", got, test.wantSelectedChannelCredsType)
 			}
-			for i, wantType := range test.wantCallCredTypes {
-				if got := svc.callCredsConfigs[i].Type; got != wantType {
-					t.Errorf("CallCredsConfig[%d] type got: %q, want: %q", i, got, wantType)
-				}
+			if got := len(svc.DialOptions()); got != test.wantDialOptions {
+				t.Errorf("len(DialOptions()) = %d, want %d", got, test.wantDialOptions)
 			}
 		})
 	}
 }
 
-// TestBootstrap_AllowedGrpcServices_UnsupportedChannelCreds verifies that a
-// bootstrap fails to load when an allowed_grpc_services entry has no supported
-// channel-creds type.
-func (s) TestBootstrap_AllowedGrpcServices_UnsupportedChannelCreds(t *testing.T) {
+// TestAllowedGRPCServices_UnmarshalJSON_Errors verifies that invalid
+// allowed_grpc_services entries are rejected while parsing the field.
+func (s) TestAllowedGRPCServices_UnmarshalJSON_Errors(t *testing.T) {
+	testutils.SetEnvConfig(t, &envconfig.XDSClientExtProcEnabled, true)
+	tests := []struct {
+		name string
+		json string
+	}{
+		{
+			name: "no_supported_channel_creds",
+			json: `{"dns:///sharding-service:443": {"channel_creds": [{"type": "unsupported_cred_type"}]}}`,
+		},
+		{
+			name: "null_entry",
+			json: `{"dns:///sharding-service:443": null}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var got AllowedGRPCServices
+			if err := json.Unmarshal([]byte(test.json), &got); err == nil {
+				t.Fatalf("AllowedGRPCServices unmarshal succeeded, want error")
+			}
+		})
+	}
+}
+
+// TestBootstrap_NullAuthorityRejected verifies that a null authority entry in
+// the bootstrap configuration is rejected with an error rather than causing a
+// panic during authority post-processing.
+func (s) TestBootstrap_NullAuthorityRejected(t *testing.T) {
 	cfg := `{
-		"node": { "id": "ENVOY_NODE_ID" },
 		"xds_servers": [{
 			"server_uri": "trafficdirector.googleapis.com:443",
-			"channel_creds": [{ "type": "insecure" }]
+			"channel_creds": [{"type": "insecure"}]
 		}],
-		"allowed_grpc_services": {
-			"dns:///sharding-service:443": {
-				"channel_creds": [{ "type": "unsupported_cred_type" }]
-			}
-		}
+		"authorities": {"foo": null}
 	}`
-	cancel := setupBootstrapOverride(map[string]string{"config": cfg})
-	defer cancel()
-	testutils.SetEnvConfig(t, &envconfig.XDSBootstrapFileName, "config")
-
-	if _, err := GetConfiguration(); err == nil {
-		t.Fatal("GetConfiguration() succeeded; want error for unsupported channel creds")
+	var c Config
+	if err := c.UnmarshalJSON([]byte(cfg)); err == nil {
+		t.Fatal("Config.UnmarshalJSON() succeeded; want error for null authority")
 	}
 }
 
-// allowedGrpcServiceForTarget parses the bootstrap config and returns the
-// AllowedGrpcService for the given target URI, failing the test if absent.
-func allowedGrpcServiceForTarget(t *testing.T, target string) *AllowedGrpcService {
-	t.Helper()
-	cfg, err := GetConfiguration()
-	if err != nil {
-		t.Fatalf("GetConfiguration() failed: %v", err)
-	}
-	svc, ok := cfg.AllowedGrpcServices()[target]
-	if !ok {
-		t.Fatalf("AllowedGrpcServices() missing key %q", target)
-	}
-	return svc
-}
-
-// allowedGrpcServiceWithCallCreds is a bootstrap config whose allowed gRPC
-// service has both a channel-creds and a call-creds entry.
-const allowedGrpcServiceWithCallCreds = `
-{
-	"node": { "id": "ENVOY_NODE_ID" },
-	"xds_servers" : [{
-		"server_uri": "trafficdirector.googleapis.com:443",
-		"channel_creds": [{ "type": "insecure" }]
-	}],
-	"allowed_grpc_services": {
-		"dns:///sharding-service:443": {
-			"channel_creds": [{ "type": "insecure" }],
-			"call_creds": [
-				{ "type": "jwt_token_file", "config": {"jwt_token_file": "/var/run/secrets/tokens/istio-token"} }
-			]
-		}
-	}
-}`
-
-// TestBootstrap_AllowedGrpcServices_ChannelCredsSkipsUnsupported verifies that
-// channel-credential selection skips unsupported types and stops at the first
-// supported one.
-func (s) TestBootstrap_AllowedGrpcServices_ChannelCredsSkipsUnsupported(t *testing.T) {
-	const target = "dns:///sharding-service:443"
-	cancel := setupBootstrapOverride(map[string]string{
-		// First channel-creds entry is an unsupported type; the supported
-		// "insecure" entry follows and must be selected.
-		"config": `
-		{
-			"node": { "id": "ENVOY_NODE_ID" },
-			"xds_servers" : [{
-				"server_uri": "trafficdirector.googleapis.com:443",
-				"channel_creds": [{ "type": "insecure" }]
-			}],
-			"allowed_grpc_services": {
-				"dns:///sharding-service:443": {
-					"channel_creds": [
-						{ "type": "unsupported_cred_type" },
-						{ "type": "insecure" }
-					]
-				}
-			}
-		}`,
-	})
-	defer cancel()
-	testutils.SetEnvConfig(t, &envconfig.XDSBootstrapFileName, "config")
-
-	svc := allowedGrpcServiceForTarget(t, target)
-	if got := svc.selectedChannelCreds.Type; got != "insecure" {
-		t.Errorf("selectedChannelCreds.Type = %q, want %q", got, "insecure")
-	}
-	// Only the channel-creds dial option is expected (no call creds).
-	if got := len(svc.DialOptions()); got != 1 {
-		t.Errorf("len(DialOptions()) = %d, want 1", got)
-	}
-}
-
-// TestBootstrap_AllowedGrpcServices_CallCredsAppliedWhenEnabled verifies that
-// call credentials are built and added as a dial option when the call-creds
-// env var is enabled.
-func (s) TestBootstrap_AllowedGrpcServices_CallCredsAppliedWhenEnabled(t *testing.T) {
-	const target = "dns:///sharding-service:443"
-	testutils.SetEnvConfig(t, &envconfig.XDSBootstrapCallCredsEnabled, true)
-	cancel := setupBootstrapOverride(map[string]string{"config": allowedGrpcServiceWithCallCreds})
-	defer cancel()
-	testutils.SetEnvConfig(t, &envconfig.XDSBootstrapFileName, "config")
-
-	svc := allowedGrpcServiceForTarget(t, target)
-	// One channel-creds dial option plus one per-RPC call-creds option.
-	if got := len(svc.DialOptions()); got != 2 {
-		t.Errorf("len(DialOptions()) = %d, want 2", got)
-	}
-}
-
-// TestBootstrap_AllowedGrpcServices_CallCredsIgnoredWhenDisabled verifies that
-// call credentials are not built when the call-creds env var is disabled, while
-// the parsed config is still retained.
-func (s) TestBootstrap_AllowedGrpcServices_CallCredsIgnoredWhenDisabled(t *testing.T) {
-	const target = "dns:///sharding-service:443"
-	testutils.SetEnvConfig(t, &envconfig.XDSBootstrapCallCredsEnabled, false)
-	cancel := setupBootstrapOverride(map[string]string{"config": allowedGrpcServiceWithCallCreds})
-	defer cancel()
-	testutils.SetEnvConfig(t, &envconfig.XDSBootstrapFileName, "config")
-
-	svc := allowedGrpcServiceForTarget(t, target)
-	// Call creds must not be built, so only the channel-creds option remains.
-	if got := len(svc.DialOptions()); got != 1 {
-		t.Errorf("len(DialOptions()) = %d, want 1", got)
-	}
-	// The parsed call-creds config is still kept.
-	if got := len(svc.callCredsConfigs); got != 1 {
-		t.Errorf("len(callCredsConfigs) = %d, want 1", got)
-	}
-}
-
-// observableChannelCreds is a fake bootstrap channel-credentials builder whose
-// teardown is observable, used to verify cleanup-on-error behavior.
-type observableChannelCreds struct{ onCancel func() }
-
-func (o observableChannelCreds) Build(json.RawMessage) (credentials.Bundle, func(), error) {
-	return insecure.NewBundle(), o.onCancel, nil
-}
-
-func (observableChannelCreds) Name() string { return "test_observable_channel_creds" }
-
-// TestBootstrap_CleanupOnUnmarshalError verifies that credentials built while
-// unmarshaling server configs (top-level and per-authority) and allowed gRPC
-// services are released if bootstrap parsing fails, rather than leaking. It
-// covers failures during later validation, in nested authorities, and mid-way
-// through json.Unmarshal itself.
-func (s) TestBootstrap_CleanupOnUnmarshalError(t *testing.T) {
-	cancels := 0
-	// Registers a test-only channel-creds type in the process-global registry
-	// (there is no unregister API). The unique type name avoids colliding with
-	// real credentials, and the shared cancels counter is safe because the
-	// subtests below run sequentially.
-	bootstrap.RegisterChannelCredentials(observableChannelCreds{onCancel: func() { cancels++ }})
-
-	tests := []struct {
-		name        string
-		desc        string
-		cfg         string
-		wantErr     bool
-		wantCancels int
-	}{
-		{
-			name: "validation_error_releases_allowed_service_creds",
-			desc: "allowed_grpc_services builds creds, then validation fails on the empty xds_servers list",
-			cfg: `{
-				"xds_servers": [],
-				"allowed_grpc_services": {
-					"dns:///side-channel:443": {
-						"channel_creds": [{"type": "test_observable_channel_creds"}]
-					}
-				}
-			}`,
-			wantErr:     true,
-			wantCancels: 1,
-		},
-		{
-			name: "validation_error_releases_authority_server_creds",
-			desc: "a per-authority server builds creds, then validation fails on the invalid authority listener template",
-			cfg: `{
-				"xds_servers": [{
-					"server_uri": "trafficdirector.googleapis.com:443",
-					"channel_creds": [{"type": "insecure"}]
-				}],
-				"authorities": {
-					"auth1": {
-						"client_listener_resource_name_template": "invalid-no-prefix",
-						"xds_servers": [{
-							"server_uri": "authority-server:443",
-							"channel_creds": [{"type": "test_observable_channel_creds"}]
-						}]
-					}
-				}
-			}`,
-			wantErr:     true,
-			wantCancels: 1,
-		},
-		{
-			name: "midway_unmarshal_failure_releases_creds",
-			desc: "allowed_grpc_services (decoded first) builds creds, then json.Unmarshal fails on a malformed field",
-			cfg: `{
-				"allowed_grpc_services": {
-					"dns:///side-channel:443": {
-						"channel_creds": [{"type": "test_observable_channel_creds"}]
-					}
-				},
-				"authorities": "should-be-an-object"
-			}`,
-			wantErr:     true,
-			wantCancels: 1,
-		},
-		{
-			name: "intra_list_server_failure_releases_earlier_creds",
-			desc: "a later server in the list fails to unmarshal; the earlier server's built creds must be released",
-			cfg: `{
-				"xds_servers": [
-					{"server_uri": "s1:443", "channel_creds": [{"type": "test_observable_channel_creds"}]},
-					{"server_uri": "s2:443", "channel_creds": [{"type": "unsupported_cred_type"}]}
-				]
-			}`,
-			wantErr:     true,
-			wantCancels: 1,
-		},
-		{
-			name: "intra_authority_server_failure_releases_creds",
-			desc: "same credential release as the intra-list case, but inside an authority's server list",
-			cfg: `{
-				"xds_servers": [{
-					"server_uri": "trafficdirector.googleapis.com:443",
-					"channel_creds": [{"type": "insecure"}]
-				}],
-				"authorities": {
-					"auth1": {
-						"xds_servers": [
-							{"server_uri": "a1:443", "channel_creds": [{"type": "test_observable_channel_creds"}]},
-							{"server_uri": "a2:443", "channel_creds": [{"type": "unsupported_cred_type"}]}
-						]
-					}
-				}
-			}`,
-			wantErr:     true,
-			wantCancels: 1,
-		},
-		{
-			name: "null_authority_is_rejected_without_panic",
-			desc: "a null authority must be rejected, not panic",
-			cfg: `{
-				"xds_servers": [{
-					"server_uri": "trafficdirector.googleapis.com:443",
-					"channel_creds": [{"type": "insecure"}]
-				}],
-				"authorities": {"foo": null}
-			}`,
-			wantErr:     true,
-			wantCancels: 0,
-		},
-		{
-			name: "success_retains_cleanups",
-			desc: "on success, cleanups are retained for the Config's lifetime and must not run during parsing",
-			cfg: `{
-				"xds_servers": [{
-					"server_uri": "trafficdirector.googleapis.com:443",
-					"channel_creds": [{"type": "insecure"}]
-				}],
-				"allowed_grpc_services": {
-					"dns:///side-channel:443": {
-						"channel_creds": [{"type": "test_observable_channel_creds"}]
-					}
-				}
-			}`,
-			wantErr:     false,
-			wantCancels: 0,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			cancels = 0
-			var c Config
-			if err := c.UnmarshalJSON([]byte(test.cfg)); (err != nil) != test.wantErr {
-				t.Fatalf("%s: Config.UnmarshalJSON() error = %v, wantErr %v", test.desc, err, test.wantErr)
-			}
-			if cancels != test.wantCancels {
-				t.Errorf("%s: cleanups ran %d times, want %d", test.desc, cancels, test.wantCancels)
-			}
-		})
-	}
-}
-
-// TestBootstrap_AllowedGrpcServices_NullEntryRejected verifies that a null
+// TestBootstrap_AllowedGRPCServices_NullEntryRejected verifies that a null
 // allowed_grpc_services entry is rejected rather than silently accepted as a
 // credential-less allowlisted target. gRFC A102 requires channel_creds on
 // every entry, but a JSON null map value is decoded without invoking
 // UnmarshalJSON, so it would otherwise bypass that validation.
-func (s) TestBootstrap_AllowedGrpcServices_NullEntryRejected(t *testing.T) {
+func (s) TestBootstrap_AllowedGRPCServices_NullEntryRejected(t *testing.T) {
+	testutils.SetEnvConfig(t, &envconfig.XDSClientExtProcEnabled, true)
 	cfg := `{
 		"xds_servers": [{
 			"server_uri": "trafficdirector.googleapis.com:443",
@@ -2160,55 +1883,46 @@ func (s) TestBootstrap_AllowedGrpcServices_NullEntryRejected(t *testing.T) {
 	}
 }
 
-// TestBootstrap_AllowedGrpcService_Accessors exercises TargetURI, MarshalJSON,
-// and Equal, including inequality when only the target URI differs.
-func (s) TestBootstrap_AllowedGrpcService_Accessors(t *testing.T) {
-	testutils.SetEnvConfig(t, &envconfig.XDSBootstrapCallCredsEnabled, true)
+// TestAllowedGRPCService_Accessors exercises TargetURI and Equal, including
+// inequality when only the target URI differs.
+func (s) TestAllowedGRPCService_Accessors(t *testing.T) {
+	testutils.SetEnvConfig(t, &envconfig.XDSClientExtProcEnabled, true)
 	const target = "dns:///sharding-service:443"
-	cfg := `{
-		"node": { "id": "ENVOY_NODE_ID" },
-		"xds_servers": [{
-			"server_uri": "trafficdirector.googleapis.com:443",
-			"channel_creds": [{ "type": "insecure" }]
-		}],
-		"allowed_grpc_services": {
-			"dns:///sharding-service:443": {
-				"channel_creds": [{ "type": "insecure" }],
-				"call_creds": [
-					{ "type": "jwt_token_file", "config": {"jwt_token_file": "/tmp/token"} }
-				]
-			}
-		}
-	}`
-	var c1, c2 Config
-	if err := c1.UnmarshalJSON([]byte(cfg)); err != nil {
-		t.Fatalf("Config.UnmarshalJSON() failed: %v", err)
+	cfg := `{"dns:///sharding-service:443": {"channel_creds": [{"type": "insecure"}]}}`
+	var s1, s2 AllowedGRPCServices
+	if err := json.Unmarshal([]byte(cfg), &s1); err != nil {
+		t.Fatalf("AllowedGRPCServices unmarshal failed: %v", err)
 	}
-	if err := c2.UnmarshalJSON([]byte(cfg)); err != nil {
-		t.Fatalf("Config.UnmarshalJSON() failed: %v", err)
+	if err := json.Unmarshal([]byte(cfg), &s2); err != nil {
+		t.Fatalf("AllowedGRPCServices unmarshal failed: %v", err)
 	}
-	svc := c1.AllowedGrpcServices()[target]
-	if svc == nil {
-		t.Fatalf("AllowedGrpcServices() missing %q", target)
-	}
+	svc := s1[target]
 	if got := svc.TargetURI(); got != target {
 		t.Errorf("TargetURI() = %q, want %q", got, target)
 	}
-
 	// Two independent parses of the same config must compare equal.
-	if !svc.Equal(c2.AllowedGrpcServices()[target]) {
+	if !svc.Equal(s2[target]) {
 		t.Errorf("Equal() = false for identical configs, want true")
 	}
-
-	// MarshalJSON must succeed and produce non-empty output.
-	if data, err := c1.MarshalJSON(); err != nil || len(data) == 0 {
-		t.Errorf("MarshalJSON() = (%d bytes, %v), want (non-empty, nil)", len(data), err)
-	}
-
 	// Two services identical except for target URI must not be equal.
 	diff := *svc
 	diff.targetURI = "dns:///different:443"
 	if svc.Equal(&diff) {
 		t.Errorf("Equal() = true for services with different target URIs, want false")
+	}
+}
+
+// TestAllowedGRPCServices_Disabled verifies that the allowed_grpc_services
+// field is ignored entirely when no consuming feature is enabled: nothing is
+// parsed, and even a malformed entry does not fail parsing.
+func (s) TestAllowedGRPCServices_Disabled(t *testing.T) {
+	testutils.SetEnvConfig(t, &envconfig.XDSClientExtProcEnabled, false)
+	cfg := `{"dns:///side-channel:443": {"channel_creds": [{"type": "unsupported_cred_type"}]}}`
+	var got AllowedGRPCServices
+	if err := json.Unmarshal([]byte(cfg), &got); err != nil {
+		t.Fatalf("AllowedGRPCServices unmarshal failed: %v", err)
+	}
+	if got != nil {
+		t.Errorf("AllowedGRPCServices = %v, want nil when disabled", got)
 	}
 }

--- a/internal/xds/bootstrap/bootstrap_test.go
+++ b/internal/xds/bootstrap/bootstrap_test.go
@@ -1960,7 +1960,7 @@ func (s) TestBootstrap_AllowedGrpcServices_CallCredsIgnoredWhenDisabled(t *testi
 	if got := len(svc.DialOptions()); got != 1 {
 		t.Errorf("len(DialOptions()) = %d, want 1", got)
 	}
-	// The parsed call-creds config is still retained for round-tripping.
+	// The parsed call-creds config is still kept.
 	if got := len(svc.callCredsConfigs); got != 1 {
 		t.Errorf("len(callCredsConfigs) = %d, want 1", got)
 	}

--- a/internal/xds/bootstrap/bootstrap_test.go
+++ b/internal/xds/bootstrap/bootstrap_test.go
@@ -1774,6 +1774,43 @@ func (s) TestAllowedGRPCServices_UnmarshalJSON(t *testing.T) {
 			wantDialOptions: 2,
 		},
 		{
+			name: "unsupported_call_creds_skipped",
+			json: `{"dns:///sharding-service:443": {"channel_creds": [{"type": "insecure"}], "call_creds": [{"type": "unsupported_call_creds_type"}]}}`,
+			want: &AllowedGRPCService{
+				targetURI:    target,
+				channelCreds: []ChannelCreds{{Type: "insecure"}},
+				callCredsConfigs: []CallCredsConfig{{
+					Type: "unsupported_call_creds_type",
+				}},
+			},
+			wantSelectedChannelCredsType: "insecure",
+			// Unsupported call-creds types are skipped without error, so
+			// only the channel-creds dial option is built.
+			wantDialOptions: 1,
+		},
+		{
+			name: "multiple_supported_call_creds",
+			json: `{"dns:///sharding-service:443": {"channel_creds": [{"type": "insecure"}], "call_creds": [{"type": "jwt_token_file", "config": {"jwt_token_file": "/tokens/token-one"}}, {"type": "jwt_token_file", "config": {"jwt_token_file": "/tokens/token-two"}}]}}`,
+			want: &AllowedGRPCService{
+				targetURI:    target,
+				channelCreds: []ChannelCreds{{Type: "insecure"}},
+				callCredsConfigs: []CallCredsConfig{
+					{
+						Type:   "jwt_token_file",
+						Config: json.RawMessage(`{"jwt_token_file": "/tokens/token-one"}`),
+					},
+					{
+						Type:   "jwt_token_file",
+						Config: json.RawMessage(`{"jwt_token_file": "/tokens/token-two"}`),
+					},
+				},
+			},
+			wantSelectedChannelCredsType: "insecure",
+			// One channel-creds dial option plus one per-RPC option for
+			// each supported call credential.
+			wantDialOptions: 3,
+		},
+		{
 			name: "tls_channel_creds",
 			json: `{"dns:///sharding-service:443": {"channel_creds": [{"type": "tls", "config": {}}]}}`,
 			want: &AllowedGRPCService{


### PR DESCRIPTION
Adds parsing and credential resolution for the allowed_grpc_services bootstrap field (gRFC A102), used to validate side-channel targets received from untrusted xDS servers. Channel credentials stop at the first supported type; call credentials are built only when the call-creds env var is enabled.

This is second of 3 PRs and is independent of other PRs. Can be reviewed in isolation.

RELEASE NOTES: n/a
