### PR TITLE
httpfilter/extproc: add check to ensure that response trailer mode must be SEND if response body mode is GRPC

### DIFF
--- a/internal/xds/httpfilter/extproc/config_test.go
+++ b/internal/xds/httpfilter/extproc/config_test.go
@@ -151,8 +151,9 @@ func (s) TestParseFilterConfig_Success(t *testing.T) {
 						},
 					},
 					ProcessingMode: &fpb.ProcessingMode{
-						RequestBodyMode:  fpb.ProcessingMode_GRPC,
-						ResponseBodyMode: fpb.ProcessingMode_GRPC,
+						RequestBodyMode:     fpb.ProcessingMode_GRPC,
+						ResponseBodyMode:    fpb.ProcessingMode_GRPC,
+						ResponseTrailerMode: fpb.ProcessingMode_SEND,
 					},
 				})
 				return m
@@ -165,7 +166,7 @@ func (s) TestParseFilterConfig_Success(t *testing.T) {
 				processingModes: processingModes{
 					requestHeaderMode:   modeSend,
 					responseHeaderMode:  modeSend,
-					responseTrailerMode: modeSkip,
+					responseTrailerMode: modeSend,
 					requestBodyMode:     modeSend,
 					responseBodyMode:    modeSend,
 				},
@@ -314,6 +315,46 @@ func (s) TestParseFilterConfig_Errors(t *testing.T) {
 			wantErr: "extproc: invalid response body mode STREAMED",
 		},
 		{
+			name: "InvalidProcessingMode_ResponseBodySendTrailerDefault",
+			cfg: func() proto.Message {
+				m, _ := anypb.New(&fpb.ExternalProcessor{
+					GrpcService: &corepb.GrpcService{
+						TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
+							GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
+								TargetUri: "localhost:1234",
+							},
+						},
+					},
+					ProcessingMode: &fpb.ProcessingMode{
+						ResponseBodyMode:    fpb.ProcessingMode_GRPC,
+						ResponseTrailerMode: fpb.ProcessingMode_DEFAULT,
+					},
+				})
+				return m
+			}(),
+			wantErr: fmt.Sprintf("extproc: invalid response trailer mode DEFAULT: must be %q when response body mode is %q", "SEND", "GRPC"),
+		},
+		{
+			name: "InvalidProcessingMode_ResponseBodySendTrailerSkip",
+			cfg: func() proto.Message {
+				m, _ := anypb.New(&fpb.ExternalProcessor{
+					GrpcService: &corepb.GrpcService{
+						TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
+							GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
+								TargetUri: "localhost:1234",
+							},
+						},
+					},
+					ProcessingMode: &fpb.ProcessingMode{
+						ResponseBodyMode:    fpb.ProcessingMode_GRPC,
+						ResponseTrailerMode: fpb.ProcessingMode_SKIP,
+					},
+				})
+				return m
+			}(),
+			wantErr: fmt.Sprintf("extproc: invalid response trailer mode SKIP: must be %q when response body mode is %q", "SEND", "GRPC"),
+		},
+		{
 			name: "InvalidMutationRules",
 			cfg: func() proto.Message {
 				m, _ := anypb.New(&fpb.ExternalProcessor{
@@ -415,8 +456,9 @@ func (s) TestParseFilterConfigOverride_Success(t *testing.T) {
 						Override: &fpb.ExtProcPerRoute_Overrides{
 							Overrides: &fpb.ExtProcOverrides{
 								ProcessingMode: &fpb.ProcessingMode{
-									RequestBodyMode:  fpb.ProcessingMode_GRPC,
-									ResponseBodyMode: fpb.ProcessingMode_GRPC,
+									RequestBodyMode:     fpb.ProcessingMode_GRPC,
+									ResponseBodyMode:    fpb.ProcessingMode_GRPC,
+									ResponseTrailerMode: fpb.ProcessingMode_SEND,
 								},
 							},
 						},
@@ -427,7 +469,7 @@ func (s) TestParseFilterConfigOverride_Success(t *testing.T) {
 				processingModes: optional.New(processingModes{
 					requestHeaderMode:   modeSend,
 					responseHeaderMode:  modeSend,
-					responseTrailerMode: modeSkip,
+					responseTrailerMode: modeSend,
 					requestBodyMode:     modeSend,
 					responseBodyMode:    modeSend,
 				}),
@@ -503,6 +545,40 @@ func (s) TestParseFilterConfigOverride_Errors(t *testing.T) {
 				return m
 			}(),
 			wantErr: "extproc: invalid response body mode STREAMED",
+		},
+		{
+			name: "ProcessingMode_ResponseBodySendTrailerDefault",
+			override: func() proto.Message {
+				m, _ := anypb.New(&fpb.ExtProcPerRoute{
+					Override: &fpb.ExtProcPerRoute_Overrides{
+						Overrides: &fpb.ExtProcOverrides{
+							ProcessingMode: &fpb.ProcessingMode{
+								ResponseBodyMode:    fpb.ProcessingMode_GRPC,
+								ResponseTrailerMode: fpb.ProcessingMode_DEFAULT,
+							},
+						},
+					},
+				})
+				return m
+			}(),
+			wantErr: fmt.Sprintf("extproc: invalid response trailer mode DEFAULT: must be %q when response body mode is %q", "SEND", "GRPC"),
+		},
+		{
+			name: "ProcessingMode_ResponseBodySendTrailerSkip",
+			override: func() proto.Message {
+				m, _ := anypb.New(&fpb.ExtProcPerRoute{
+					Override: &fpb.ExtProcPerRoute_Overrides{
+						Overrides: &fpb.ExtProcOverrides{
+							ProcessingMode: &fpb.ProcessingMode{
+								ResponseBodyMode:    fpb.ProcessingMode_GRPC,
+								ResponseTrailerMode: fpb.ProcessingMode_SKIP,
+							},
+						},
+					},
+				})
+				return m
+			}(),
+			wantErr: fmt.Sprintf("extproc: invalid response trailer mode SKIP: must be %q when response body mode is %q", "SEND", "GRPC"),
 		},
 		{
 			name:     "InvalidOverrideType",

--- a/internal/xds/httpfilter/extproc/ext_proc.go
+++ b/internal/xds/httpfilter/extproc/ext_proc.go
@@ -69,13 +69,17 @@ func (builder) TypeURLs() []string {
 }
 
 // validateBodyProcessingMode ensures that the body processing mode is either
-// NONE or GRPC.
+// NONE or GRPC. Also ensures that if response body mode is GRPC then response
+// trailer mode must be SEND.
 func validateBodyProcessingMode(mode *v3procfilterpb.ProcessingMode) error {
 	if m := mode.GetRequestBodyMode(); m != v3procfilterpb.ProcessingMode_NONE && m != v3procfilterpb.ProcessingMode_GRPC {
 		return fmt.Errorf("extproc: invalid request body mode %v: want %q or %q", m, "NONE", "GRPC")
 	}
 	if m := mode.GetResponseBodyMode(); m != v3procfilterpb.ProcessingMode_NONE && m != v3procfilterpb.ProcessingMode_GRPC {
 		return fmt.Errorf("extproc: invalid response body mode %v: want %q or %q", m, "NONE", "GRPC")
+	}
+	if mode.GetResponseBodyMode() == v3procfilterpb.ProcessingMode_GRPC && mode.GetResponseTrailerMode() != v3procfilterpb.ProcessingMode_SEND {
+		return fmt.Errorf("extproc: invalid response trailer mode %v: must be %q when response body mode is %q", mode.GetResponseTrailerMode(), "SEND", "GRPC")
 	}
 	return nil
 }


### PR DESCRIPTION
Adds a check to ensure response trailer mode is Send if response body mode is GRPC as part of parsing the extproc filter config.

#ext-proc-a93

RELEASE NOTES: None
