### PR TITLE
xds: reject EDS drop policy with unsupported denominator

### DIFF
--- a/internal/xds/xdsclient/xdsresource/unmarshal_eds.go
+++ b/internal/xds/xdsclient/xdsresource/unmarshal_eds.go
@@ -77,7 +77,7 @@ func parseAddress(socketAddress *v3corepb.SocketAddress) string {
 	return net.JoinHostPort(socketAddress.GetAddress(), strconv.Itoa(int(socketAddress.GetPortValue())))
 }
 
-func parseDropPolicy(dropPolicy *v3endpointpb.ClusterLoadAssignment_Policy_DropOverload) OverloadDropConfig {
+func parseDropPolicy(dropPolicy *v3endpointpb.ClusterLoadAssignment_Policy_DropOverload) (OverloadDropConfig, error) {
 	percentage := dropPolicy.GetDropPercentage()
 	var (
 		numerator   = percentage.GetNumerator()
@@ -90,12 +90,14 @@ func parseDropPolicy(dropPolicy *v3endpointpb.ClusterLoadAssignment_Policy_DropO
 		denominator = 10000
 	case v3typepb.FractionalPercent_MILLION:
 		denominator = 1000000
+	default:
+		return OverloadDropConfig{}, fmt.Errorf("EDS response contains a drop policy with unsupported denominator: %v", percentage.GetDenominator())
 	}
 	return OverloadDropConfig{
 		Category:    dropPolicy.GetCategory(),
 		Numerator:   numerator,
 		Denominator: denominator,
-	}
+	}, nil
 }
 
 func parseEndpoints(lbEndpoints []*v3endpointpb.LbEndpoint, uniqueEndpointAddrs map[string]bool) ([]Endpoint, error) {
@@ -179,7 +181,11 @@ func hashKeyFromMetadata(metadata map[string]any) string {
 func parseEDSRespProto(m *v3endpointpb.ClusterLoadAssignment) (EndpointsUpdate, error) {
 	ret := EndpointsUpdate{}
 	for _, dropPolicy := range m.GetPolicy().GetDropOverloads() {
-		ret.Drops = append(ret.Drops, parseDropPolicy(dropPolicy))
+		drop, err := parseDropPolicy(dropPolicy)
+		if err != nil {
+			return EndpointsUpdate{}, err
+		}
+		ret.Drops = append(ret.Drops, drop)
 	}
 	priorities := make(map[uint32]map[string]bool)
 	sumOfWeights := make(map[uint32]uint64)

--- a/internal/xds/xdsclient/xdsresource/unmarshal_eds_test.go
+++ b/internal/xds/xdsclient/xdsresource/unmarshal_eds_test.go
@@ -181,6 +181,23 @@ func (s) TestEDSParseRespProto(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "unsupported-drop-denominator",
+			m: &v3endpointpb.ClusterLoadAssignment{
+				ClusterName: "test",
+				Policy: &v3endpointpb.ClusterLoadAssignment_Policy{
+					DropOverloads: []*v3endpointpb.ClusterLoadAssignment_Policy_DropOverload{{
+						Category: "test-drop",
+						DropPercentage: &v3typepb.FractionalPercent{
+							Numerator:   1,
+							Denominator: v3typepb.FractionalPercent_DenominatorType(7),
+						},
+					}},
+				},
+			},
+			want:    EndpointsUpdate{},
+			wantErr: true,
+		},
+		{
 			name: "good",
 			m: func() *v3endpointpb.ClusterLoadAssignment {
 				clab0 := newClaBuilder("test", nil)


### PR DESCRIPTION
`parseDropPolicy` maps a `FractionalPercent` denominator to a divisor with a switch that has no default, so an EDS `drop_overload` carrying an unknown denominator enum value leaves the divisor at 0. That value reaches `clusterimpl`, which evaluates `d.Numerator * million / d.Denominator`, and a management server sending such a resource crashes the client with an integer divide-by-zero.

Reject the unsupported denominator while parsing the resource so it is NACKed, matching how `parseEDSRespProto` already errors on other malformed fields. Validating in the parser keeps the balancer free of divisor checks and stops one bad resource from taking down the client.

RELEASE NOTES:
- xds: Prevent divide-by-zero client crashes on unsupported EDS drop policy denominators 