### PR TITLE
credentials/alts: fix alts record ensures the frame size is bigger than the message type field size

### DIFF
--- a/credentials/alts/internal/conn/record.go
+++ b/credentials/alts/internal/conn/record.go
@@ -257,6 +257,9 @@ func (p *conn) ReadOnReady(bufSize int, pool mem.BufferPool) (*[]byte, int, erro
 		}
 		// Now we have a complete frame, decrypted it.
 		msg := framedMsg[MsgLenFieldSize:]
+		if len(msg) < msgTypeFieldSize {
+			return nil, 0, fmt.Errorf("received frame with size %v which is shorter than message type field size %v", len(msg), msgTypeFieldSize)
+		}
 		msgType := binary.LittleEndian.Uint32(msg[:msgTypeFieldSize])
 		if msgType&0xff != altsRecordMsgType {
 			return nil, 0, fmt.Errorf("received frame with incorrect message type %v, expected lower byte %v",

--- a/credentials/alts/internal/conn/record_test.go
+++ b/credentials/alts/internal/conn/record_test.go
@@ -421,3 +421,29 @@ func (c *noopConn) Write(b []byte) (n int, err error) {
 func (c *noopConn) Close() error {
 	return nil
 }
+
+func (s) TestParseFramedMsgVulnerability(t *testing.T) {
+	key := []byte{
+		0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0xe2, 0xd2, 0x4c, 0xce, 0x4f, 0x49}
+	tc := testConn{
+		in:  new(bytes.Buffer),
+		out: new(bytes.Buffer),
+	}
+	// We pass a protected buffer representing a framed message length of 0,
+	// followed by bytes that will act as a dirty buffer capacity. If the capacity
+	// bytes happen to start with `0x06` (altsRecordMsgType), the vulnerable
+	// code will try to slice `msg[4:]` which panics because len(msg) is 0.
+	malformedProtected := []byte{0x00, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00}
+	c, err := NewConn(&tc, core.ServerSide, rekeyRecordProtocol, key, malformedProtected)
+	if err != nil {
+		t.Fatalf("NewConn failed: %v", err)
+	}
+	buf := make([]byte, 1024)
+	_, err = c.Read(buf)
+	if err == nil {
+		t.Fatal("c.Read(buf) succeeded, but expected a parsing error")
+	}
+	if !strings.Contains(err.Error(), "shorter than message type field size") && !strings.Contains(err.Error(), "incorrect message type") {
+		t.Fatalf("c.Read(buf) returned unexpected error: %v", err)
+	}
+}

--- a/credentials/alts/internal/conn/record_test.go
+++ b/credentials/alts/internal/conn/record_test.go
@@ -423,8 +423,7 @@ func (c *noopConn) Close() error {
 }
 
 func (s) TestParseFramedMsgVulnerability(t *testing.T) {
-	key := []byte{
-		0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0xe2, 0xd2, 0x4c, 0xce, 0x4f, 0x49}
+	key := []byte{0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0xe2, 0xd2, 0x4c, 0xce, 0x4f, 0x49}
 	tc := testConn{
 		in:  new(bytes.Buffer),
 		out: new(bytes.Buffer),
@@ -443,7 +442,7 @@ func (s) TestParseFramedMsgVulnerability(t *testing.T) {
 	if err == nil {
 		t.Fatal("c.Read(buf) succeeded, but expected a parsing error")
 	}
-	if !strings.Contains(err.Error(), "shorter than message type field size") && !strings.Contains(err.Error(), "incorrect message type") {
+	if !strings.Contains(err.Error(), "shorter than message type field size") {
 		t.Fatalf("c.Read(buf) returned unexpected error: %v", err)
 	}
 }

--- a/credentials/alts/internal/conn/record_test.go
+++ b/credentials/alts/internal/conn/record_test.go
@@ -440,6 +440,6 @@ func (s) TestParseFramedMsgVulnerability(t *testing.T) {
 	buf := make([]byte, 1024)
 	const wantErr = "shorter than message type field size"
 	if _, err := c.Read(buf); err == nil || !strings.Contains(err.Error(), wantErr) {
-		t.Fatal("c.Read(buf) returned error: %v, want error containing %q", err, wantErr)
+		t.Fatalf("c.Read(buf) returned error: %v, want error containing %q", err, wantErr)
 	}
 }

--- a/credentials/alts/internal/conn/record_test.go
+++ b/credentials/alts/internal/conn/record_test.go
@@ -438,11 +438,8 @@ func (s) TestParseFramedMsgVulnerability(t *testing.T) {
 		t.Fatalf("NewConn failed: %v", err)
 	}
 	buf := make([]byte, 1024)
-	_, err = c.Read(buf)
-	if err == nil {
-		t.Fatal("c.Read(buf) succeeded, but expected a parsing error")
-	}
-	if !strings.Contains(err.Error(), "shorter than message type field size") {
-		t.Fatalf("c.Read(buf) returned unexpected error: %v", err)
+	const wantErr = "shorter than message type field size"
+	if _, err := c.Read(buf); err == nil || !strings.Contains(err.Error(), wantErr) {
+		t.Fatal("c.Read(buf) returned error: %v, want error containing %q", err, wantErr)
 	}
 }


### PR DESCRIPTION
RELEASE NOTES: 
* credentials/alts/internal/conn: ALTS record protocol correctly checks the length of the message frame to ensure it's bigger than the message type field size.