### PR TITLE
extauthz: parse base and override config for A92.

### DIFF
--- a/internal/envconfig/xds.go
+++ b/internal/envconfig/xds.go
@@ -98,4 +98,9 @@ var (
 	// filter. For more details, see:
 	// https://github.com/grpc/proposal/blob/master/A83-xds-gcp-authn-filter.md
 	GCPAuthenticationFilterEnabled = boolFromEnv("GRPC_EXPERIMENTAL_XDS_GCP_AUTHENTICATION_FILTER", false)
+
+	// XDSClientExtAuthzEnabled indicates whether the external authorization
+	// filter is enabled on the client side. For more details, see:
+	// https://github.com/grpc/proposal/blob/master/A92-xds-ext-authz.md
+	XDSClientExtAuthzEnabled = boolFromEnv("GRPC_EXPERIMENTAL_XDS_EXT_AUTHZ_ON_CLIENT", false)
 )

--- a/internal/xds/httpfilter/ext_authz/config.go
+++ b/internal/xds/httpfilter/ext_authz/config.go
@@ -34,12 +34,12 @@ type baseConfig struct {
 	filterEnabled fraction
 	// denyAtDisabled specifies whether to deny requests when external
 	// authorization is disabled via the filterEnabled configuration. If true,
-	// requests will be denied with a status based on StatusCodeOnError.
+	// requests will be denied with a status based on statusOnError.
 	denyAtDisable bool
 	// failureModeAllow specifies the behavior when the call to the external
 	// authorization server fails. If true, the request will be allowed in such
 	// cases. If false, the request will be denied with a status based on
-	// StatusCodeOnError.
+	// statusOnError.
 	failureModeAllow bool
 	// failureModeAllowHeaderAdd specifies whether to add the
 	// `x-envoy-auth-failure-mode-allowed: true` header to the data plane RPC
@@ -58,7 +58,7 @@ type baseConfig struct {
 	// external authorization server. If unset, all headers are allowed.
 	allowedHeaders []matcher.StringMatcher
 	// disallowedHeaders specifies the headers that will not be sent to the
-	// external authorization server. This overrides the above AllowedHeaders if
+	// external authorization server. This overrides the above allowedHeaders if
 	// a header matches both.
 	disallowedHeaders []matcher.StringMatcher
 	// decoderHeaderMutationRules specifies the rules for what modifications an

--- a/internal/xds/httpfilter/ext_authz/config.go
+++ b/internal/xds/httpfilter/ext_authz/config.go
@@ -1,0 +1,82 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package extauthz
+
+import (
+	"google.golang.org/grpc/internal/xds/httpfilter"
+	"google.golang.org/grpc/internal/xds/matcher"
+	"google.golang.org/grpc/internal/xds/xdsclient/xdsresource"
+)
+
+// baseConfig contains the configuration for the external authorization filter.
+type baseConfig struct {
+	httpfilter.FilterConfig
+	// grpcService is the configuration for the external authorization server.
+	grpcService xdsresource.GRPCServiceConfig
+	// filterEnabled specifies the percentage of requests to be authorized by
+	// the external authorization server.
+	filterEnabled fraction
+	// denyAtDisabled specifies whether to deny requests when external
+	// authorization is disabled via the filterEnabled configuration. If true,
+	// requests will be denied with a status based on StatusCodeOnError.
+	denyAtDisable bool
+	// failureModeAllow specifies the behavior when the call to the external
+	// authorization server fails. If true, the request will be allowed in such
+	// cases. If false, the request will be denied with a status based on
+	// StatusCodeOnError.
+	failureModeAllow bool
+	// failureModeAllowHeaderAdd specifies whether to add the
+	// `x-envoy-auth-failure-mode-allowed: true` header to the data plane RPC
+	// when the call to the external authorization server fails.
+	failureModeAllowHeaderAdd bool
+	// statusOnError is a HTTP status code to use when the external
+	// authorization is disabled or when the call to the external authorization
+	// server fails. The HTTP status code will be converted to a gRPC status
+	// code using the mapping defined in
+	// https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md.
+	//
+	// If unset, it defaults to 403 (Forbidden), which translates to gRPC status
+	// PERMISSION_DENIED.
+	statusOnError int32
+	// allowedHeaders specifies the headers that are allowed to be sent to the
+	// external authorization server. If unset, all headers are allowed.
+	allowedHeaders []matcher.StringMatcher
+	// disallowedHeaders specifies the headers that will not be sent to the
+	// external authorization server. This overrides the above AllowedHeaders if
+	// a header matches both.
+	disallowedHeaders []matcher.StringMatcher
+	// decoderHeaderMutationRules specifies the rules for what modifications an
+	// external authorization server may make to headers sent on the data plane
+	// RPC.
+	decoderHeaderMutationRules httpfilter.HeaderMutationRules
+	// includePeerCertificate specifies whether to include the peer certificate
+	// in the request sent to the external authorization server.
+	includePeerCertificate bool
+}
+
+// fraction uses a numerator and denominator to specify a fractional value. If
+// the denominator specified is less than the numerator, the final fractional
+// value is capped at 1.
+type fraction struct {
+	// numerator is the numerator of the fraction.
+	numerator uint32
+	// denominator is the denominator of the fraction. If unset, it defaults
+	// to 100.
+	denominator uint32
+}

--- a/internal/xds/httpfilter/ext_authz/config.go
+++ b/internal/xds/httpfilter/ext_authz/config.go
@@ -19,6 +19,7 @@
 package extauthz
 
 import (
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/internal/xds/httpfilter"
 	"google.golang.org/grpc/internal/xds/matcher"
 	"google.golang.org/grpc/internal/xds/xdsclient/xdsresource"
@@ -45,15 +46,12 @@ type baseConfig struct {
 	// `x-envoy-auth-failure-mode-allowed: true` header to the data plane RPC
 	// when the call to the external authorization server fails.
 	failureModeAllowHeaderAdd bool
-	// statusOnError is a HTTP status code to use when the external
+	// statusOnError is the gRPC status code to use when the external
 	// authorization is disabled or when the call to the external authorization
-	// server fails. The HTTP status code will be converted to a gRPC status
-	// code using the mapping defined in
-	// https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md.
+	// server fails.
 	//
-	// If unset, it defaults to 403 (Forbidden), which translates to gRPC status
-	// PERMISSION_DENIED.
-	statusOnError int32
+	// If unset, it defaults to PERMISSION_DENIED.
+	statusOnError codes.Code
 	// allowedHeaders specifies the headers that are allowed to be sent to the
 	// external authorization server. If unset, all headers are allowed.
 	allowedHeaders []matcher.StringMatcher
@@ -76,7 +74,6 @@ type baseConfig struct {
 type fraction struct {
 	// numerator is the numerator of the fraction.
 	numerator uint32
-	// denominator is the denominator of the fraction. If unset, it defaults
-	// to 100.
+	// denominator is the denominator of the fraction.
 	denominator uint32
 }

--- a/internal/xds/httpfilter/ext_authz/config.go
+++ b/internal/xds/httpfilter/ext_authz/config.go
@@ -25,8 +25,8 @@ import (
 	"google.golang.org/grpc/internal/xds/xdsclient/xdsresource"
 )
 
-// baseConfig contains the configuration for the external authorization filter.
-type baseConfig struct {
+// config contains the configuration for the external authorization filter.
+type config struct {
 	httpfilter.FilterConfig
 	// grpcService is the configuration for the external authorization server.
 	grpcService xdsresource.GRPCServiceConfig
@@ -50,14 +50,14 @@ type baseConfig struct {
 	// authorization is disabled or when the call to the external authorization
 	// server fails.
 	//
-	// If unset, it defaults to PERMISSION_DENIED.
+	// The default value is PERMISSION_DENIED.
 	statusOnError codes.Code
 	// allowedHeaders specifies the headers that are allowed to be sent to the
 	// external authorization server. If unset, all headers are allowed.
 	allowedHeaders []matcher.StringMatcher
 	// disallowedHeaders specifies the headers that will not be sent to the
-	// external authorization server. This overrides the above allowedHeaders if
-	// a header matches both.
+	// external authorization server. This takes precedence over the
+	// allowedHeaders field.
 	disallowedHeaders []matcher.StringMatcher
 	// decoderHeaderMutationRules specifies the rules for what modifications an
 	// external authorization server may make to headers sent on the data plane

--- a/internal/xds/httpfilter/ext_authz/ext_authz.go
+++ b/internal/xds/httpfilter/ext_authz/ext_authz.go
@@ -60,21 +60,22 @@ func parseFilterEnabled(fp *v3corepb.RuntimeFractionalPercent) (fraction, error)
 	if fp == nil {
 		return fraction{numerator: 100, denominator: 100}, nil
 	}
-	pct := fp.GetDefaultValue()
-	if pct == nil {
+	fracPercent := fp.GetDefaultValue()
+	if fracPercent == nil {
 		return fraction{}, fmt.Errorf("extauthz: missing default_value in filter_enabled")
 	}
 
-	num := pct.GetNumerator()
-	switch pct.GetDenominator() {
-	case v3typepb.FractionalPercent_HUNDRED:
-		return fraction{numerator: num, denominator: 100}, nil
+	den := uint32(100)
+	switch fracPercent.GetDenominator() {
 	case v3typepb.FractionalPercent_TEN_THOUSAND:
-		return fraction{numerator: num, denominator: 10000}, nil
+		den = 10000
 	case v3typepb.FractionalPercent_MILLION:
-		return fraction{numerator: num, denominator: 1000000}, nil
+		den = 1000000
 	}
-	return fraction{numerator: num, denominator: 100}, nil
+
+	// If the numerator exceeds the denominator, cap the fractional value at 100%.
+	num := min(fracPercent.GetNumerator(), den)
+	return fraction{numerator: num, denominator: den}, nil
 }
 
 func (builder) ParseFilterConfig(cfg proto.Message) (httpfilter.FilterConfig, error) {
@@ -142,6 +143,12 @@ func (builder) ParseFilterConfig(cfg proto.Message) (httpfilter.FilterConfig, er
 	}, nil
 }
 
+// ParseFilterConfigOverride parses the provided override configuration.
+//
+// Note that ExtAuthzPerRoute is unmarshaled to verify its syntax during xDS
+// resource validation, no filter configuration object is returned. Per-route
+// disabling is supported via the generic FilterConfig wrapper mechanism rather
+// than the ExtAuthzPerRoute.disabled field directly.
 func (builder) ParseFilterConfigOverride(overrideCfg proto.Message) (httpfilter.FilterConfig, error) {
 	m, ok := overrideCfg.(*anypb.Any)
 	if !ok {

--- a/internal/xds/httpfilter/ext_authz/ext_authz.go
+++ b/internal/xds/httpfilter/ext_authz/ext_authz.go
@@ -1,0 +1,159 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package extauthz implements the xDS External Authorization HTTP filter.
+package extauthz
+
+import (
+	"fmt"
+
+	"google.golang.org/grpc/internal/envconfig"
+	"google.golang.org/grpc/internal/xds/httpfilter"
+	"google.golang.org/grpc/internal/xds/matcher"
+	"google.golang.org/grpc/internal/xds/xdsclient/xdsresource"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	v3extauthzfilterpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
+	v3typepb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+)
+
+func init() {
+	if envconfig.XDSClientExtAuthzEnabled {
+		httpfilter.Register(builder{})
+	}
+}
+
+var (
+	// TODO: Remove this once gRFC A102 is implemented.
+	parseGRPCServiceConfig = func(*v3corepb.GrpcService) (xdsresource.GRPCServiceConfig, error) {
+		return xdsresource.GRPCServiceConfig{}, fmt.Errorf("parseGRPCServiceConfig not implemented")
+	}
+)
+
+type builder struct{}
+
+func (builder) TypeURLs() []string {
+	return []string{
+		"type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
+		"type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
+	}
+}
+
+func parseFilterEnabled(fp *v3corepb.RuntimeFractionalPercent) (fraction, error) {
+	if fp == nil {
+		return fraction{numerator: 100, denominator: 100}, nil
+	}
+	pct := fp.GetDefaultValue()
+	if pct == nil {
+		return fraction{}, fmt.Errorf("extauthz: missing default_value in filter_enabled")
+	}
+
+	num := pct.GetNumerator()
+	switch pct.GetDenominator() {
+	case v3typepb.FractionalPercent_HUNDRED:
+		return fraction{numerator: num, denominator: 100}, nil
+	case v3typepb.FractionalPercent_TEN_THOUSAND:
+		return fraction{numerator: num, denominator: 10000}, nil
+	case v3typepb.FractionalPercent_MILLION:
+		return fraction{numerator: num, denominator: 1000000}, nil
+	}
+	return fraction{numerator: num, denominator: 100}, nil
+}
+
+func (builder) ParseFilterConfig(cfg proto.Message) (httpfilter.FilterConfig, error) {
+	m, ok := cfg.(*anypb.Any)
+	if !ok {
+		return nil, fmt.Errorf("extauthz: error parsing config %v: unknown type %T, want *anypb.Any", cfg, cfg)
+	}
+	msg := new(v3extauthzfilterpb.ExtAuthz)
+	if err := m.UnmarshalTo(msg); err != nil {
+		return nil, fmt.Errorf("extauthz: failed to unmarshal config: %v", err)
+	}
+
+	if msg.GetGrpcService() == nil {
+		return nil, fmt.Errorf("extauthz: empty grpc_service provided in config %v", cfg)
+	}
+	server, err := parseGRPCServiceConfig(msg.GetGrpcService())
+	if err != nil {
+		return nil, fmt.Errorf("extauthz: failed to parse grpc_service: %v", err)
+	}
+
+	filterEnabled, err := parseFilterEnabled(msg.GetFilterEnabled())
+	if err != nil {
+		return nil, err
+	}
+
+	var denyAtDisable bool
+	if df := msg.GetDenyAtDisable(); df != nil {
+		if df.GetDefaultValue() == nil {
+			return nil, fmt.Errorf("extauthz: missing default_value in deny_at_disable")
+		}
+		denyAtDisable = df.GetDefaultValue().GetValue()
+	}
+
+	mutationRules, err := httpfilter.HeaderMutationRulesFromProto(msg.GetDecoderHeaderMutationRules())
+	if err != nil {
+		return nil, err
+	}
+
+	var allowedHeaders, disallowedHeaders []matcher.StringMatcher
+	if allowed := msg.GetAllowedHeaders(); allowed != nil {
+		allowedHeaders, err = httpfilter.ConvertStringMatchers(allowed.GetPatterns())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if disallowed := msg.GetDisallowedHeaders(); disallowed != nil {
+		disallowedHeaders, err = httpfilter.ConvertStringMatchers(disallowed.GetPatterns())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return baseConfig{
+		grpcService:                server,
+		filterEnabled:              filterEnabled,
+		denyAtDisable:              denyAtDisable,
+		failureModeAllow:           msg.GetFailureModeAllow(),
+		failureModeAllowHeaderAdd:  msg.GetFailureModeAllowHeaderAdd(),
+		statusOnError:              int32(msg.GetStatusOnError().GetCode()),
+		allowedHeaders:             allowedHeaders,
+		disallowedHeaders:          disallowedHeaders,
+		decoderHeaderMutationRules: mutationRules,
+		includePeerCertificate:     msg.GetIncludePeerCertificate(),
+	}, nil
+}
+
+func (builder) ParseFilterConfigOverride(overrideCfg proto.Message) (httpfilter.FilterConfig, error) {
+	m, ok := overrideCfg.(*anypb.Any)
+	if !ok {
+		return nil, fmt.Errorf("extauthz: error parsing override config %v: unknown type %T, want *anypb.Any", overrideCfg, overrideCfg)
+	}
+	msg := new(v3extauthzfilterpb.ExtAuthzPerRoute)
+	if err := m.UnmarshalTo(msg); err != nil {
+		return nil, fmt.Errorf("extauthz: failed to unmarshal override config %v: %v", overrideCfg, err)
+	}
+	return nil, nil
+}
+
+func (builder) IsTerminal() bool {
+	return false
+}

--- a/internal/xds/httpfilter/ext_authz/ext_authz.go
+++ b/internal/xds/httpfilter/ext_authz/ext_authz.go
@@ -22,7 +22,9 @@ package extauthz
 import (
 	"fmt"
 
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/internal/envconfig"
+	"google.golang.org/grpc/internal/transport"
 	"google.golang.org/grpc/internal/xds/httpfilter"
 	"google.golang.org/grpc/internal/xds/matcher"
 	"google.golang.org/grpc/internal/xds/xdsclient/xdsresource"
@@ -78,6 +80,14 @@ func parseFilterEnabled(fp *v3corepb.RuntimeFractionalPercent) (fraction, error)
 	return fraction{numerator: num, denominator: den}, nil
 }
 
+// grpcStatusCode converts an HTTP status code to a gRPC status code.
+func grpcStatusCode(httpStatus int32) codes.Code {
+	if code, ok := transport.HTTPStatusConvTab[int(httpStatus)]; ok {
+		return code
+	}
+	return codes.Unknown
+}
+
 func (builder) ParseFilterConfig(cfg proto.Message) (httpfilter.FilterConfig, error) {
 	m, ok := cfg.(*anypb.Any)
 	if !ok {
@@ -109,6 +119,12 @@ func (builder) ParseFilterConfig(cfg proto.Message) (httpfilter.FilterConfig, er
 		denyAtDisable = df.GetDefaultValue().GetValue()
 	}
 
+	httpStatus := int32(403)
+	if st := msg.GetStatusOnError().GetCode(); st != 0 {
+		httpStatus = int32(st)
+	}
+	statusOnError := grpcStatusCode(httpStatus)
+
 	mutationRules, err := httpfilter.HeaderMutationRulesFromProto(msg.GetDecoderHeaderMutationRules())
 	if err != nil {
 		return nil, err
@@ -135,7 +151,7 @@ func (builder) ParseFilterConfig(cfg proto.Message) (httpfilter.FilterConfig, er
 		denyAtDisable:              denyAtDisable,
 		failureModeAllow:           msg.GetFailureModeAllow(),
 		failureModeAllowHeaderAdd:  msg.GetFailureModeAllowHeaderAdd(),
-		statusOnError:              int32(msg.GetStatusOnError().GetCode()),
+		statusOnError:              statusOnError,
 		allowedHeaders:             allowedHeaders,
 		disallowedHeaders:          disallowedHeaders,
 		decoderHeaderMutationRules: mutationRules,

--- a/internal/xds/httpfilter/ext_authz/ext_authz.go
+++ b/internal/xds/httpfilter/ext_authz/ext_authz.go
@@ -33,7 +33,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	v3extauthzfilterpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
+	v3extauthzpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
 	v3typepb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 )
 
@@ -94,7 +94,7 @@ func (builder) ParseFilterConfig(cfg proto.Message) (httpfilter.FilterConfig, er
 	if !ok {
 		return nil, fmt.Errorf("extauthz: error parsing config %v: unknown type %T, want *anypb.Any", cfg, cfg)
 	}
-	msg := new(v3extauthzfilterpb.ExtAuthz)
+	msg := new(v3extauthzpb.ExtAuthz)
 	if err := m.UnmarshalTo(msg); err != nil {
 		return nil, fmt.Errorf("extauthz: failed to unmarshal config: %v", err)
 	}
@@ -171,7 +171,7 @@ func (builder) ParseFilterConfigOverride(overrideCfg proto.Message) (httpfilter.
 	if !ok {
 		return nil, fmt.Errorf("extauthz: error parsing override config %v: unknown type %T, want *anypb.Any", overrideCfg, overrideCfg)
 	}
-	msg := new(v3extauthzfilterpb.ExtAuthzPerRoute)
+	msg := new(v3extauthzpb.ExtAuthzPerRoute)
 	if err := m.UnmarshalTo(msg); err != nil {
 		return nil, fmt.Errorf("extauthz: failed to unmarshal override config %v: %v", overrideCfg, err)
 	}

--- a/internal/xds/httpfilter/ext_authz/ext_authz.go
+++ b/internal/xds/httpfilter/ext_authz/ext_authz.go
@@ -21,6 +21,7 @@ package extauthz
 
 import (
 	"fmt"
+	"net/http"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/internal/envconfig"
@@ -112,14 +113,14 @@ func (builder) ParseFilterConfig(cfg proto.Message) (httpfilter.FilterConfig, er
 	}
 
 	var denyAtDisable bool
-	if df := msg.GetDenyAtDisable(); df != nil {
-		if df.GetDefaultValue() == nil {
+	if denyAtDisableFlag := msg.GetDenyAtDisable(); denyAtDisableFlag != nil {
+		if denyAtDisableFlag.GetDefaultValue() == nil {
 			return nil, fmt.Errorf("extauthz: missing default_value in deny_at_disable")
 		}
-		denyAtDisable = df.GetDefaultValue().GetValue()
+		denyAtDisable = denyAtDisableFlag.GetDefaultValue().GetValue()
 	}
 
-	httpStatus := int32(403)
+	httpStatus := int32(http.StatusForbidden)
 	if st := msg.GetStatusOnError().GetCode(); st != 0 {
 		httpStatus = int32(st)
 	}
@@ -145,7 +146,7 @@ func (builder) ParseFilterConfig(cfg proto.Message) (httpfilter.FilterConfig, er
 		}
 	}
 
-	return baseConfig{
+	return config{
 		grpcService:                server,
 		filterEnabled:              filterEnabled,
 		denyAtDisable:              denyAtDisable,

--- a/internal/xds/httpfilter/ext_authz/ext_authz_test.go
+++ b/internal/xds/httpfilter/ext_authz/ext_authz_test.go
@@ -1,0 +1,482 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package extauthz
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/internal/grpctest"
+	"google.golang.org/grpc/internal/xds/httpfilter"
+	"google.golang.org/grpc/internal/xds/matcher"
+	"google.golang.org/grpc/internal/xds/xdsclient/xdsresource"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	mutationpb "github.com/envoyproxy/go-control-plane/envoy/config/common/mutation_rules/v3"
+	corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	v3extauthzfilterpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
+	matcherpb "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	v3typepb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+)
+
+type s struct {
+	grpctest.Tester
+}
+
+func Test(t *testing.T) {
+	grpctest.RunSubTests(t, s{})
+}
+
+// testParseGRPCServiceConfig is a helper function that parses a GrpcService
+// proto message into a GRPCServiceConfig. This is a temporary test
+// implementation that will be removed once gRFC A102 is implemented.
+func testParseGRPCServiceConfig(grpcService *corepb.GrpcService) (xdsresource.GRPCServiceConfig, error) {
+	if grpcService == nil {
+		return xdsresource.GRPCServiceConfig{}, nil
+	}
+	if grpcService.GetGoogleGrpc() == nil {
+		return xdsresource.GRPCServiceConfig{}, fmt.Errorf("only google_grpc grpc_service is supported")
+	}
+	if grpcService.GetGoogleGrpc().GetTargetUri() == "" {
+		return xdsresource.GRPCServiceConfig{}, fmt.Errorf("targetURI must be a non-empty string")
+	}
+
+	sc := xdsresource.GRPCServiceConfig{
+		TargetURI: grpcService.GetGoogleGrpc().GetTargetUri(),
+	}
+	return sc, nil
+}
+
+var cmpOpts = []cmp.Option{
+	cmp.AllowUnexported(
+		baseConfig{},
+		xdsresource.GRPCServiceConfig{},
+		fraction{},
+	),
+	protocmp.Transform(),
+	cmp.Transformer("RegexpToString", func(r *regexp.Regexp) string {
+		if r == nil {
+			return ""
+		}
+		return r.String()
+	}),
+	cmp.Comparer(func(x, y matcher.StringMatcher) bool {
+		return x.Equal(y)
+	}),
+}
+
+// Test verifies that ParseFilterConfig successfully parses valid external
+// authorization filter configurations into their internal representation.
+func (s) TestParseFilterConfig_Success(t *testing.T) {
+	origParseGRPCServiceConfig := parseGRPCServiceConfig
+	defer func() { parseGRPCServiceConfig = origParseGRPCServiceConfig }()
+	parseGRPCServiceConfig = testParseGRPCServiceConfig
+
+	tests := []struct {
+		name    string
+		cfg     proto.Message
+		wantCfg httpfilter.FilterConfig
+	}{
+		{
+			name: "DefaultConfig",
+			cfg: func() proto.Message {
+				m, _ := anypb.New(&v3extauthzfilterpb.ExtAuthz{
+					Services: &v3extauthzfilterpb.ExtAuthz_GrpcService{
+						GrpcService: &corepb.GrpcService{
+							TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
+								GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
+									TargetUri: "localhost:1234",
+								},
+							},
+						},
+					},
+				})
+				return m
+			}(),
+			wantCfg: baseConfig{
+				grpcService: xdsresource.GRPCServiceConfig{
+					TargetURI: "localhost:1234",
+				},
+				filterEnabled: fraction{
+					numerator:   100,
+					denominator: 100,
+				},
+			},
+		},
+		{
+			name: "FullConfig",
+			cfg: func() proto.Message {
+				m, _ := anypb.New(&v3extauthzfilterpb.ExtAuthz{
+					Services: &v3extauthzfilterpb.ExtAuthz_GrpcService{
+						GrpcService: &corepb.GrpcService{
+							TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
+								GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
+									TargetUri: "localhost:5678",
+								},
+							},
+						},
+					},
+					FilterEnabled: &corepb.RuntimeFractionalPercent{
+						DefaultValue: &v3typepb.FractionalPercent{
+							Numerator:   50,
+							Denominator: v3typepb.FractionalPercent_TEN_THOUSAND,
+						},
+					},
+					DenyAtDisable: &corepb.RuntimeFeatureFlag{
+						DefaultValue: wrapperspb.Bool(true),
+					},
+					FailureModeAllow:          true,
+					FailureModeAllowHeaderAdd: true,
+					StatusOnError: &v3typepb.HttpStatus{
+						Code: v3typepb.StatusCode_Forbidden,
+					},
+					DecoderHeaderMutationRules: &mutationpb.HeaderMutationRules{
+						AllowExpression:    &matcherpb.RegexMatcher{Regex: ".*"},
+						DisallowExpression: &matcherpb.RegexMatcher{Regex: "a"},
+					},
+					AllowedHeaders: &matcherpb.ListStringMatcher{
+						Patterns: []*matcherpb.StringMatcher{
+							{
+								MatchPattern: &matcherpb.StringMatcher_Exact{Exact: "allow-header"},
+							},
+						},
+					},
+					DisallowedHeaders: &matcherpb.ListStringMatcher{
+						Patterns: []*matcherpb.StringMatcher{
+							{
+								MatchPattern: &matcherpb.StringMatcher_Exact{Exact: "disallow-header"},
+							},
+						},
+					},
+					IncludePeerCertificate: true,
+				})
+				return m
+			}(),
+			wantCfg: baseConfig{
+				grpcService: xdsresource.GRPCServiceConfig{
+					TargetURI: "localhost:5678",
+				},
+				filterEnabled: fraction{
+					numerator:   50,
+					denominator: 10000,
+				},
+				denyAtDisable:             true,
+				failureModeAllow:          true,
+				failureModeAllowHeaderAdd: true,
+				statusOnError:             int32(v3typepb.StatusCode_Forbidden),
+				decoderHeaderMutationRules: httpfilter.HeaderMutationRules{
+					AllowExpr:    regexp.MustCompile("^(?:.*)$"),
+					DisallowExpr: regexp.MustCompile("^(?:a)$"),
+				},
+				allowedHeaders: []matcher.StringMatcher{
+					matcher.NewExactStringMatcher("allow-header", false),
+				},
+				disallowedHeaders: []matcher.StringMatcher{
+					matcher.NewExactStringMatcher("disallow-header", false),
+				},
+				includePeerCertificate: true,
+			},
+		},
+		{
+			name: "FilterEnabled_DenominatorHundred",
+			cfg: func() proto.Message {
+				m, _ := anypb.New(&v3extauthzfilterpb.ExtAuthz{
+					Services: &v3extauthzfilterpb.ExtAuthz_GrpcService{
+						GrpcService: &corepb.GrpcService{
+							TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
+								GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
+									TargetUri: "localhost:1234",
+								},
+							},
+						},
+					},
+					FilterEnabled: &corepb.RuntimeFractionalPercent{
+						DefaultValue: &v3typepb.FractionalPercent{
+							Numerator:   10,
+							Denominator: v3typepb.FractionalPercent_HUNDRED,
+						},
+					},
+				})
+				return m
+			}(),
+			wantCfg: baseConfig{
+				grpcService: xdsresource.GRPCServiceConfig{
+					TargetURI: "localhost:1234",
+				},
+				filterEnabled: fraction{
+					numerator:   10,
+					denominator: 100,
+				},
+			},
+		},
+		{
+			name: "FilterEnabled_DenominatorMillion",
+			cfg: func() proto.Message {
+				m, _ := anypb.New(&v3extauthzfilterpb.ExtAuthz{
+					Services: &v3extauthzfilterpb.ExtAuthz_GrpcService{
+						GrpcService: &corepb.GrpcService{
+							TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
+								GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
+									TargetUri: "localhost:1234",
+								},
+							},
+						},
+					},
+					FilterEnabled: &corepb.RuntimeFractionalPercent{
+						DefaultValue: &v3typepb.FractionalPercent{
+							Numerator:   5,
+							Denominator: v3typepb.FractionalPercent_MILLION,
+						},
+					},
+				})
+				return m
+			}(),
+			wantCfg: baseConfig{
+				grpcService: xdsresource.GRPCServiceConfig{
+					TargetURI: "localhost:1234",
+				},
+				filterEnabled: fraction{
+					numerator:   5,
+					denominator: 1000000,
+				},
+			},
+		},
+		{
+			name: "FilterEnabled_DefaultDenominator",
+			cfg: func() proto.Message {
+				m, _ := anypb.New(&v3extauthzfilterpb.ExtAuthz{
+					Services: &v3extauthzfilterpb.ExtAuthz_GrpcService{
+						GrpcService: &corepb.GrpcService{
+							TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
+								GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
+									TargetUri: "localhost:1234",
+								},
+							},
+						},
+					},
+					FilterEnabled: &corepb.RuntimeFractionalPercent{
+						DefaultValue: &v3typepb.FractionalPercent{
+							Numerator: 25,
+						},
+					},
+				})
+				return m
+			}(),
+			wantCfg: baseConfig{
+				grpcService: xdsresource.GRPCServiceConfig{
+					TargetURI: "localhost:1234",
+				},
+				filterEnabled: fraction{
+					numerator:   25,
+					denominator: 100,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := builder{}
+			got, err := b.ParseFilterConfig(tt.cfg)
+			if err != nil {
+				t.Fatalf("ParseFilterConfig() failed with unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(got, tt.wantCfg, cmpOpts...); diff != "" {
+				t.Fatalf("ParseFilterConfig() returned unexpected config (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+// Test verifies that ParseFilterConfig returns an error when provided with
+// invalid or unsupported configurations.
+func (s) TestParseFilterConfig_Failure(t *testing.T) {
+	origParseGRPCServiceConfig := parseGRPCServiceConfig
+	defer func() { parseGRPCServiceConfig = origParseGRPCServiceConfig }()
+	parseGRPCServiceConfig = testParseGRPCServiceConfig
+
+	tests := []struct {
+		name    string
+		cfg     proto.Message
+		wantErr string
+	}{
+		{
+			name:    "InvalidConfigType",
+			cfg:     &v3extauthzfilterpb.ExtAuthz{},
+			wantErr: "extauthz: error parsing config",
+		},
+		{
+			name: "Config_Unmarshaling_Failed",
+			cfg: &anypb.Any{
+				TypeUrl: "type.googleapis.com/invalid",
+				Value:   []byte("invalid"),
+			},
+			wantErr: "extauthz: failed to unmarshal config",
+		},
+		{
+			name: "MissingGrpcService",
+			cfg: func() proto.Message {
+				m, _ := anypb.New(&v3extauthzfilterpb.ExtAuthz{})
+				return m
+			}(),
+			wantErr: "extauthz: empty grpc_service provided",
+		},
+		{
+			name: "UnsupportedGrpcService_EnvoyGrpc",
+			cfg: func() proto.Message {
+				m, _ := anypb.New(&v3extauthzfilterpb.ExtAuthz{
+					Services: &v3extauthzfilterpb.ExtAuthz_GrpcService{
+						GrpcService: &corepb.GrpcService{
+							TargetSpecifier: &corepb.GrpcService_EnvoyGrpc_{
+								EnvoyGrpc: &corepb.GrpcService_EnvoyGrpc{
+									ClusterName: "cluster",
+								},
+							},
+						},
+					},
+				})
+				return m
+			}(),
+			wantErr: "extauthz: failed to parse grpc_service: only google_grpc grpc_service is supported",
+		},
+		{
+			name: "InvalidServerConfig_EmptyTargetURI",
+			cfg: func() proto.Message {
+				m, _ := anypb.New(&v3extauthzfilterpb.ExtAuthz{
+					Services: &v3extauthzfilterpb.ExtAuthz_GrpcService{
+						GrpcService: &corepb.GrpcService{
+							TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
+								GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
+									TargetUri: "",
+								},
+							},
+						},
+					},
+				})
+				return m
+			}(),
+			wantErr: "extauthz: failed to parse grpc_service: targetURI must be a non-empty string",
+		},
+		{
+			name: "MissingDefaultValueInFilterEnabled",
+			cfg: func() proto.Message {
+				m, _ := anypb.New(&v3extauthzfilterpb.ExtAuthz{
+					Services: &v3extauthzfilterpb.ExtAuthz_GrpcService{
+						GrpcService: &corepb.GrpcService{
+							TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
+								GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
+									TargetUri: "localhost:1234",
+								},
+							},
+						},
+					},
+					FilterEnabled: &corepb.RuntimeFractionalPercent{},
+				})
+				return m
+			}(),
+			wantErr: "extauthz: missing default_value in filter_enabled",
+		},
+		{
+			name: "MissingDefaultValueInDenyAtDisable",
+			cfg: func() proto.Message {
+				m, _ := anypb.New(&v3extauthzfilterpb.ExtAuthz{
+					Services: &v3extauthzfilterpb.ExtAuthz_GrpcService{
+						GrpcService: &corepb.GrpcService{
+							TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
+								GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
+									TargetUri: "localhost:1234",
+								},
+							},
+						},
+					},
+					DenyAtDisable: &corepb.RuntimeFeatureFlag{},
+				})
+				return m
+			}(),
+			wantErr: "extauthz: missing default_value in deny_at_disable",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := builder{}
+			if _, err := b.ParseFilterConfig(tt.cfg); err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ParseFilterConfig() returned error = %v, wantErr containing %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// Test verifies that ParseFilterConfigOverride successfully unmarshals valid
+// per-route override configurations.
+func (s) TestParseFilterConfigOverride_Success(t *testing.T) {
+	override, err := anypb.New(&v3extauthzfilterpb.ExtAuthzPerRoute{
+		Override: &v3extauthzfilterpb.ExtAuthzPerRoute_Disabled{
+			Disabled: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to marshal ExtAuthzPerRoute to anypb.Any: %v", err)
+	}
+
+	b := builder{}
+	got, err := b.ParseFilterConfigOverride(override)
+	if err != nil {
+		t.Fatalf("ParseFilterConfigOverride() failed with unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("ParseFilterConfigOverride() = %v, want nil", got)
+	}
+}
+
+// Test verifies that ParseFilterConfigOverride returns an error when provided
+// with an invalid proto message type or a malformed Any message.
+func (s) TestParseFilterConfigOverride_Failure(t *testing.T) {
+	tests := []struct {
+		name     string
+		override proto.Message
+		wantErr  string
+	}{
+		{
+			name:     "InvalidOverrideType",
+			override: &v3extauthzfilterpb.ExtAuthzPerRoute{},
+			wantErr:  "extauthz: error parsing override config",
+		},
+		{
+			name: "Unmarshal_Failed",
+			override: &anypb.Any{
+				TypeUrl: "type.googleapis.com/invalid",
+				Value:   []byte("invalid"),
+			},
+			wantErr: "extauthz: failed to unmarshal override config",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := builder{}
+			if _, err := b.ParseFilterConfigOverride(tt.override); err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ParseFilterConfigOverride() returned error = %v, wantErr containing %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/xds/httpfilter/ext_authz/ext_authz_test.go
+++ b/internal/xds/httpfilter/ext_authz/ext_authz_test.go
@@ -157,11 +157,9 @@ func (s) TestParseFilterConfig_Success(t *testing.T) {
 						DisallowExpression: &matcherpb.RegexMatcher{Regex: "a"},
 					},
 					AllowedHeaders: &matcherpb.ListStringMatcher{
-						Patterns: []*matcherpb.StringMatcher{
-							{
-								MatchPattern: &matcherpb.StringMatcher_Exact{Exact: "allow-header"},
-							},
-						},
+						Patterns: []*matcherpb.StringMatcher{{
+							MatchPattern: &matcherpb.StringMatcher_Exact{Exact: "allow-header"},
+						}},
 					},
 					DisallowedHeaders: &matcherpb.ListStringMatcher{
 						Patterns: []*matcherpb.StringMatcher{
@@ -290,6 +288,38 @@ func (s) TestParseFilterConfig_Success(t *testing.T) {
 				},
 				filterEnabled: fraction{
 					numerator:   25,
+					denominator: 100,
+				},
+			},
+		},
+		{
+			name: "FilterEnabled_CappedToHundredPercent",
+			cfg: func() proto.Message {
+				m, _ := anypb.New(&v3extauthzfilterpb.ExtAuthz{
+					Services: &v3extauthzfilterpb.ExtAuthz_GrpcService{
+						GrpcService: &corepb.GrpcService{
+							TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
+								GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
+									TargetUri: "localhost:1234",
+								},
+							},
+						},
+					},
+					FilterEnabled: &corepb.RuntimeFractionalPercent{
+						DefaultValue: &v3typepb.FractionalPercent{
+							Numerator:   200,
+							Denominator: v3typepb.FractionalPercent_HUNDRED,
+						},
+					},
+				})
+				return m
+			}(),
+			wantCfg: baseConfig{
+				grpcService: xdsresource.GRPCServiceConfig{
+					TargetURI: "localhost:1234",
+				},
+				filterEnabled: fraction{
+					numerator:   100,
 					denominator: 100,
 				},
 			},

--- a/internal/xds/httpfilter/ext_authz/ext_authz_test.go
+++ b/internal/xds/httpfilter/ext_authz/ext_authz_test.go
@@ -32,13 +32,12 @@ import (
 	"google.golang.org/grpc/internal/xds/matcher"
 	"google.golang.org/grpc/internal/xds/xdsclient/xdsresource"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	mutationpb "github.com/envoyproxy/go-control-plane/envoy/config/common/mutation_rules/v3"
 	corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	v3authzfitlerpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
+	v3extauthzpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
 	matcherpb "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	v3typepb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 )
@@ -73,11 +72,10 @@ func testParseGRPCServiceConfig(grpcService *corepb.GrpcService) (xdsresource.GR
 
 var cmpOpts = []cmp.Option{
 	cmp.AllowUnexported(
-		baseConfig{},
+		config{},
 		xdsresource.GRPCServiceConfig{},
 		fraction{},
 	),
-	protocmp.Transform(),
 	cmp.Transformer("RegexpToString", func(r *regexp.Regexp) string {
 		if r == nil {
 			return ""
@@ -98,13 +96,15 @@ func (s) TestParseFilterConfig_Success(t *testing.T) {
 
 	tests := []struct {
 		name    string
+		desc    string
 		cfg     proto.Message
 		wantCfg httpfilter.FilterConfig
 	}{
 		{
 			name: "DefaultConfig",
-			cfg: testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthz{
-				Services: &v3authzfitlerpb.ExtAuthz_GrpcService{
+			desc: "verifies default fallback values when only grpc_service is provided",
+			cfg: testutils.MarshalAny(t, &v3extauthzpb.ExtAuthz{
+				Services: &v3extauthzpb.ExtAuthz_GrpcService{
 					GrpcService: &corepb.GrpcService{
 						TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
 							GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
@@ -114,7 +114,7 @@ func (s) TestParseFilterConfig_Success(t *testing.T) {
 					},
 				},
 			}),
-			wantCfg: baseConfig{
+			wantCfg: config{
 				grpcService: xdsresource.GRPCServiceConfig{
 					TargetURI: "localhost:1234",
 				},
@@ -127,8 +127,9 @@ func (s) TestParseFilterConfig_Success(t *testing.T) {
 		},
 		{
 			name: "FullConfig",
-			cfg: testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthz{
-				Services: &v3authzfitlerpb.ExtAuthz_GrpcService{
+			desc: "verifies all config fields are parsed and mapped correctly when explicitly configured",
+			cfg: testutils.MarshalAny(t, &v3extauthzpb.ExtAuthz{
+				Services: &v3extauthzpb.ExtAuthz_GrpcService{
 					GrpcService: &corepb.GrpcService{
 						TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
 							GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
@@ -169,7 +170,7 @@ func (s) TestParseFilterConfig_Success(t *testing.T) {
 				},
 				IncludePeerCertificate: true,
 			}),
-			wantCfg: baseConfig{
+			wantCfg: config{
 				grpcService: xdsresource.GRPCServiceConfig{
 					TargetURI: "localhost:5678",
 				},
@@ -194,134 +195,17 @@ func (s) TestParseFilterConfig_Success(t *testing.T) {
 				includePeerCertificate: true,
 			},
 		},
-		{
-			name: "FilterEnabled_DenominatorHundred",
-			cfg: testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthz{
-				Services: &v3authzfitlerpb.ExtAuthz_GrpcService{
-					GrpcService: &corepb.GrpcService{
-						TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
-							GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
-								TargetUri: "localhost:1234",
-							},
-						},
-					},
-				},
-				FilterEnabled: &corepb.RuntimeFractionalPercent{
-					DefaultValue: &v3typepb.FractionalPercent{
-						Numerator:   10,
-						Denominator: v3typepb.FractionalPercent_HUNDRED,
-					},
-				},
-			}),
-			wantCfg: baseConfig{
-				grpcService: xdsresource.GRPCServiceConfig{
-					TargetURI: "localhost:1234",
-				},
-				filterEnabled: fraction{
-					numerator:   10,
-					denominator: 100,
-				},
-				statusOnError: codes.PermissionDenied,
-			},
-		},
-		{
-			name: "FilterEnabled_DenominatorMillion",
-			cfg: testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthz{
-				Services: &v3authzfitlerpb.ExtAuthz_GrpcService{
-					GrpcService: &corepb.GrpcService{
-						TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
-							GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
-								TargetUri: "localhost:1234",
-							},
-						},
-					},
-				},
-				FilterEnabled: &corepb.RuntimeFractionalPercent{
-					DefaultValue: &v3typepb.FractionalPercent{
-						Numerator:   5,
-						Denominator: v3typepb.FractionalPercent_MILLION,
-					},
-				},
-			}),
-			wantCfg: baseConfig{
-				grpcService: xdsresource.GRPCServiceConfig{
-					TargetURI: "localhost:1234",
-				},
-				filterEnabled: fraction{
-					numerator:   5,
-					denominator: 1000000,
-				},
-				statusOnError: codes.PermissionDenied,
-			},
-		},
-		{
-			name: "FilterEnabled_DefaultDenominator",
-			cfg: testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthz{
-				Services: &v3authzfitlerpb.ExtAuthz_GrpcService{
-					GrpcService: &corepb.GrpcService{
-						TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
-							GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
-								TargetUri: "localhost:1234",
-							},
-						},
-					},
-				},
-				FilterEnabled: &corepb.RuntimeFractionalPercent{
-					DefaultValue: &v3typepb.FractionalPercent{
-						Numerator: 25,
-					},
-				},
-			}),
-			wantCfg: baseConfig{
-				grpcService: xdsresource.GRPCServiceConfig{
-					TargetURI: "localhost:1234",
-				},
-				filterEnabled: fraction{
-					numerator:   25,
-					denominator: 100,
-				},
-				statusOnError: codes.PermissionDenied,
-			},
-		},
-		{
-			name: "FilterEnabled_CappedToHundredPercent",
-			cfg: testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthz{
-				Services: &v3authzfitlerpb.ExtAuthz_GrpcService{
-					GrpcService: &corepb.GrpcService{
-						TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
-							GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
-								TargetUri: "localhost:1234",
-							},
-						},
-					},
-				},
-				FilterEnabled: &corepb.RuntimeFractionalPercent{
-					DefaultValue: &v3typepb.FractionalPercent{
-						Numerator:   200,
-						Denominator: v3typepb.FractionalPercent_HUNDRED,
-					},
-				},
-			}),
-			wantCfg: baseConfig{
-				grpcService: xdsresource.GRPCServiceConfig{
-					TargetURI: "localhost:1234",
-				},
-				filterEnabled: fraction{
-					numerator:   100,
-					denominator: 100,
-				},
-				statusOnError: codes.PermissionDenied,
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := builder{}
 			got, err := b.ParseFilterConfig(tt.cfg)
 			if err != nil {
+				t.Log(tt.desc)
 				t.Fatalf("ParseFilterConfig() failed with unexpected error: %v", err)
 			}
 			if diff := cmp.Diff(tt.wantCfg, got, cmpOpts...); diff != "" {
+				t.Log(tt.desc)
 				t.Fatalf("ParseFilterConfig() returned unexpected config (-want, +got):\n%s", diff)
 			}
 		})
@@ -337,16 +221,19 @@ func (s) TestParseFilterConfig_Failure(t *testing.T) {
 
 	tests := []struct {
 		name    string
+		desc    string
 		cfg     proto.Message
 		wantErr string
 	}{
 		{
 			name:    "InvalidConfigType",
-			cfg:     &v3authzfitlerpb.ExtAuthz{},
+			desc:    "verifies error when input message is not a valid proto message",
+			cfg:     &v3extauthzpb.ExtAuthz{},
 			wantErr: "extauthz: error parsing config",
 		},
 		{
 			name: "Config_Unmarshaling_Failed",
+			desc: "verifies error when input proto message cannot be unmarshaled into an ExtAuthz message",
 			cfg: &anypb.Any{
 				TypeUrl: "type.googleapis.com/invalid",
 				Value:   []byte("invalid"),
@@ -355,13 +242,15 @@ func (s) TestParseFilterConfig_Failure(t *testing.T) {
 		},
 		{
 			name:    "MissingGrpcService",
-			cfg:     testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthz{}),
+			desc:    "verifies error when required grpc_service is missing",
+			cfg:     testutils.MarshalAny(t, &v3extauthzpb.ExtAuthz{}),
 			wantErr: "extauthz: empty grpc_service provided",
 		},
 		{
 			name: "UnsupportedGrpcService_EnvoyGrpc",
-			cfg: testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthz{
-				Services: &v3authzfitlerpb.ExtAuthz_GrpcService{
+			desc: "verifies error when unsupported envoy_grpc service is used",
+			cfg: testutils.MarshalAny(t, &v3extauthzpb.ExtAuthz{
+				Services: &v3extauthzpb.ExtAuthz_GrpcService{
 					GrpcService: &corepb.GrpcService{
 						TargetSpecifier: &corepb.GrpcService_EnvoyGrpc_{
 							EnvoyGrpc: &corepb.GrpcService_EnvoyGrpc{
@@ -375,8 +264,9 @@ func (s) TestParseFilterConfig_Failure(t *testing.T) {
 		},
 		{
 			name: "InvalidServerConfig_EmptyTargetURI",
-			cfg: testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthz{
-				Services: &v3authzfitlerpb.ExtAuthz_GrpcService{
+			desc: "verifies error when google_grpc has empty target URI",
+			cfg: testutils.MarshalAny(t, &v3extauthzpb.ExtAuthz{
+				Services: &v3extauthzpb.ExtAuthz_GrpcService{
 					GrpcService: &corepb.GrpcService{
 						TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
 							GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
@@ -390,8 +280,9 @@ func (s) TestParseFilterConfig_Failure(t *testing.T) {
 		},
 		{
 			name: "MissingDefaultValueInFilterEnabled",
-			cfg: testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthz{
-				Services: &v3authzfitlerpb.ExtAuthz_GrpcService{
+			desc: "verifies error when filter_enabled lacks default value",
+			cfg: testutils.MarshalAny(t, &v3extauthzpb.ExtAuthz{
+				Services: &v3extauthzpb.ExtAuthz_GrpcService{
 					GrpcService: &corepb.GrpcService{
 						TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
 							GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
@@ -406,8 +297,9 @@ func (s) TestParseFilterConfig_Failure(t *testing.T) {
 		},
 		{
 			name: "MissingDefaultValueInDenyAtDisable",
-			cfg: testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthz{
-				Services: &v3authzfitlerpb.ExtAuthz_GrpcService{
+			desc: "verifies error when deny_at_disable lacks default value",
+			cfg: testutils.MarshalAny(t, &v3extauthzpb.ExtAuthz{
+				Services: &v3extauthzpb.ExtAuthz_GrpcService{
 					GrpcService: &corepb.GrpcService{
 						TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
 							GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
@@ -425,6 +317,7 @@ func (s) TestParseFilterConfig_Failure(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := builder{}
 			if _, err := b.ParseFilterConfig(tt.cfg); err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Log(tt.desc)
 				t.Fatalf("ParseFilterConfig() returned error = %v, wantErr containing %v", err, tt.wantErr)
 			}
 		})
@@ -434,8 +327,8 @@ func (s) TestParseFilterConfig_Failure(t *testing.T) {
 // Test verifies that ParseFilterConfigOverride successfully unmarshals valid
 // per-route override configurations.
 func (s) TestParseFilterConfigOverride_Success(t *testing.T) {
-	override := testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthzPerRoute{
-		Override: &v3authzfitlerpb.ExtAuthzPerRoute_Disabled{
+	override := testutils.MarshalAny(t, &v3extauthzpb.ExtAuthzPerRoute{
+		Override: &v3extauthzpb.ExtAuthzPerRoute_Disabled{
 			Disabled: true,
 		},
 	})
@@ -455,16 +348,19 @@ func (s) TestParseFilterConfigOverride_Success(t *testing.T) {
 func (s) TestParseFilterConfigOverride_Failure(t *testing.T) {
 	tests := []struct {
 		name     string
+		desc     string
 		override proto.Message
 		wantErr  string
 	}{
 		{
 			name:     "InvalidOverrideType",
-			override: &v3authzfitlerpb.ExtAuthzPerRoute{},
+			desc:     "verifies error when input override is not an Any message",
+			override: &v3extauthzpb.ExtAuthzPerRoute{},
 			wantErr:  "extauthz: error parsing override config",
 		},
 		{
 			name: "Unmarshal_Failed",
+			desc: "verifies error when Any message unmarshal to ExtAuthzPerRoute fails",
 			override: &anypb.Any{
 				TypeUrl: "type.googleapis.com/invalid",
 				Value:   []byte("invalid"),
@@ -476,7 +372,74 @@ func (s) TestParseFilterConfigOverride_Failure(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := builder{}
 			if _, err := b.ParseFilterConfigOverride(tt.override); err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Log(tt.desc)
 				t.Fatalf("ParseFilterConfigOverride() returned error = %v, wantErr containing %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// Test verifies that parseFilterEnabled correctly parses the
+// RuntimeFractionalPercent configuration into its internal representation.
+func (s) TestParseFilterEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		fp   *corepb.RuntimeFractionalPercent
+		want fraction
+	}{
+		{
+			name: "NilFraction",
+			fp:   nil,
+			want: fraction{numerator: 100, denominator: 100},
+		},
+		{
+			name: "DenominatorHundred",
+			fp: &corepb.RuntimeFractionalPercent{
+				DefaultValue: &v3typepb.FractionalPercent{
+					Numerator:   10,
+					Denominator: v3typepb.FractionalPercent_HUNDRED,
+				},
+			},
+			want: fraction{numerator: 10, denominator: 100},
+		},
+		{
+			name: "DenominatorMillion",
+			fp: &corepb.RuntimeFractionalPercent{
+				DefaultValue: &v3typepb.FractionalPercent{
+					Numerator:   5,
+					Denominator: v3typepb.FractionalPercent_MILLION,
+				},
+			},
+			want: fraction{numerator: 5, denominator: 1000000},
+		},
+		{
+			name: "DefaultDenominator",
+			fp: &corepb.RuntimeFractionalPercent{
+				DefaultValue: &v3typepb.FractionalPercent{
+					Numerator: 25,
+				},
+			},
+			want: fraction{numerator: 25, denominator: 100},
+		},
+		{
+			name: "CappedToHundredPercent",
+			fp: &corepb.RuntimeFractionalPercent{
+				DefaultValue: &v3typepb.FractionalPercent{
+					Numerator:   200,
+					Denominator: v3typepb.FractionalPercent_HUNDRED,
+				},
+			},
+			want: fraction{numerator: 100, denominator: 100},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseFilterEnabled(tt.fp)
+			if err != nil {
+				t.Fatalf("parseFilterEnabled(%v) failed: %v", tt.fp, err)
+			}
+			if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(fraction{})); diff != "" {
+				t.Fatalf("parseFilterEnabled(%v) returned unexpected fraction (-want, +got):\n%s", tt.fp, diff)
 			}
 		})
 	}

--- a/internal/xds/httpfilter/ext_authz/ext_authz_test.go
+++ b/internal/xds/httpfilter/ext_authz/ext_authz_test.go
@@ -198,14 +198,13 @@ func (s) TestParseFilterConfig_Success(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Log(tt.desc)
 			b := builder{}
 			got, err := b.ParseFilterConfig(tt.cfg)
 			if err != nil {
-				t.Log(tt.desc)
 				t.Fatalf("ParseFilterConfig() failed with unexpected error: %v", err)
 			}
 			if diff := cmp.Diff(tt.wantCfg, got, cmpOpts...); diff != "" {
-				t.Log(tt.desc)
 				t.Fatalf("ParseFilterConfig() returned unexpected config (-want, +got):\n%s", diff)
 			}
 		})
@@ -315,9 +314,9 @@ func (s) TestParseFilterConfig_Failure(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Log(tt.desc)
 			b := builder{}
 			if _, err := b.ParseFilterConfig(tt.cfg); err == nil || !strings.Contains(err.Error(), tt.wantErr) {
-				t.Log(tt.desc)
 				t.Fatalf("ParseFilterConfig() returned error = %v, wantErr containing %v", err, tt.wantErr)
 			}
 		})
@@ -370,9 +369,9 @@ func (s) TestParseFilterConfigOverride_Failure(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Log(tt.desc)
 			b := builder{}
 			if _, err := b.ParseFilterConfigOverride(tt.override); err == nil || !strings.Contains(err.Error(), tt.wantErr) {
-				t.Log(tt.desc)
 				t.Fatalf("ParseFilterConfigOverride() returned error = %v, wantErr containing %v", err, tt.wantErr)
 			}
 		})

--- a/internal/xds/httpfilter/ext_authz/ext_authz_test.go
+++ b/internal/xds/httpfilter/ext_authz/ext_authz_test.go
@@ -25,7 +25,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/internal/grpctest"
+	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/xds/httpfilter"
 	"google.golang.org/grpc/internal/xds/matcher"
 	"google.golang.org/grpc/internal/xds/xdsclient/xdsresource"
@@ -36,7 +38,7 @@ import (
 
 	mutationpb "github.com/envoyproxy/go-control-plane/envoy/config/common/mutation_rules/v3"
 	corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	v3extauthzfilterpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
+	v3authzfitlerpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
 	matcherpb "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	v3typepb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 )
@@ -101,20 +103,17 @@ func (s) TestParseFilterConfig_Success(t *testing.T) {
 	}{
 		{
 			name: "DefaultConfig",
-			cfg: func() proto.Message {
-				m, _ := anypb.New(&v3extauthzfilterpb.ExtAuthz{
-					Services: &v3extauthzfilterpb.ExtAuthz_GrpcService{
-						GrpcService: &corepb.GrpcService{
-							TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
-								GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
-									TargetUri: "localhost:1234",
-								},
+			cfg: testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthz{
+				Services: &v3authzfitlerpb.ExtAuthz_GrpcService{
+					GrpcService: &corepb.GrpcService{
+						TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
+							GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
+								TargetUri: "localhost:1234",
 							},
 						},
 					},
-				})
-				return m
-			}(),
+				},
+			}),
 			wantCfg: baseConfig{
 				grpcService: xdsresource.GRPCServiceConfig{
 					TargetURI: "localhost:1234",
@@ -123,55 +122,53 @@ func (s) TestParseFilterConfig_Success(t *testing.T) {
 					numerator:   100,
 					denominator: 100,
 				},
+				statusOnError: codes.PermissionDenied,
 			},
 		},
 		{
 			name: "FullConfig",
-			cfg: func() proto.Message {
-				m, _ := anypb.New(&v3extauthzfilterpb.ExtAuthz{
-					Services: &v3extauthzfilterpb.ExtAuthz_GrpcService{
-						GrpcService: &corepb.GrpcService{
-							TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
-								GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
-									TargetUri: "localhost:5678",
-								},
+			cfg: testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthz{
+				Services: &v3authzfitlerpb.ExtAuthz_GrpcService{
+					GrpcService: &corepb.GrpcService{
+						TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
+							GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
+								TargetUri: "localhost:5678",
 							},
 						},
 					},
-					FilterEnabled: &corepb.RuntimeFractionalPercent{
-						DefaultValue: &v3typepb.FractionalPercent{
-							Numerator:   50,
-							Denominator: v3typepb.FractionalPercent_TEN_THOUSAND,
+				},
+				FilterEnabled: &corepb.RuntimeFractionalPercent{
+					DefaultValue: &v3typepb.FractionalPercent{
+						Numerator:   50,
+						Denominator: v3typepb.FractionalPercent_TEN_THOUSAND,
+					},
+				},
+				DenyAtDisable: &corepb.RuntimeFeatureFlag{
+					DefaultValue: wrapperspb.Bool(true),
+				},
+				FailureModeAllow:          true,
+				FailureModeAllowHeaderAdd: true,
+				StatusOnError: &v3typepb.HttpStatus{
+					Code: v3typepb.StatusCode_Unauthorized,
+				},
+				DecoderHeaderMutationRules: &mutationpb.HeaderMutationRules{
+					AllowExpression:    &matcherpb.RegexMatcher{Regex: ".*"},
+					DisallowExpression: &matcherpb.RegexMatcher{Regex: "a"},
+				},
+				AllowedHeaders: &matcherpb.ListStringMatcher{
+					Patterns: []*matcherpb.StringMatcher{{
+						MatchPattern: &matcherpb.StringMatcher_Exact{Exact: "allow-header"},
+					}},
+				},
+				DisallowedHeaders: &matcherpb.ListStringMatcher{
+					Patterns: []*matcherpb.StringMatcher{
+						{
+							MatchPattern: &matcherpb.StringMatcher_Exact{Exact: "disallow-header"},
 						},
 					},
-					DenyAtDisable: &corepb.RuntimeFeatureFlag{
-						DefaultValue: wrapperspb.Bool(true),
-					},
-					FailureModeAllow:          true,
-					FailureModeAllowHeaderAdd: true,
-					StatusOnError: &v3typepb.HttpStatus{
-						Code: v3typepb.StatusCode_Forbidden,
-					},
-					DecoderHeaderMutationRules: &mutationpb.HeaderMutationRules{
-						AllowExpression:    &matcherpb.RegexMatcher{Regex: ".*"},
-						DisallowExpression: &matcherpb.RegexMatcher{Regex: "a"},
-					},
-					AllowedHeaders: &matcherpb.ListStringMatcher{
-						Patterns: []*matcherpb.StringMatcher{{
-							MatchPattern: &matcherpb.StringMatcher_Exact{Exact: "allow-header"},
-						}},
-					},
-					DisallowedHeaders: &matcherpb.ListStringMatcher{
-						Patterns: []*matcherpb.StringMatcher{
-							{
-								MatchPattern: &matcherpb.StringMatcher_Exact{Exact: "disallow-header"},
-							},
-						},
-					},
-					IncludePeerCertificate: true,
-				})
-				return m
-			}(),
+				},
+				IncludePeerCertificate: true,
+			}),
 			wantCfg: baseConfig{
 				grpcService: xdsresource.GRPCServiceConfig{
 					TargetURI: "localhost:5678",
@@ -183,7 +180,7 @@ func (s) TestParseFilterConfig_Success(t *testing.T) {
 				denyAtDisable:             true,
 				failureModeAllow:          true,
 				failureModeAllowHeaderAdd: true,
-				statusOnError:             int32(v3typepb.StatusCode_Forbidden),
+				statusOnError:             codes.Unauthenticated,
 				decoderHeaderMutationRules: httpfilter.HeaderMutationRules{
 					AllowExpr:    regexp.MustCompile("^(?:.*)$"),
 					DisallowExpr: regexp.MustCompile("^(?:a)$"),
@@ -199,26 +196,23 @@ func (s) TestParseFilterConfig_Success(t *testing.T) {
 		},
 		{
 			name: "FilterEnabled_DenominatorHundred",
-			cfg: func() proto.Message {
-				m, _ := anypb.New(&v3extauthzfilterpb.ExtAuthz{
-					Services: &v3extauthzfilterpb.ExtAuthz_GrpcService{
-						GrpcService: &corepb.GrpcService{
-							TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
-								GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
-									TargetUri: "localhost:1234",
-								},
+			cfg: testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthz{
+				Services: &v3authzfitlerpb.ExtAuthz_GrpcService{
+					GrpcService: &corepb.GrpcService{
+						TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
+							GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
+								TargetUri: "localhost:1234",
 							},
 						},
 					},
-					FilterEnabled: &corepb.RuntimeFractionalPercent{
-						DefaultValue: &v3typepb.FractionalPercent{
-							Numerator:   10,
-							Denominator: v3typepb.FractionalPercent_HUNDRED,
-						},
+				},
+				FilterEnabled: &corepb.RuntimeFractionalPercent{
+					DefaultValue: &v3typepb.FractionalPercent{
+						Numerator:   10,
+						Denominator: v3typepb.FractionalPercent_HUNDRED,
 					},
-				})
-				return m
-			}(),
+				},
+			}),
 			wantCfg: baseConfig{
 				grpcService: xdsresource.GRPCServiceConfig{
 					TargetURI: "localhost:1234",
@@ -227,30 +221,28 @@ func (s) TestParseFilterConfig_Success(t *testing.T) {
 					numerator:   10,
 					denominator: 100,
 				},
+				statusOnError: codes.PermissionDenied,
 			},
 		},
 		{
 			name: "FilterEnabled_DenominatorMillion",
-			cfg: func() proto.Message {
-				m, _ := anypb.New(&v3extauthzfilterpb.ExtAuthz{
-					Services: &v3extauthzfilterpb.ExtAuthz_GrpcService{
-						GrpcService: &corepb.GrpcService{
-							TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
-								GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
-									TargetUri: "localhost:1234",
-								},
+			cfg: testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthz{
+				Services: &v3authzfitlerpb.ExtAuthz_GrpcService{
+					GrpcService: &corepb.GrpcService{
+						TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
+							GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
+								TargetUri: "localhost:1234",
 							},
 						},
 					},
-					FilterEnabled: &corepb.RuntimeFractionalPercent{
-						DefaultValue: &v3typepb.FractionalPercent{
-							Numerator:   5,
-							Denominator: v3typepb.FractionalPercent_MILLION,
-						},
+				},
+				FilterEnabled: &corepb.RuntimeFractionalPercent{
+					DefaultValue: &v3typepb.FractionalPercent{
+						Numerator:   5,
+						Denominator: v3typepb.FractionalPercent_MILLION,
 					},
-				})
-				return m
-			}(),
+				},
+			}),
 			wantCfg: baseConfig{
 				grpcService: xdsresource.GRPCServiceConfig{
 					TargetURI: "localhost:1234",
@@ -259,29 +251,27 @@ func (s) TestParseFilterConfig_Success(t *testing.T) {
 					numerator:   5,
 					denominator: 1000000,
 				},
+				statusOnError: codes.PermissionDenied,
 			},
 		},
 		{
 			name: "FilterEnabled_DefaultDenominator",
-			cfg: func() proto.Message {
-				m, _ := anypb.New(&v3extauthzfilterpb.ExtAuthz{
-					Services: &v3extauthzfilterpb.ExtAuthz_GrpcService{
-						GrpcService: &corepb.GrpcService{
-							TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
-								GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
-									TargetUri: "localhost:1234",
-								},
+			cfg: testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthz{
+				Services: &v3authzfitlerpb.ExtAuthz_GrpcService{
+					GrpcService: &corepb.GrpcService{
+						TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
+							GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
+								TargetUri: "localhost:1234",
 							},
 						},
 					},
-					FilterEnabled: &corepb.RuntimeFractionalPercent{
-						DefaultValue: &v3typepb.FractionalPercent{
-							Numerator: 25,
-						},
+				},
+				FilterEnabled: &corepb.RuntimeFractionalPercent{
+					DefaultValue: &v3typepb.FractionalPercent{
+						Numerator: 25,
 					},
-				})
-				return m
-			}(),
+				},
+			}),
 			wantCfg: baseConfig{
 				grpcService: xdsresource.GRPCServiceConfig{
 					TargetURI: "localhost:1234",
@@ -290,30 +280,28 @@ func (s) TestParseFilterConfig_Success(t *testing.T) {
 					numerator:   25,
 					denominator: 100,
 				},
+				statusOnError: codes.PermissionDenied,
 			},
 		},
 		{
 			name: "FilterEnabled_CappedToHundredPercent",
-			cfg: func() proto.Message {
-				m, _ := anypb.New(&v3extauthzfilterpb.ExtAuthz{
-					Services: &v3extauthzfilterpb.ExtAuthz_GrpcService{
-						GrpcService: &corepb.GrpcService{
-							TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
-								GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
-									TargetUri: "localhost:1234",
-								},
+			cfg: testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthz{
+				Services: &v3authzfitlerpb.ExtAuthz_GrpcService{
+					GrpcService: &corepb.GrpcService{
+						TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
+							GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
+								TargetUri: "localhost:1234",
 							},
 						},
 					},
-					FilterEnabled: &corepb.RuntimeFractionalPercent{
-						DefaultValue: &v3typepb.FractionalPercent{
-							Numerator:   200,
-							Denominator: v3typepb.FractionalPercent_HUNDRED,
-						},
+				},
+				FilterEnabled: &corepb.RuntimeFractionalPercent{
+					DefaultValue: &v3typepb.FractionalPercent{
+						Numerator:   200,
+						Denominator: v3typepb.FractionalPercent_HUNDRED,
 					},
-				})
-				return m
-			}(),
+				},
+			}),
 			wantCfg: baseConfig{
 				grpcService: xdsresource.GRPCServiceConfig{
 					TargetURI: "localhost:1234",
@@ -322,6 +310,7 @@ func (s) TestParseFilterConfig_Success(t *testing.T) {
 					numerator:   100,
 					denominator: 100,
 				},
+				statusOnError: codes.PermissionDenied,
 			},
 		},
 	}
@@ -332,8 +321,8 @@ func (s) TestParseFilterConfig_Success(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ParseFilterConfig() failed with unexpected error: %v", err)
 			}
-			if diff := cmp.Diff(got, tt.wantCfg, cmpOpts...); diff != "" {
-				t.Fatalf("ParseFilterConfig() returned unexpected config (-got +want):\n%s", diff)
+			if diff := cmp.Diff(tt.wantCfg, got, cmpOpts...); diff != "" {
+				t.Fatalf("ParseFilterConfig() returned unexpected config (-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -353,7 +342,7 @@ func (s) TestParseFilterConfig_Failure(t *testing.T) {
 	}{
 		{
 			name:    "InvalidConfigType",
-			cfg:     &v3extauthzfilterpb.ExtAuthz{},
+			cfg:     &v3authzfitlerpb.ExtAuthz{},
 			wantErr: "extauthz: error parsing config",
 		},
 		{
@@ -365,85 +354,70 @@ func (s) TestParseFilterConfig_Failure(t *testing.T) {
 			wantErr: "extauthz: failed to unmarshal config",
 		},
 		{
-			name: "MissingGrpcService",
-			cfg: func() proto.Message {
-				m, _ := anypb.New(&v3extauthzfilterpb.ExtAuthz{})
-				return m
-			}(),
+			name:    "MissingGrpcService",
+			cfg:     testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthz{}),
 			wantErr: "extauthz: empty grpc_service provided",
 		},
 		{
 			name: "UnsupportedGrpcService_EnvoyGrpc",
-			cfg: func() proto.Message {
-				m, _ := anypb.New(&v3extauthzfilterpb.ExtAuthz{
-					Services: &v3extauthzfilterpb.ExtAuthz_GrpcService{
-						GrpcService: &corepb.GrpcService{
-							TargetSpecifier: &corepb.GrpcService_EnvoyGrpc_{
-								EnvoyGrpc: &corepb.GrpcService_EnvoyGrpc{
-									ClusterName: "cluster",
-								},
+			cfg: testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthz{
+				Services: &v3authzfitlerpb.ExtAuthz_GrpcService{
+					GrpcService: &corepb.GrpcService{
+						TargetSpecifier: &corepb.GrpcService_EnvoyGrpc_{
+							EnvoyGrpc: &corepb.GrpcService_EnvoyGrpc{
+								ClusterName: "cluster",
 							},
 						},
 					},
-				})
-				return m
-			}(),
+				},
+			}),
 			wantErr: "extauthz: failed to parse grpc_service: only google_grpc grpc_service is supported",
 		},
 		{
 			name: "InvalidServerConfig_EmptyTargetURI",
-			cfg: func() proto.Message {
-				m, _ := anypb.New(&v3extauthzfilterpb.ExtAuthz{
-					Services: &v3extauthzfilterpb.ExtAuthz_GrpcService{
-						GrpcService: &corepb.GrpcService{
-							TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
-								GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
-									TargetUri: "",
-								},
+			cfg: testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthz{
+				Services: &v3authzfitlerpb.ExtAuthz_GrpcService{
+					GrpcService: &corepb.GrpcService{
+						TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
+							GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
+								TargetUri: "",
 							},
 						},
 					},
-				})
-				return m
-			}(),
+				},
+			}),
 			wantErr: "extauthz: failed to parse grpc_service: targetURI must be a non-empty string",
 		},
 		{
 			name: "MissingDefaultValueInFilterEnabled",
-			cfg: func() proto.Message {
-				m, _ := anypb.New(&v3extauthzfilterpb.ExtAuthz{
-					Services: &v3extauthzfilterpb.ExtAuthz_GrpcService{
-						GrpcService: &corepb.GrpcService{
-							TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
-								GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
-									TargetUri: "localhost:1234",
-								},
+			cfg: testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthz{
+				Services: &v3authzfitlerpb.ExtAuthz_GrpcService{
+					GrpcService: &corepb.GrpcService{
+						TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
+							GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
+								TargetUri: "localhost:1234",
 							},
 						},
 					},
-					FilterEnabled: &corepb.RuntimeFractionalPercent{},
-				})
-				return m
-			}(),
+				},
+				FilterEnabled: &corepb.RuntimeFractionalPercent{},
+			}),
 			wantErr: "extauthz: missing default_value in filter_enabled",
 		},
 		{
 			name: "MissingDefaultValueInDenyAtDisable",
-			cfg: func() proto.Message {
-				m, _ := anypb.New(&v3extauthzfilterpb.ExtAuthz{
-					Services: &v3extauthzfilterpb.ExtAuthz_GrpcService{
-						GrpcService: &corepb.GrpcService{
-							TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
-								GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
-									TargetUri: "localhost:1234",
-								},
+			cfg: testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthz{
+				Services: &v3authzfitlerpb.ExtAuthz_GrpcService{
+					GrpcService: &corepb.GrpcService{
+						TargetSpecifier: &corepb.GrpcService_GoogleGrpc_{
+							GoogleGrpc: &corepb.GrpcService_GoogleGrpc{
+								TargetUri: "localhost:1234",
 							},
 						},
 					},
-					DenyAtDisable: &corepb.RuntimeFeatureFlag{},
-				})
-				return m
-			}(),
+				},
+				DenyAtDisable: &corepb.RuntimeFeatureFlag{},
+			}),
 			wantErr: "extauthz: missing default_value in deny_at_disable",
 		},
 	}
@@ -460,14 +434,11 @@ func (s) TestParseFilterConfig_Failure(t *testing.T) {
 // Test verifies that ParseFilterConfigOverride successfully unmarshals valid
 // per-route override configurations.
 func (s) TestParseFilterConfigOverride_Success(t *testing.T) {
-	override, err := anypb.New(&v3extauthzfilterpb.ExtAuthzPerRoute{
-		Override: &v3extauthzfilterpb.ExtAuthzPerRoute_Disabled{
+	override := testutils.MarshalAny(t, &v3authzfitlerpb.ExtAuthzPerRoute{
+		Override: &v3authzfitlerpb.ExtAuthzPerRoute_Disabled{
 			Disabled: true,
 		},
 	})
-	if err != nil {
-		t.Fatalf("Failed to marshal ExtAuthzPerRoute to anypb.Any: %v", err)
-	}
 
 	b := builder{}
 	got, err := b.ParseFilterConfigOverride(override)
@@ -489,7 +460,7 @@ func (s) TestParseFilterConfigOverride_Failure(t *testing.T) {
 	}{
 		{
 			name:     "InvalidOverrideType",
-			override: &v3extauthzfilterpb.ExtAuthzPerRoute{},
+			override: &v3authzfitlerpb.ExtAuthzPerRoute{},
 			wantErr:  "extauthz: error parsing override config",
 		},
 		{

--- a/internal/xds/xdsclient/xdsresource/unmarshal_lds.go
+++ b/internal/xds/xdsclient/xdsresource/unmarshal_lds.go
@@ -187,7 +187,7 @@ func processHTTPFilterOverrides(cfgs map[string]*anypb.Any) (map[string]httpfilt
 			}
 			cfg = s.GetConfig()
 			optional = s.GetIsOptional()
-			if envconfig.XDSClientExtProcEnabled {
+			if envconfig.XDSClientExtProcEnabled || envconfig.XDSClientExtAuthzEnabled {
 				disabled = s.GetDisabled()
 			}
 		}
@@ -246,7 +246,7 @@ func processHTTPFilters(filters []*v3httppb.HttpFilter, server bool) ([]HTTPFilt
 		}
 
 		disabled := false
-		if envconfig.XDSClientExtProcEnabled {
+		if envconfig.XDSClientExtProcEnabled || envconfig.XDSClientExtAuthzEnabled {
 			disabled = filter.GetDisabled()
 		}
 		// Save name/config


### PR DESCRIPTION
This PR implements configuration parsing for the xDS External Authorization (ext_authz) HTTP filter as specified in gRFC [A92: xds-ext-authz](https://github.com/grpc/proposal/blob/master/A92-xds-ext-authz.md).

This PR adds the ext_authz filter parsing and validating the base and the override config. The registration of the filter is under the `GRPC_EXPERIMENTAL_XDS_EXT_AUTHZ_ON_CLIENT` flag.

#ext-authz-a92

RELEASE NOTES: None