### PR TITLE
security/advancedtls: add SkipServerAuthEKU option to bypass server EKU verification

### DIFF
--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -226,6 +226,9 @@ type Options struct {
 	// name of authority (e.g. :authority header field) in requests and the
 	// target hostname used during server cert verification.
 	serverNameOverride string
+	// SkipServerAuthEKU if set to true, skips EKU check during server authentication.
+	// This is useful when the server certificate does not have the Server Auth EKU.
+	SkipServerAuthEKU bool
 }
 
 func (o *Options) clientConfig() (*tls.Config, error) {
@@ -417,6 +420,7 @@ type advancedTLSCreds struct {
 	isClient            bool
 	revocationOptions   *RevocationOptions
 	verificationType    VerificationType
+	skipServerAuthEKU   bool
 }
 
 func (c advancedTLSCreds) Info() credentials.ProtocolInfo {
@@ -489,6 +493,9 @@ func (c *advancedTLSCreds) Clone() credentials.TransportCredentials {
 		verifyFunc:          c.verifyFunc,
 		getRootCertificates: c.getRootCertificates,
 		isClient:            c.isClient,
+		revocationOptions:   c.revocationOptions,
+		verificationType:    c.verificationType,
+		skipServerAuthEKU:   c.skipServerAuthEKU,
 	}
 }
 
@@ -546,7 +553,9 @@ func buildVerifyFunc(c *advancedTLSCreds,
 			}
 			// Verify peers' certificates against RootCAs and get verifiedChains.
 			keyUsages := []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
-			if !c.isClient {
+			if c.isClient && c.skipServerAuthEKU {
+				keyUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageAny}
+			} else if !c.isClient {
 				keyUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
 			}
 			opts := x509.VerifyOptions{
@@ -616,6 +625,7 @@ func NewClientCreds(o *Options) (credentials.TransportCredentials, error) {
 		verifyFunc:          o.AdditionalPeerVerification,
 		revocationOptions:   o.RevocationOptions,
 		verificationType:    o.VerificationType,
+		skipServerAuthEKU:   o.SkipServerAuthEKU,
 	}
 	tc.config.NextProtos = credinternal.AppendH2ToNextProtos(tc.config.NextProtos)
 	return tc, nil
@@ -635,6 +645,7 @@ func NewServerCreds(o *Options) (credentials.TransportCredentials, error) {
 		verifyFunc:          o.AdditionalPeerVerification,
 		revocationOptions:   o.RevocationOptions,
 		verificationType:    o.VerificationType,
+		skipServerAuthEKU:   o.SkipServerAuthEKU,
 	}
 	tc.config.NextProtos = credinternal.AppendH2ToNextProtos(tc.config.NextProtos)
 	return tc, nil

--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -565,11 +565,13 @@ func buildVerifyFunc(c *advancedTLSCreds,
 				rootCAs = results.TrustCerts
 			}
 			// Verify peers' certificates against RootCAs and get verifiedChains.
-			keyUsages := []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
-			if c.isClient && c.skipServerAuthEKU {
-				keyUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageAny}
-			} else if !c.isClient {
-				keyUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+			keyUsages := []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+			if c.isClient {
+				if c.skipServerAuthEKU {
+					keyUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageAny}
+				} else {
+					keyUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+				}
 			}
 			opts := x509.VerifyOptions{
 				Roots:         rootCAs,

--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -226,8 +226,21 @@ type Options struct {
 	// name of authority (e.g. :authority header field) in requests and the
 	// target hostname used during server cert verification.
 	serverNameOverride string
-	// SkipServerAuthEKU if set to true, skips EKU check during server authentication.
-	// This is useful when the server certificate does not have the Server Auth EKU.
+	// SkipServerAuthEKU is an UNSAFE option that, if set to true, skips checking
+	// for the Server Auth Extended Key Usage (EKU) extension in peer
+	// certificates during server authentication.
+	//
+	// Doing so goes against the RFC 5280 specification (Section 4.2.1.12),
+	// which mandates that the certificate key usage should be compatible with
+	// the purpose of the key.
+	// See: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12
+	//
+	// Behavior:
+	// - Client-side: If set to true, the client will verify the server's
+	//   certificate using x509.ExtKeyUsageAny instead of requiring
+	//   x509.ExtKeyUsageServerAuth. This is useful when the server's certificate
+	//   does not possess the Server Auth EKU.
+	// - Server-side: No-op.
 	SkipServerAuthEKU bool
 }
 

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/credentials"
@@ -1115,18 +1116,17 @@ func (s) TestServerAuthEKUValidation(t *testing.T) {
 		wantErr           bool
 	}{
 		{
-			desc:              "SkipServerAuthEKU is false (default) -> handshake fails",
+			desc:              "SkipServerAuthEKU_False_HandshakeFails",
 			skipServerAuthEKU: false,
 			wantErr:           true,
 		},
 		{
-			desc:              "SkipServerAuthEKU is true -> handshake succeeds",
+			desc:              "SkipServerAuthEKU_True_HandshakeSucceeds",
 			skipServerAuthEKU: true,
 			wantErr:           false,
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			done := make(chan credentials.AuthInfo, 1)
 			lis, err := net.Listen("tcp", "localhost:0")
 			if err != nil {
 				t.Fatalf("Failed to listen: %v", err)
@@ -1139,6 +1139,7 @@ func (s) TestServerAuthEKUValidation(t *testing.T) {
 				},
 				VerificationType: CertVerification,
 			}
+			done := make(chan credentials.AuthInfo, 1)
 			go func() {
 				serverRawConn, err := lis.Accept()
 				if err != nil {
@@ -1185,7 +1186,11 @@ func (s) TestServerAuthEKUValidation(t *testing.T) {
 			_, _, handshakeErr := clientTLS.ClientHandshake(ctx, lisAddr, conn)
 
 			// wait for server side to finish
-			<-done
+			select {
+			case <-done:
+			case <-time.After(defaultTestTimeout):
+				t.Fatalf("timed out waiting for server handshake to finish")
+			}
 
 			gotErr := handshakeErr != nil
 			if gotErr != test.wantErr {

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -21,19 +21,14 @@ package advancedtls
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
 	"errors"
 	"fmt"
-	"math/big"
 	"net"
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/credentials"
@@ -1110,57 +1105,6 @@ func (s) TestVerifyPeerCertificateZeroCerts(t *testing.T) {
 	}
 }
 
-func generateCertificates(t *testing.T, extKeyUsages []x509.ExtKeyUsage) (*x509.CertPool, tls.Certificate) {
-	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Fatalf("Failed to generate CA key: %v", err)
-	}
-	caTemplate := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: "Test CA"},
-		NotBefore:             time.Now().Add(-1 * time.Hour),
-		NotAfter:              time.Now().Add(1 * time.Hour),
-		IsCA:                  true,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
-		BasicConstraintsValid: true,
-	}
-	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
-	if err != nil {
-		t.Fatalf("Failed to create CA cert: %v", err)
-	}
-	caCert, err := x509.ParseCertificate(caDER)
-	if err != nil {
-		t.Fatalf("Failed to parse CA cert: %v", err)
-	}
-
-	serverKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Fatalf("Failed to generate server key: %v", err)
-	}
-	serverTemplate := &x509.Certificate{
-		SerialNumber: big.NewInt(2),
-		Subject:      pkix.Name{CommonName: "localhost"},
-		NotBefore:    time.Now().Add(-1 * time.Hour),
-		NotAfter:     time.Now().Add(1 * time.Hour),
-		ExtKeyUsage:  extKeyUsages,
-		DNSNames:     []string{"localhost"},
-	}
-	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caCert, &serverKey.PublicKey, caKey)
-	if err != nil {
-		t.Fatalf("Failed to create server cert: %v", err)
-	}
-
-	rootPool := x509.NewCertPool()
-	rootPool.AddCert(caCert)
-
-	serverCert := tls.Certificate{
-		Certificate: [][]byte{serverDER},
-		PrivateKey:  serverKey,
-	}
-
-	return rootPool, serverCert
-}
-
 func (s) TestServerAuthEKUValidation(t *testing.T) {
 	// Generate server cert with ClientAuth EKU (no ServerAuth EKU)
 	rootPool, serverCert := generateCertificates(t, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
@@ -1243,11 +1187,9 @@ func (s) TestServerAuthEKUValidation(t *testing.T) {
 			// wait for server side to finish
 			<-done
 
-			if test.expectError && handshakeErr == nil {
-				t.Fatalf("Expected handshake error but got none")
-			}
-			if !test.expectError && handshakeErr != nil {
-				t.Fatalf("Expected handshake success but got error: %v", handshakeErr)
+			gotErr := handshakeErr != nil
+			if gotErr != test.expectError {
+				t.Fatalf("ClientHandshake() got error: %v, want error: %v", handshakeErr, test.expectError)
 			}
 		})
 	}

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -21,14 +21,19 @@ package advancedtls
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"errors"
 	"fmt"
+	"math/big"
 	"net"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/credentials"
@@ -1102,5 +1107,148 @@ func (s) TestVerifyPeerCertificateZeroCerts(t *testing.T) {
 	const wantErr = "no peer certificates presented"
 	if err := verifyPeerCertificate(nil, nil); err == nil || !strings.Contains(err.Error(), wantErr) {
 		t.Errorf("verifyPeerCertificate(nil, nil) = %v, want error containing %q", err, wantErr)
+	}
+}
+
+func generateCertificates(t *testing.T, extKeyUsages []x509.ExtKeyUsage) (*x509.CertPool, tls.Certificate) {
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate CA key: %v", err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(1 * time.Hour),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("Failed to create CA cert: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("Failed to parse CA cert: %v", err)
+	}
+
+	serverKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate server key: %v", err)
+	}
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+		ExtKeyUsage:  extKeyUsages,
+		DNSNames:     []string{"localhost"},
+	}
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caCert, &serverKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("Failed to create server cert: %v", err)
+	}
+
+	rootPool := x509.NewCertPool()
+	rootPool.AddCert(caCert)
+
+	serverCert := tls.Certificate{
+		Certificate: [][]byte{serverDER},
+		PrivateKey:  serverKey,
+	}
+
+	return rootPool, serverCert
+}
+
+func (s) TestServerAuthEKUValidation(t *testing.T) {
+	// Generate server cert with ClientAuth EKU (no ServerAuth EKU)
+	rootPool, serverCert := generateCertificates(t, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
+
+	for _, test := range []struct {
+		desc              string
+		skipServerAuthEKU bool
+		expectError       bool
+	}{
+		{
+			desc:              "SkipServerAuthEKU is false (default) -> handshake fails",
+			skipServerAuthEKU: false,
+			expectError:       true,
+		},
+		{
+			desc:              "SkipServerAuthEKU is true -> handshake succeeds",
+			skipServerAuthEKU: true,
+			expectError:       false,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			done := make(chan credentials.AuthInfo, 1)
+			lis, err := net.Listen("tcp", "localhost:0")
+			if err != nil {
+				t.Fatalf("Failed to listen: %v", err)
+			}
+			defer lis.Close()
+
+			serverOptions := &Options{
+				IdentityOptions: IdentityCertificateOptions{
+					Certificates: []tls.Certificate{serverCert},
+				},
+				VerificationType: CertVerification,
+			}
+			go func() {
+				serverRawConn, err := lis.Accept()
+				if err != nil {
+					close(done)
+					return
+				}
+				serverTLS, err := NewServerCreds(serverOptions)
+				if err != nil {
+					serverRawConn.Close()
+					close(done)
+					return
+				}
+				_, serverAuthInfo, err := serverTLS.ServerHandshake(serverRawConn)
+				if err != nil {
+					serverRawConn.Close()
+					close(done)
+					return
+				}
+				done <- serverAuthInfo
+			}()
+
+			lisAddr := lis.Addr().String()
+			conn, err := net.Dial("tcp", lisAddr)
+			if err != nil {
+				t.Fatalf("Client failed to connect to %s. Error: %v", lisAddr, err)
+			}
+			defer conn.Close()
+
+			clientOptions := &Options{
+				RootOptions: RootCertificateOptions{
+					RootCertificates: rootPool,
+				},
+				VerificationType:  CertVerification,
+				SkipServerAuthEKU: test.skipServerAuthEKU,
+			}
+			clientTLS, err := NewClientCreds(clientOptions)
+			if err != nil {
+				t.Fatalf("NewClientCreds failed: %v", err)
+			}
+			// Clone the credentials to ensure the cloned instance also respects SkipServerAuthEKU
+			clientTLS = clientTLS.Clone()
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+			defer cancel()
+			_, _, handshakeErr := clientTLS.ClientHandshake(ctx, lisAddr, conn)
+
+			// wait for server side to finish
+			<-done
+
+			if test.expectError && handshakeErr == nil {
+				t.Fatalf("Expected handshake error but got none")
+			}
+			if !test.expectError && handshakeErr != nil {
+				t.Fatalf("Expected handshake success but got error: %v", handshakeErr)
+			}
+		})
 	}
 }

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -1112,17 +1112,17 @@ func (s) TestServerAuthEKUValidation(t *testing.T) {
 	for _, test := range []struct {
 		desc              string
 		skipServerAuthEKU bool
-		expectError       bool
+		wantErr           bool
 	}{
 		{
 			desc:              "SkipServerAuthEKU is false (default) -> handshake fails",
 			skipServerAuthEKU: false,
-			expectError:       true,
+			wantErr:           true,
 		},
 		{
 			desc:              "SkipServerAuthEKU is true -> handshake succeeds",
 			skipServerAuthEKU: true,
-			expectError:       false,
+			wantErr:           false,
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
@@ -1188,8 +1188,8 @@ func (s) TestServerAuthEKUValidation(t *testing.T) {
 			<-done
 
 			gotErr := handshakeErr != nil
-			if gotErr != test.expectError {
-				t.Fatalf("ClientHandshake() got error: %v, want error: %v", handshakeErr, test.expectError)
+			if gotErr != test.wantErr {
+				t.Fatalf("ClientHandshake() got error: %v, want error: %v", handshakeErr, test.wantErr)
 			}
 		})
 	}

--- a/security/advancedtls/certificate_utils_test.go
+++ b/security/advancedtls/certificate_utils_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func generateCertificates(t *testing.T, extKeyUsages []x509.ExtKeyUsage) (*x509.CertPool, tls.Certificate) {
+	t.Helper()
 	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		t.Fatalf("Failed to generate CA key: %v", err)

--- a/security/advancedtls/helper_test.go
+++ b/security/advancedtls/helper_test.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package advancedtls
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+)
+
+func generateCertificates(t *testing.T, extKeyUsages []x509.ExtKeyUsage) (*x509.CertPool, tls.Certificate) {
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate CA key: %v", err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(1 * time.Hour),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("Failed to create CA cert: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("Failed to parse CA cert: %v", err)
+	}
+
+	serverKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate server key: %v", err)
+	}
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+		ExtKeyUsage:  extKeyUsages,
+		DNSNames:     []string{"localhost"},
+	}
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caCert, &serverKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("Failed to create server cert: %v", err)
+	}
+
+	rootPool := x509.NewCertPool()
+	rootPool.AddCert(caCert)
+
+	serverCert := tls.Certificate{
+		Certificate: [][]byte{serverDER},
+		PrivateKey:  serverKey,
+	}
+
+	return rootPool, serverCert
+}


### PR DESCRIPTION
This adds `SkipServerAuthEKU` option to `Options`. When set to `true`, the client will verify server certificates using `x509.ExtKeyUsageAny` instead of requiring `x509.ExtKeyUsageServerAuth`. This is useful when the server's certificate does not possess the Server Auth EKU.

BUG=528004991

RELEASE NOTES:
* security/advancedtls: Add `SkipServerAuthEKU` option to skip EKU check during server authentication.
