### PR TITLE
xds: reject rbac not_rule/not_id with no inner matcher

### DIFF
--- a/internal/xds/rbac/matchers.go
+++ b/internal/xds/rbac/matchers.go
@@ -120,6 +120,9 @@ func matchersFromPermissions(permissions []*v3rbacpb.Permission) ([]matcher, err
 			if err != nil {
 				return nil, err
 			}
+			if len(mList) == 0 {
+				return nil, fmt.Errorf("rbac: not_rule has no supported inner rule: %v", permission.GetNotRule())
+			}
 			matchers = append(matchers, &notMatcher{matcherToNot: mList[0]})
 		case *v3rbacpb.Permission_Metadata:
 			// Never matches - so no-op if not inverted, always match if
@@ -182,6 +185,9 @@ func matchersFromPrincipals(principals []*v3rbacpb.Principal) ([]matcher, error)
 			mList, err := matchersFromPrincipals([]*v3rbacpb.Principal{{Identifier: principal.GetNotId().Identifier}})
 			if err != nil {
 				return nil, err
+			}
+			if len(mList) == 0 {
+				return nil, fmt.Errorf("rbac: not_id has no supported inner id: %v", principal.GetNotId())
 			}
 			matchers = append(matchers, &notMatcher{matcherToNot: mList[0]})
 		case *v3rbacpb.Principal_SourceIp:

--- a/internal/xds/rbac/rbac_engine_test.go
+++ b/internal/xds/rbac/rbac_engine_test.go
@@ -667,6 +667,50 @@ func (s) TestNewChainEngine(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		// A not_rule wrapping an inner permission that gRPC RBAC does not
+		// translate into a matcher (here an empty inner rule) must be rejected
+		// rather than panic while indexing the empty matcher list.
+		{
+			name: "NotRuleWithoutInnerMatcher",
+			policies: []*v3rbacpb.RBAC{
+				{
+					Action: v3rbacpb.RBAC_ALLOW,
+					Policies: map[string]*v3rbacpb.Policy{
+						"anyone": {
+							Permissions: []*v3rbacpb.Permission{
+								{Rule: &v3rbacpb.Permission_NotRule{NotRule: &v3rbacpb.Permission{}}},
+							},
+							Principals: []*v3rbacpb.Principal{
+								{Identifier: &v3rbacpb.Principal_Any{Any: true}},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		// A not_id wrapping an inner principal that gRPC RBAC does not translate
+		// into a matcher (here an empty inner identifier) must be rejected
+		// rather than panic while indexing the empty matcher list.
+		{
+			name: "NotIdWithoutInnerMatcher",
+			policies: []*v3rbacpb.RBAC{
+				{
+					Action: v3rbacpb.RBAC_ALLOW,
+					Policies: map[string]*v3rbacpb.Policy{
+						"anyone": {
+							Permissions: []*v3rbacpb.Permission{
+								{Rule: &v3rbacpb.Permission_Any{Any: true}},
+							},
+							Principals: []*v3rbacpb.Principal{
+								{Identifier: &v3rbacpb.Principal_NotId{NotId: &v3rbacpb.Principal{}}},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
matchersFromPermissions and matchersFromPrincipals build a not_rule/not_id by recursing on a single-element slice and then reading mList[0]. The recursion returns nothing when the wrapped inner rule is one gRPC RBAC does not turn into a matcher: an empty inner rule, a requested_server_name or non-inverted metadata permission, or a deprecated source_ip / metadata principal. An RBAC config carried in an xDS HTTP filter (or an authz policy) with a not_rule{} or not_id{} of that shape indexes an empty slice and panics during resource parsing, and nothing recovers it in the xdsclient decode path.

Return an error from the two builders when the inner rule produces no matcher, so the resource is rejected the way other invalid RBAC fields are instead of crashing the process. Keeping the check next to the mList[0] read covers the permission and principal sites with the same guard.

RELEASE NOTES:
* xds: fix a panic parsing an RBAC config whose not_rule or not_id wraps an unsupported inner matcher