### PR TITLE
gcp_authn: remove unnecessary import rename

### DIFF
--- a/internal/xds/httpfilter/gcp_authn/gcp_authn_filter.go
+++ b/internal/xds/httpfilter/gcp_authn/gcp_authn_filter.go
@@ -37,9 +37,9 @@ import (
 	"google.golang.org/grpc/internal/xds/xdsclient/xdsresource"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	v3gcpauthnpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/gcp_authn/v3"
-	anypb "google.golang.org/protobuf/types/known/anypb"
 )
 
 const defaultCacheSize = 10 // default capacity of the LRU credentials cache.

--- a/internal/xds/httpfilter/gcp_authn/gcp_authn_filter_e2e_test.go
+++ b/internal/xds/httpfilter/gcp_authn/gcp_authn_filter_e2e_test.go
@@ -46,6 +46,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -57,7 +58,6 @@ import (
 	testgrpc "google.golang.org/grpc/interop/grpc_testing"
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 	anypb "google.golang.org/protobuf/types/known/anypb"
-	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 type s struct {

--- a/internal/xds/httpfilter/gcp_authn/gcp_authn_filter_e2e_test.go
+++ b/internal/xds/httpfilter/gcp_authn/gcp_authn_filter_e2e_test.go
@@ -46,6 +46,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -57,7 +58,6 @@ import (
 	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	testgrpc "google.golang.org/grpc/interop/grpc_testing"
 	testpb "google.golang.org/grpc/interop/grpc_testing"
-	anypb "google.golang.org/protobuf/types/known/anypb"
 )
 
 type s struct {

--- a/internal/xds/httpfilter/gcp_authn/gcp_authn_filter_test.go
+++ b/internal/xds/httpfilter/gcp_authn/gcp_authn_filter_test.go
@@ -32,9 +32,9 @@ import (
 	"google.golang.org/grpc/internal/xds/httpfilter"
 	"google.golang.org/grpc/internal/xds/xdsclient/xdsresource"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	v3gcpauthnpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/gcp_authn/v3"
-	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 type s struct {


### PR DESCRIPTION
The import script doesn't like this.

RELEASE NOTES: none