### PR TITLE
internal/buffer: make Unbounded buffer use generic type

### DIFF
--- a/balancer/rls/balancer.go
+++ b/balancer/rls/balancer.go
@@ -140,7 +140,7 @@ func (rlsBB) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.
 		lbCfg:              &lbConfig{},
 		pendingMap:         make(map[cacheKey]*backoffState),
 		childPolicies:      make(map[string]*childPolicyWrapper),
-		updateCh:           buffer.NewUnbounded(),
+		updateCh:           buffer.NewUnbounded[any](),
 	}
 	lb.logger = internalgrpclog.NewPrefixLogger(logger, fmt.Sprintf("[rls-experimental-lb %p] ", lb))
 	lb.dataCache = newDataCache(maxCacheSize, lb.logger, opts.Target.String())
@@ -204,7 +204,7 @@ type rlsBalancer struct {
 	inhibitPickerUpdates bool
 
 	// Channel on which all updates are pushed. Processed in run().
-	updateCh *buffer.Unbounded
+	updateCh *buffer.Unbounded[any]
 }
 
 type resumePickerUpdates struct {

--- a/balancer/rls/balancer_test.go
+++ b/balancer/rls/balancer_test.go
@@ -981,7 +981,7 @@ func (s) TestDataCachePurging(t *testing.T) {
 // connectivity state updates to both the delegate and a channel for testing.
 type wrappingConnectivityStateSubscriber struct {
 	delegate    grpcsync.Subscriber
-	connStateCh *buffer.Unbounded
+	connStateCh *buffer.Unbounded[connectivity.State]
 }
 
 func (w *wrappingConnectivityStateSubscriber) OnMessage(msg any) {
@@ -993,19 +993,18 @@ func (w *wrappingConnectivityStateSubscriber) OnMessage(msg any) {
 // to appear on the channel, returning the state that matched first. It skips
 // intermediate states that do not match any of the wanted states, and fails
 // the test if the context expires before any of the desired states are reached.
-func waitForConnectivityState(ctx context.Context, t *testing.T, ch *buffer.Unbounded, wants ...connectivity.State) connectivity.State {
+func waitForConnectivityState(ctx context.Context, t *testing.T, ch *buffer.Unbounded[connectivity.State], wants ...connectivity.State) connectivity.State {
 	t.Helper()
 	for {
 		select {
-		case gotState := <-ch.Get():
+		case gotState, ok := <-ch.Get():
 			ch.Load()
-			if gotState == nil {
+			if !ok {
 				t.Fatalf("Channel closed while waiting for RLS control channel to become one of %v", wants)
 			}
-			got := gotState.(connectivity.State)
 			for _, want := range wants {
-				if got == want {
-					return got
+				if gotState == want {
+					return gotState
 				}
 			}
 		case <-ctx.Done():
@@ -1048,7 +1047,7 @@ func (s) TestControlChannelConnectivityStateMonitoring(t *testing.T) {
 
 	// Override the connectivity state subscriber to wrap the original and
 	// make connectivity state changes visible to the test.
-	wrappedSubscriber := &wrappingConnectivityStateSubscriber{connStateCh: buffer.NewUnbounded()}
+	wrappedSubscriber := &wrappingConnectivityStateSubscriber{connStateCh: buffer.NewUnbounded[connectivity.State]()}
 	origConnectivityStateSubscriber := newConnectivityStateSubscriber
 	newConnectivityStateSubscriber = func(delegate grpcsync.Subscriber) grpcsync.Subscriber {
 		return &wrappingConnectivityStateSubscriber{
@@ -1193,7 +1192,7 @@ func (s) TestControlChannelIdleTransitionNoBackoffReset(t *testing.T) {
 
 	// Override the connectivity state subscriber to wrap the original and
 	// make connectivity state changes visible to the test.
-	wrappedSubscriber := &wrappingConnectivityStateSubscriber{connStateCh: buffer.NewUnbounded()}
+	wrappedSubscriber := &wrappingConnectivityStateSubscriber{connStateCh: buffer.NewUnbounded[connectivity.State]()}
 	origConnectivityStateSubscriber := newConnectivityStateSubscriber
 	newConnectivityStateSubscriber = func(delegate grpcsync.Subscriber) grpcsync.Subscriber {
 		return &wrappingConnectivityStateSubscriber{

--- a/internal/buffer/unbounded.go
+++ b/internal/buffer/unbounded.go
@@ -27,6 +27,10 @@ import (
 // extra goroutines. This is typically used for passing updates from one entity
 // to another within gRPC.
 //
+// To avoid extra memory allocations and type assertions, using any on
+// performance-critical code paths is discouraged. Use concrete types wherever
+// possible when instantiating Unbounded.
+//
 // All methods on this type are thread-safe and don't block on anything except
 // the underlying mutex used for synchronization.
 type Unbounded[T any] struct {

--- a/internal/buffer/unbounded.go
+++ b/internal/buffer/unbounded.go
@@ -29,13 +29,6 @@ import (
 //
 // All methods on this type are thread-safe and don't block on anything except
 // the underlying mutex used for synchronization.
-//
-// Unbounded supports values of any type to be stored in it by using a channel
-// of `any`. This means that a call to Put() incurs an extra memory allocation,
-// and also that users need a type assertion while reading. For performance
-// critical code paths, using Unbounded is strongly discouraged and defining a
-// new type specific implementation of this buffer is preferred. See
-// internal/transport/transport.go for an example of this.
 type Unbounded[T any] struct {
 	c       chan T
 	closed  bool

--- a/internal/buffer/unbounded.go
+++ b/internal/buffer/unbounded.go
@@ -36,23 +36,23 @@ import (
 // critical code paths, using Unbounded is strongly discouraged and defining a
 // new type specific implementation of this buffer is preferred. See
 // internal/transport/transport.go for an example of this.
-type Unbounded struct {
-	c       chan any
+type Unbounded[T any] struct {
+	c       chan T
 	closed  bool
 	closing bool
 	mu      sync.Mutex
-	backlog []any
+	backlog []T
 }
 
 // NewUnbounded returns a new instance of Unbounded.
-func NewUnbounded() *Unbounded {
-	return &Unbounded{c: make(chan any, 1)}
+func NewUnbounded[T any]() *Unbounded[T] {
+	return &Unbounded[T]{c: make(chan T, 1)}
 }
 
 var errBufferClosed = errors.New("Put called on closed buffer.Unbounded")
 
 // Put adds t to the unbounded buffer.
-func (b *Unbounded) Put(t any) error {
+func (b *Unbounded[T]) Put(t T) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.closing {
@@ -72,13 +72,14 @@ func (b *Unbounded) Put(t any) error {
 // Load sends the earliest buffered data, if any, onto the read channel returned
 // by Get(). Users are expected to call this every time they successfully read a
 // value from the read channel.
-func (b *Unbounded) Load() {
+func (b *Unbounded[T]) Load() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if len(b.backlog) > 0 {
 		select {
 		case b.c <- b.backlog[0]:
-			b.backlog[0] = nil
+			var zero T
+			b.backlog[0] = zero
 			b.backlog = b.backlog[1:]
 		default:
 		}
@@ -96,14 +97,14 @@ func (b *Unbounded) Load() {
 //
 // If the unbounded buffer is closed, the read channel returned by this method
 // is closed after all data is drained.
-func (b *Unbounded) Get() <-chan any {
+func (b *Unbounded[T]) Get() <-chan T {
 	return b.c
 }
 
 // Close closes the unbounded buffer. No subsequent data may be Put(), and the
 // channel returned from Get() will be closed after all the data is read and
 // Load() is called for the final time.
-func (b *Unbounded) Close() {
+func (b *Unbounded[T]) Close() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.closing {

--- a/internal/buffer/unbounded_test.go
+++ b/internal/buffer/unbounded_test.go
@@ -54,7 +54,7 @@ func init() {
 // TestSingleWriter starts one reader and one writer goroutine and makes sure
 // that the reader gets all the values added to the buffer by the writer.
 func (s) TestSingleWriter(t *testing.T) {
-	ub := NewUnbounded()
+	ub := NewUnbounded[int]()
 	reads := []int{}
 
 	var wg sync.WaitGroup
@@ -64,7 +64,7 @@ func (s) TestSingleWriter(t *testing.T) {
 		ch := ub.Get()
 		for i := 0; i < numWriters*numWrites; i++ {
 			r := <-ch
-			reads = append(reads, r.(int))
+			reads = append(reads, r)
 			ub.Load()
 		}
 	}()
@@ -88,7 +88,7 @@ func (s) TestSingleWriter(t *testing.T) {
 // TestMultipleWriters starts multiple writers and one reader goroutine and
 // makes sure that the reader gets all the data written by all writers.
 func (s) TestMultipleWriters(t *testing.T) {
-	ub := NewUnbounded()
+	ub := NewUnbounded[int]()
 	reads := []int{}
 
 	var wg sync.WaitGroup
@@ -98,7 +98,7 @@ func (s) TestMultipleWriters(t *testing.T) {
 		ch := ub.Get()
 		for i := 0; i < numWriters*numWrites; i++ {
 			r := <-ch
-			reads = append(reads, r.(int))
+			reads = append(reads, r)
 			ub.Load()
 		}
 	}()
@@ -123,7 +123,7 @@ func (s) TestMultipleWriters(t *testing.T) {
 // TestClose closes the buffer and makes sure that nothing is sent after the
 // buffer is closed.
 func (s) TestClose(t *testing.T) {
-	ub := NewUnbounded()
+	ub := NewUnbounded[int]()
 	if err := ub.Put(1); err != nil {
 		t.Fatalf("Unbounded.Put() = %v; want nil", err)
 	}

--- a/internal/grpcsync/callback_serializer.go
+++ b/internal/grpcsync/callback_serializer.go
@@ -36,7 +36,7 @@ type CallbackSerializer struct {
 	// its resources.
 	done chan struct{}
 
-	callbacks *buffer.Unbounded
+	callbacks *buffer.Unbounded[func(context.Context)]
 }
 
 // NewCallbackSerializer returns a new CallbackSerializer instance. The provided
@@ -47,7 +47,7 @@ type CallbackSerializer struct {
 func NewCallbackSerializer(ctx context.Context) *CallbackSerializer {
 	cs := &CallbackSerializer{
 		done:      make(chan struct{}),
-		callbacks: buffer.NewUnbounded(),
+		callbacks: buffer.NewUnbounded[func(context.Context)](),
 	}
 	go cs.run(ctx)
 	return cs
@@ -87,7 +87,7 @@ func (cs *CallbackSerializer) run(ctx context.Context) {
 	// Run all callbacks.
 	for cb := range cs.callbacks.Get() {
 		cs.callbacks.Load()
-		cb.(func(context.Context))(ctx)
+		cb(ctx)
 	}
 }
 

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -63,10 +63,10 @@ type recvMsg struct {
 
 // recvBuffer is an unbounded channel of recvMsg structs.
 //
-// Note: recvBuffer differs from buffer.Unbounded only in the fact that it
-// holds a channel of recvMsg structs instead of objects implementing "item"
-// interface. recvBuffer is written to much more often and using strict recvMsg
-// structs helps avoid allocation in "recvBuffer.put"
+// Note: recvBuffer differs from buffer.Unbounded in that it provides in-place
+// value initialization (via init) to avoid struct pointer allocations on
+// streams, and automatically frees pooled mem.Buffer payloads when stream
+// errors occur.
 type recvBuffer struct {
 	c       chan recvMsg
 	mu      sync.Mutex

--- a/internal/xds/balancer/outlierdetection/balancer.go
+++ b/internal/xds/balancer/outlierdetection/balancer.go
@@ -83,8 +83,8 @@ func (bb) Build(cc balancer.ClientConn, bOpts balancer.BuildOptions) balancer.Ba
 		closed:          grpcsync.NewEvent(),
 		done:            grpcsync.NewEvent(),
 		addrs:           make(map[string]*endpointInfo),
-		scUpdateCh:      buffer.NewUnbounded(),
-		pickerUpdateCh:  buffer.NewUnbounded(),
+		scUpdateCh:      buffer.NewUnbounded[any](),
+		pickerUpdateCh:  buffer.NewUnbounded[any](),
 		channelzParent:  bOpts.ChannelzParent,
 		endpoints:       resolver.NewEndpointMap[*endpointInfo](),
 		metricsRecorder: cc.MetricsRecorder(), // we use an explicit field instead of using cc.MetricsRecorder() so we can override the metric recorder in tests.
@@ -229,8 +229,8 @@ type outlierDetectionBalancer struct {
 	updateUnconditionally bool
 	numEndpointsEjected   int // For fast calculations of percentage of endpoints ejected
 
-	scUpdateCh     *buffer.Unbounded
-	pickerUpdateCh *buffer.Unbounded
+	scUpdateCh     *buffer.Unbounded[any]
+	pickerUpdateCh *buffer.Unbounded[any]
 }
 
 // noopConfig returns whether this balancer is configured with a logical no-op

--- a/internal/xds/balancer/outlierdetection/subconn_wrapper.go
+++ b/internal/xds/balancer/outlierdetection/subconn_wrapper.go
@@ -40,7 +40,7 @@ type subConnWrapper struct {
 
 	listener func(balancer.SubConnState)
 
-	scUpdateCh *buffer.Unbounded
+	scUpdateCh *buffer.Unbounded[any]
 
 	// The following fields are only referenced in the context of a work
 	// serializing buffer and don't need to be protected by a mutex.

--- a/internal/xds/balancer/priority/balancer.go
+++ b/internal/xds/balancer/priority/balancer.go
@@ -61,7 +61,7 @@ func (bb) Build(cc balancer.ClientConn, bOpts balancer.BuildOptions) balancer.Ba
 		cc:                       cc,
 		done:                     grpcsync.NewEvent(),
 		children:                 make(map[string]*childBalancer),
-		childBalancerStateUpdate: buffer.NewUnbounded(),
+		childBalancerStateUpdate: buffer.NewUnbounded[any](),
 	}
 
 	b.logger = prefixLogger(b)
@@ -97,7 +97,7 @@ type priorityBalancer struct {
 	cc                       balancer.ClientConn
 	bg                       *balancergroup.BalancerGroup
 	done                     *grpcsync.Event
-	childBalancerStateUpdate *buffer.Unbounded
+	childBalancerStateUpdate *buffer.Unbounded[any]
 
 	mu         sync.Mutex
 	childInUse string

--- a/internal/xds/clients/internal/buffer/unbounded.go
+++ b/internal/xds/clients/internal/buffer/unbounded.go
@@ -27,6 +27,10 @@ import (
 // extra goroutines. This is typically used for passing updates from one entity
 // to another within gRPC.
 //
+// To avoid extra memory allocations and type assertions, using any on
+// performance-critical code paths is discouraged. Use concrete types wherever
+// possible when instantiating Unbounded.
+//
 // All methods on this type are thread-safe and don't block on anything except
 // the underlying mutex used for synchronization.
 type Unbounded[T any] struct {

--- a/internal/xds/clients/internal/buffer/unbounded.go
+++ b/internal/xds/clients/internal/buffer/unbounded.go
@@ -29,13 +29,6 @@ import (
 //
 // All methods on this type are thread-safe and don't block on anything except
 // the underlying mutex used for synchronization.
-//
-// Unbounded supports values of any type to be stored in it by using a channel
-// of `any`. This means that a call to Put() incurs an extra memory allocation,
-// and also that users need a type assertion while reading. For performance
-// critical code paths, using Unbounded is strongly discouraged and defining a
-// new type specific implementation of this buffer is preferred. See
-// internal/transport/transport.go for an example of this.
 type Unbounded[T any] struct {
 	c       chan T
 	closed  bool

--- a/internal/xds/clients/internal/buffer/unbounded.go
+++ b/internal/xds/clients/internal/buffer/unbounded.go
@@ -36,23 +36,23 @@ import (
 // critical code paths, using Unbounded is strongly discouraged and defining a
 // new type specific implementation of this buffer is preferred. See
 // internal/transport/transport.go for an example of this.
-type Unbounded struct {
-	c       chan any
+type Unbounded[T any] struct {
+	c       chan T
 	closed  bool
 	closing bool
 	mu      sync.Mutex
-	backlog []any
+	backlog []T
 }
 
 // NewUnbounded returns a new instance of Unbounded.
-func NewUnbounded() *Unbounded {
-	return &Unbounded{c: make(chan any, 1)}
+func NewUnbounded[T any]() *Unbounded[T] {
+	return &Unbounded[T]{c: make(chan T, 1)}
 }
 
 var errBufferClosed = errors.New("Put() called on closed buffer.Unbounded")
 
 // Put adds t to the unbounded buffer.
-func (b *Unbounded) Put(t any) error {
+func (b *Unbounded[T]) Put(t T) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.closing {
@@ -72,13 +72,14 @@ func (b *Unbounded) Put(t any) error {
 // Load sends the earliest buffered data, if any, onto the read channel returned
 // by Get(). Users are expected to call this every time they successfully read a
 // value from the read channel.
-func (b *Unbounded) Load() {
+func (b *Unbounded[T]) Load() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if len(b.backlog) > 0 {
 		select {
 		case b.c <- b.backlog[0]:
-			b.backlog[0] = nil
+			var zero T
+			b.backlog[0] = zero
 			b.backlog = b.backlog[1:]
 		default:
 		}
@@ -96,14 +97,14 @@ func (b *Unbounded) Load() {
 //
 // If the unbounded buffer is closed, the read channel returned by this method
 // is closed after all data is drained.
-func (b *Unbounded) Get() <-chan any {
+func (b *Unbounded[T]) Get() <-chan T {
 	return b.c
 }
 
 // Close closes the unbounded buffer. No subsequent data may be Put(), and the
 // channel returned from Get() will be closed after all the data is read and
 // Load() is called for the final time.
-func (b *Unbounded) Close() {
+func (b *Unbounded[T]) Close() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.closing {

--- a/internal/xds/clients/internal/buffer/unbounded_test.go
+++ b/internal/xds/clients/internal/buffer/unbounded_test.go
@@ -54,7 +54,7 @@ func init() {
 // TestSingleWriter starts one reader and one writer goroutine and makes sure
 // that the reader gets all the values added to the buffer by the writer.
 func (s) TestSingleWriter(t *testing.T) {
-	ub := NewUnbounded()
+	ub := NewUnbounded[int]()
 	reads := []int{}
 
 	var wg sync.WaitGroup
@@ -64,7 +64,7 @@ func (s) TestSingleWriter(t *testing.T) {
 		ch := ub.Get()
 		for i := 0; i < numWriters*numWrites; i++ {
 			r := <-ch
-			reads = append(reads, r.(int))
+			reads = append(reads, r)
 			ub.Load()
 		}
 	}()
@@ -88,7 +88,7 @@ func (s) TestSingleWriter(t *testing.T) {
 // TestMultipleWriters starts multiple writers and one reader goroutine and
 // makes sure that the reader gets all the data written by all writers.
 func (s) TestMultipleWriters(t *testing.T) {
-	ub := NewUnbounded()
+	ub := NewUnbounded[int]()
 	reads := []int{}
 
 	var wg sync.WaitGroup
@@ -98,7 +98,7 @@ func (s) TestMultipleWriters(t *testing.T) {
 		ch := ub.Get()
 		for i := 0; i < numWriters*numWrites; i++ {
 			r := <-ch
-			reads = append(reads, r.(int))
+			reads = append(reads, r)
 			ub.Load()
 		}
 	}()
@@ -123,7 +123,7 @@ func (s) TestMultipleWriters(t *testing.T) {
 // TestClose closes the buffer and makes sure that nothing is sent after the
 // buffer is closed.
 func (s) TestClose(t *testing.T) {
-	ub := NewUnbounded()
+	ub := NewUnbounded[int]()
 	if err := ub.Put(1); err != nil {
 		t.Fatalf("Unbounded.Put() = %v; want nil", err)
 	}

--- a/internal/xds/clients/internal/syncutil/callback_serializer.go
+++ b/internal/xds/clients/internal/syncutil/callback_serializer.go
@@ -36,7 +36,7 @@ type CallbackSerializer struct {
 	// its resources.
 	done chan struct{}
 
-	callbacks *buffer.Unbounded
+	callbacks *buffer.Unbounded[func(context.Context)]
 }
 
 // NewCallbackSerializer returns a new CallbackSerializer instance. The provided
@@ -47,7 +47,7 @@ type CallbackSerializer struct {
 func NewCallbackSerializer(ctx context.Context) *CallbackSerializer {
 	cs := &CallbackSerializer{
 		done:      make(chan struct{}),
-		callbacks: buffer.NewUnbounded(),
+		callbacks: buffer.NewUnbounded[func(context.Context)](),
 	}
 	go cs.run(ctx)
 	return cs
@@ -87,7 +87,7 @@ func (cs *CallbackSerializer) run(ctx context.Context) {
 	// Run all callbacks.
 	for cb := range cs.callbacks.Get() {
 		cs.callbacks.Load()
-		cb.(func(context.Context))(ctx)
+		cb(ctx)
 	}
 }
 

--- a/internal/xds/clients/xdsclient/test/helpers_test.go
+++ b/internal/xds/clients/xdsclient/test/helpers_test.go
@@ -280,7 +280,7 @@ func buildResourceName(typeName, auth, id string, ctxParams map[string]string) s
 // recording events on channels and provides helpers to check if certain events
 // have taken place.
 type testMetricsReporter struct {
-	metricsCh *buffer.Unbounded
+	metricsCh *buffer.Unbounded[any]
 
 	mu             sync.Mutex
 	asyncReporters map[clients.AsyncReporter]struct{}
@@ -289,7 +289,7 @@ type testMetricsReporter struct {
 // newTestMetricsReporter returns a new testMetricsReporter.
 func newTestMetricsReporter() *testMetricsReporter {
 	return &testMetricsReporter{
-		metricsCh:      buffer.NewUnbounded(),
+		metricsCh:      buffer.NewUnbounded[any](),
 		asyncReporters: make(map[clients.AsyncReporter]struct{}),
 	}
 }


### PR DESCRIPTION
Refactors internal/buffer.Unbounded (and its clone under internal/xds/clients) to use generics ([T any]) instead of any. This improves type safety and removes type assertions across consumers.

RELEASE NOTES: None
