### PR TITLE
xds/fault: reject OK abort status

### DIFF
--- a/internal/xds/httpfilter/fault/fault.go
+++ b/internal/xds/httpfilter/fault/fault.go
@@ -245,7 +245,7 @@ func injectAbort(ctx context.Context, abortCfg *fpb.FaultAbort) error {
 		return nil
 	}
 	if code == codes.OK {
-		return errOKStream
+		return status.Error(codes.Unknown, "RPC terminated due to fault injection with invalid OK status")
 	}
 	return status.Errorf(code, "RPC terminated due to fault injection")
 }

--- a/internal/xds/httpfilter/fault/fault_test.go
+++ b/internal/xds/httpfilter/fault/fault_test.go
@@ -38,6 +38,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/grpctest"
+	iresolver "google.golang.org/grpc/internal/resolver"
 	"google.golang.org/grpc/internal/stubserver"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
@@ -542,6 +543,35 @@ func (s) TestFaultInjection_Unary(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func (s) TestFaultAbortOKDoesNotCreateSuccessfulStream(t *testing.T) {
+	origRandIntn := randIntn
+	randIntn = func(int) int { return 0 }
+	defer func() { randIntn = origRandIntn }()
+
+	i := &interceptor{config: &fpb.HTTPFault{
+		Abort: &fpb.FaultAbort{
+			Percentage: &tpb.FractionalPercent{
+				Numerator:   100,
+				Denominator: tpb.FractionalPercent_HUNDRED,
+			},
+			ErrorType: &fpb.FaultAbort_GrpcStatus{GrpcStatus: uint32(codes.OK)},
+		},
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cs, err := i.NewStream(ctx, iresolver.RPCInfo{}, func(context.Context, ...grpc.CallOption) (grpc.ClientStream, error) {
+		t.Fatalf("fault abort should not delegate to the underlying stream")
+		return nil, nil
+	})
+	if err == nil {
+		t.Fatalf("NewStream() returned stream %T with nil error for fault abort status OK, want non-nil error", cs)
+	}
+	if got := status.Code(err); got == codes.OK {
+		t.Fatalf("NewStream() returned error code %v, want non-OK", got)
 	}
 }
 


### PR DESCRIPTION
Fixes #9201

Map gRPC abort status OK to a non-OK error at fault injection time instead of returning a successful synthetic stream. HTTP status 200 behavior remains unchanged and continues to map to `Unknown`.

The regression test verifies that an OK gRPC abort does not delegate to the underlying stream and returns a non-OK error from `NewStream`.

RELEASE NOTES:
* xds: Fault injection with gRPC abort status OK now fails stream creation with a non-OK error.
