### PR TITLE
stats/opentelemetry: populate ai.method in tracing TagRPC when metrics is absent

### DIFF
--- a/stats/opentelemetry/client_tracing.go
+++ b/stats/opentelemetry/client_tracing.go
@@ -130,6 +130,12 @@ func (h *clientTracingHandler) TagRPC(ctx context.Context, info *stats.RPCTagInf
 		logger.Error("context passed into client side stats handler (TagRPC) has no call info")
 		return ctx
 	}
+	// ai.method may already be set by the metrics handler when both metrics and
+	// tracing are enabled. Only populate it here when tracing-only is used so
+	// that traceTagRPC always has a non-empty method to build the span name.
+	if ri.ai.method == "" {
+		ri.ai.method = removeLeadingSlash(info.FullMethodName)
+	}
 	ctx = h.traceTagRPC(ctx, ri.ai, info.NameResolutionDelay)
 	return ctx
 }

--- a/stats/opentelemetry/server_tracing.go
+++ b/stats/opentelemetry/server_tracing.go
@@ -39,8 +39,14 @@ func (h *serverTracingHandler) initializeTraces() {
 }
 
 // TagRPC implements per RPC attempt context management for traces.
-func (h *serverTracingHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+func (h *serverTracingHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
 	ctx, ri := getOrCreateServerRPCInfo(ctx)
+	// ai.method may already be set by the metrics handler when both metrics and
+	// tracing are enabled. Only populate it here when tracing-only is used so
+	// that traceTagRPC always has a non-empty method to build the span name.
+	if ri.ai.method == "" {
+		ri.ai.method = removeLeadingSlash(info.FullMethodName)
+	}
 	ctx, _ = h.traceTagRPC(ctx, ri.ai)
 	return ctx
 }


### PR DESCRIPTION
## Problem

When tracing is enabled without metrics (`TraceOptions` set but no `MetricsOptions`), `ai.method` is never populated.

The `clientMetricsHandler.TagRPC` and `serverMetricsHandler.TagRPC` are the only callers that set `ai.method` on the shared `attemptInfo`. When either handler is absent, `traceTagRPC` constructs span names from an empty string:

```go
// client_tracing.go
mn := "Attempt." + strings.Replace(ai.method, "/", ".", -1)
// => "Attempt."  ← method is missing

// server_tracing.go
mn := "Recv." + strings.Replace(ai.method, "/", ".", -1)
// => "Recv."  ← method is missing
```

In addition, `serverTracingHandler.TagRPC` accepted `_ *stats.RPCTagInfo` (discarding the info entirely), making it impossible to recover the method name even in principle.

Fixes #9097.

## Fix

In both `clientTracingHandler.TagRPC` and `serverTracingHandler.TagRPC`, populate `ri.ai.method` from `info.FullMethodName` when it has not already been set by the metrics handler.

The guard (`ai.method == ""`) preserves the existing behaviour when both metrics and tracing are enabled: the metrics handler runs first (metrics opts are appended before tracing opts in `ClientOption`/`ServerOption`) and may apply `MethodAttributeFilter` or service-registration checks to produce `"other"`. The tracing handler's assignment is then a no-op, keeping the shared field consistent.