### PR TITLE
internal/transport: validate per-RPC credential metadata

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -691,6 +691,9 @@ func (t *http2Client) getTrAuthData(ctx context.Context, audience string) (map[s
 		for k, v := range data {
 			// Capital header names are illegal in HTTP/2.
 			k = strings.ToLower(k)
+			if err := imetadata.ValidatePair(k, v); err != nil {
+				return nil, status.Error(codes.Internal, err.Error())
+			}
 			authData[k] = v
 		}
 	}
@@ -724,6 +727,9 @@ func (t *http2Client) getCallAuthData(ctx context.Context, audience string, call
 		for k, v := range data {
 			// Capital header names are illegal in HTTP/2
 			k = strings.ToLower(k)
+			if err := imetadata.ValidatePair(k, v); err != nil {
+				return nil, status.Error(codes.Internal, err.Error())
+			}
 			callAuthData[k] = v
 		}
 	}

--- a/test/creds_test.go
+++ b/test/creds_test.go
@@ -408,6 +408,85 @@ func testPerRPCCredentialsViaDialOptionsAndCallOptions(t *testing.T, e env) {
 	}
 }
 
+func (s) TestPerRPCCredentialMetadataValidationRejectsInvalidDialOptions(t *testing.T) {
+	for _, e := range listTestEnv() {
+		for _, test := range []struct {
+			name     string
+			authdata map[string]string
+			wantErr  string
+		}{
+			{
+				name:     "invalid key",
+				authdata: map[string]string{"bad key": "value"},
+				wantErr:  `header key "bad key" contains illegal characters not in [0-9a-z-_.]`,
+			},
+			{
+				name:     "invalid value",
+				authdata: map[string]string{"valid-key": "bad\x01value"},
+				wantErr:  `header key "valid-key" contains value with non-printable ASCII characters`,
+			},
+		} {
+			t.Run(e.name+"/"+test.name, func(t *testing.T) {
+				testPerRPCCredentialMetadataValidationRejectsInvalidDialOptions(t, e, test.authdata, test.wantErr)
+			})
+		}
+	}
+}
+
+func testPerRPCCredentialMetadataValidationRejectsInvalidDialOptions(t *testing.T, e env, authdata map[string]string, wantErr string) {
+	te := newTest(t, e)
+	te.perRPCCreds = testPerRPCCredentials{authdata: authdata}
+	te.startServer(&testServer{security: e.security})
+	defer te.tearDown()
+
+	cc := te.clientConn()
+	tc := testgrpc.NewTestServiceClient(cc)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}); status.Code(err) != codes.Internal || !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("EmptyCall() error = %v, want code %v and message containing %q", err, codes.Internal, wantErr)
+	}
+}
+
+func (s) TestPerRPCCredentialMetadataValidationRejectsInvalidCallOptions(t *testing.T) {
+	for _, e := range listTestEnv() {
+		for _, test := range []struct {
+			name     string
+			authdata map[string]string
+			wantErr  string
+		}{
+			{
+				name:     "invalid key",
+				authdata: map[string]string{"bad key": "value"},
+				wantErr:  `header key "bad key" contains illegal characters not in [0-9a-z-_.]`,
+			},
+			{
+				name:     "invalid value",
+				authdata: map[string]string{"valid-key": "bad\x01value"},
+				wantErr:  `header key "valid-key" contains value with non-printable ASCII characters`,
+			},
+		} {
+			t.Run(e.name+"/"+test.name, func(t *testing.T) {
+				testPerRPCCredentialMetadataValidationRejectsInvalidCallOptions(t, e, test.authdata, test.wantErr)
+			})
+		}
+	}
+}
+
+func testPerRPCCredentialMetadataValidationRejectsInvalidCallOptions(t *testing.T, e env, authdata map[string]string, wantErr string) {
+	te := newTest(t, e)
+	te.startServer(&testServer{security: e.security})
+	defer te.tearDown()
+
+	cc := te.clientConn()
+	tc := testgrpc.NewTestServiceClient(cc)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}, grpc.PerRPCCredentials(testPerRPCCredentials{authdata: authdata})); status.Code(err) != codes.Internal || !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("EmptyCall() error = %v, want code %v and message containing %q", err, codes.Internal, wantErr)
+	}
+}
+
 const testAuthority = "test.auth.ori.ty"
 
 type authorityCheckCreds struct {

--- a/test/creds_test.go
+++ b/test/creds_test.go
@@ -418,12 +418,12 @@ func (s) TestPerRPCCredentialMetadataValidationRejectsInvalidDialOptions(t *test
 			{
 				name:     "invalid key",
 				authdata: map[string]string{"bad key": "value"},
-				wantErr:  `header key "bad key" contains illegal characters not in [0-9a-z-_.]`,
+				wantErr:  fmt.Sprintf("header key %q contains illegal characters not in [0-9a-z-_.]", "bad key"),
 			},
 			{
 				name:     "invalid value",
 				authdata: map[string]string{"valid-key": "bad\x01value"},
-				wantErr:  `header key "valid-key" contains value with non-printable ASCII characters`,
+				wantErr:  fmt.Sprintf("header key %q contains value with non-printable ASCII characters", "valid-key"),
 			},
 		} {
 			t.Run(e.name+"/"+test.name, func(t *testing.T) {
@@ -458,12 +458,12 @@ func (s) TestPerRPCCredentialMetadataValidationRejectsInvalidCallOptions(t *test
 			{
 				name:     "invalid key",
 				authdata: map[string]string{"bad key": "value"},
-				wantErr:  `header key "bad key" contains illegal characters not in [0-9a-z-_.]`,
+				wantErr:  fmt.Sprintf("header key %q contains illegal characters not in [0-9a-z-_.]", "bad key"),
 			},
 			{
 				name:     "invalid value",
 				authdata: map[string]string{"valid-key": "bad\x01value"},
-				wantErr:  `header key "valid-key" contains value with non-printable ASCII characters`,
+				wantErr:  fmt.Sprintf("header key %q contains value with non-printable ASCII characters", "valid-key"),
 			},
 		} {
 			t.Run(e.name+"/"+test.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #9198

Validate metadata returned by transport-level and call-level `PerRPCCredentials` before appending it to HTTP/2 request headers. The validation happens after keys are lowercased, matching the existing outgoing metadata rules used for application metadata.

The regression tests cover invalid credential keys and values for both dial-level and call-level credentials.

RELEASE NOTES:
* credentials: Invalid metadata returned by per-RPC credentials is rejected before HTTP/2 request headers are created.
