### PR TITLE
grpc: move different type RPC handling out of underlying stream implementations

### DIFF
--- a/call.go
+++ b/call.go
@@ -75,8 +75,10 @@ func invoke(ctx context.Context, method string, req, reply any, cc *ClientConn, 
 	if err := cs.SendMsg(req); err != nil && err != io.EOF {
 		return err
 	}
-	// CloseSend is needed to signal streaming interceptors intercepting unary
-	// RPCs.
+	// CloseSend is needed because in some scenarios (e.g., xDS), the same
+	// interceptors are used to process both unary and streaming RPCs. Calling
+	// CloseSend signals to those interceptors that no more messages are on the
+	// way.
 	if err := cs.CloseSend(); err != nil && err != io.EOF {
 		return err
 	}

--- a/call.go
+++ b/call.go
@@ -71,19 +71,19 @@ func invoke(ctx context.Context, method string, req, reply any, cc *ClientConn, 
 	if err != nil {
 		return err
 	}
-	// Return nil instead of EOF on error because the generated code requires it.
-	// RecvMsg is called to get the status.
+	// In case of nil or io.EOF error, call RecvMsg.
 	if err := cs.SendMsg(req); err != nil && err != io.EOF {
 		return err
 	}
-	// CloseSend is called to signal the interceptors.
+	// CloseSend is needed to signal streaming interceptors intercepting unary
+	// RPCs.
 	if err := cs.CloseSend(); err != nil && err != io.EOF {
 		return err
 	}
 	if err := cs.RecvMsg(reply); err != nil {
 		return err
 	}
-	// Call RecvMsg again to make sure the RPC has completed successfully.
+	// Call RecvMsg again to get the trailers.
 	err = cs.RecvMsg(reply)
 	if err == io.EOF {
 		return nil

--- a/call.go
+++ b/call.go
@@ -20,6 +20,10 @@ package grpc
 
 import (
 	"context"
+	"io"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // Invoke sends the RPC request on the wire and returns after response is
@@ -67,8 +71,26 @@ func invoke(ctx context.Context, method string, req, reply any, cc *ClientConn, 
 	if err != nil {
 		return err
 	}
-	if err := cs.SendMsg(req); err != nil {
+	// Return nil instead of EOF on error because the generated code requires it.
+	// RecvMsg is called to get the status.
+	if err := cs.SendMsg(req); err != nil && err != io.EOF {
 		return err
 	}
-	return cs.RecvMsg(reply)
+	// CloseSend is a no-op for the underlying transport because SendMsg already
+	// sends Last=true for unary RPCs. This call is solely to signal interceptors.
+	if err := cs.CloseSend(); err != nil && err != io.EOF {
+		return err
+	}
+	if err := cs.RecvMsg(reply); err != nil {
+		return err
+	}
+	// Call RecvMsg again to make sure the RPC has completed successfully.
+	err = cs.RecvMsg(reply)
+	if err == io.EOF {
+		return nil
+	}
+	if err == nil {
+		return status.Error(codes.Internal, "cardinality violation: expected <EOF> for non server-streaming RPCs, but received another message")
+	}
+	return err
 }

--- a/call.go
+++ b/call.go
@@ -76,8 +76,7 @@ func invoke(ctx context.Context, method string, req, reply any, cc *ClientConn, 
 	if err := cs.SendMsg(req); err != nil && err != io.EOF {
 		return err
 	}
-	// CloseSend is a no-op for the underlying transport because SendMsg already
-	// sends Last=true for unary RPCs. This call is solely to signal interceptors.
+	// CloseSend is called to signal the interceptors.
 	if err := cs.CloseSend(); err != nil && err != io.EOF {
 		return err
 	}

--- a/clientconn.go
+++ b/clientconn.go
@@ -555,6 +555,7 @@ func chainStreamClientInterceptors(cc *ClientConn) {
 	if cc.dopts.streamInt != nil {
 		interceptors = append([]StreamClientInterceptor{cc.dopts.streamInt}, interceptors...)
 	}
+	interceptors = append([]StreamClientInterceptor{defaultStreamInterceptor}, interceptors...)
 	var chainedInt StreamClientInterceptor
 	if len(interceptors) == 0 {
 		chainedInt = nil

--- a/stream.go
+++ b/stream.go
@@ -160,49 +160,55 @@ type clientStreamWrapper struct {
 // interceptor hooks.
 func (w *clientStreamWrapper) SendMsg(m any) error {
 	err := w.ClientStream.SendMsg(m)
-	if !w.desc.ClientStreams {
-		if err == io.EOF {
-			// For non-client-streaming RPCs, we return nil instead of EOF on error
-			// because the generated code requires it. finish is not called; RecvMsg()
-			// will call it with the stream's status independently.
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-		// CloseSend is called to signal the interceptors.
-		if err := w.ClientStream.CloseSend(); err != nil && err != io.EOF {
-			return err
-		}
+	if w.desc.ClientStreams {
+		return err
+	}
+	if err == io.EOF {
+		// For non-client-streaming RPCs, we return nil instead of EOF on error
+		// because the generated code requires it. finish is not called; RecvMsg()
+		// will call it with the stream's status independently.
 		return nil
 	}
-	return err
+	if err != nil {
+		return err
+	}
+	// CloseSend is needed to signal streaming interceptors intercepting
+	// non-client streaming RPCs.
+	if err := w.ClientStream.CloseSend(); err != nil && err != io.EOF {
+		return err
+	}
+	return nil
+
 }
 
 // RecvMsg receives message m from the stream. For non-server-streaming RPCs, it
 // calls the underlying RecvMsg a second time after receiving the first message
-// to verify that the stream terminates cleanly with io.EOF and without any
-// cardinality violations.
+// to get the trailers.
 func (w *clientStreamWrapper) RecvMsg(m any) error {
 	err := w.ClientStream.RecvMsg(m)
 	if err != nil {
 		return err
 	}
-	if !w.desc.ServerStreams {
-		err = w.ClientStream.RecvMsg(m)
-		if err == io.EOF {
-			return nil
-		}
-		if err == nil {
-			return status.Error(codes.Internal, "cardinality violation: expected <EOF> for non server-streaming RPCs, but received another message")
-		}
-		return err
+	if w.desc.ServerStreams {
+		return nil
 	}
-	return nil
+	// Call RecvMsg again for non-server streaming RPCs to get the trailers and
+	// ensure RPC has completed successfully.
+	err = w.ClientStream.RecvMsg(m)
+	if err == io.EOF {
+		return nil
+	}
+	if err == nil {
+		return status.Error(codes.Internal, "cardinality violation: expected <EOF> for non server-streaming RPCs, but received another message")
+	}
+	return err
 }
 
 // defaultStreamInterceptor is a StreamClientInterceptor which wraps the
-// ClientStream and is always invoked as the first interceptor.
+// ClientStream and is always invoked as the first interceptor. It consolidates
+// behavior for different RPC types at the level closest to the application,
+// which simplifies the underlying stream implementation and other interceptors
+// by avoiding duplicate or scattered handling.
 func defaultStreamInterceptor(ctx context.Context, desc *StreamDesc, cc *ClientConn, method string, streamer Streamer, opts ...CallOption) (ClientStream, error) {
 	cs, err := streamer(ctx, desc, cc, method, opts...)
 	if err != nil {

--- a/stream.go
+++ b/stream.go
@@ -155,14 +155,18 @@ type clientStreamWrapper struct {
 	desc *StreamDesc
 }
 
-// SendMsg sends message m across the stream. For non-client-streaming RPCs, it
-// converts io.EOF to nil and immediately calls CloseSend to trigger any
-// interceptor hooks.
+// SendMsg sends message m across the stream. For RPCs where client can call
+// SendMsg only once, i.e. only server-streaming RPCs, it converts io.EOF to nil
+// and immediately calls CloseSend to trigger any interceptor hooks.
 func (w *clientStreamWrapper) SendMsg(m any) error {
 	err := w.ClientStream.SendMsg(m)
+	// If the RPC is a client-streaming RPC, the client can send multiple
+	// messages. In this case, the client should handle any type of
+	// error,including io.EOF and call CloseSend once it is done sending messages.
 	if w.desc.ClientStreams {
 		return err
 	}
+
 	if err == io.EOF {
 		// For non-client-streaming RPCs, we return nil instead of EOF on error
 		// because the generated code requires it. finish is not called; RecvMsg()
@@ -172,8 +176,10 @@ func (w *clientStreamWrapper) SendMsg(m any) error {
 	if err != nil {
 		return err
 	}
-	// CloseSend is needed to signal streaming interceptors intercepting
-	// non-client streaming RPCs.
+	// CloseSend is needed because in some scenarios (e.g., xDS), the same
+	// interceptors are used to process both unary and streaming RPCs. Calling
+	// CloseSend signals to those interceptors that no more messages are on the
+	// way.
 	if err := w.ClientStream.CloseSend(); err != nil && err != io.EOF {
 		return err
 	}
@@ -181,9 +187,9 @@ func (w *clientStreamWrapper) SendMsg(m any) error {
 
 }
 
-// RecvMsg receives message m from the stream. For non-server-streaming RPCs, it
-// calls the underlying RecvMsg a second time after receiving the first message
-// to get the trailers.
+// RecvMsg receives message m from the stream. For RPCs that call RecvMsg only
+// once i.e. only client streaming RPCs, it calls the underlying RecvMsg a
+// second time after receiving the first message to get the trailers.
 func (w *clientStreamWrapper) RecvMsg(m any) error {
 	err := w.ClientStream.RecvMsg(m)
 	if err != nil {

--- a/stream.go
+++ b/stream.go
@@ -148,6 +148,81 @@ type ClientStream interface {
 	RecvMsg(m any) error
 }
 
+// clientStreamWrapper wraps a ClientStream and handles SendMsg, CloseSend, and
+// RecvMsg parities based on the nature of stream.
+type clientStreamWrapper struct {
+	ClientStream
+	desc *StreamDesc
+}
+
+// SendMsg sends message m across the stream. For non-client-streaming RPCs, it
+// converts io.EOF to nil and immediately calls CloseSend to trigger any
+// interceptor hooks.
+func (w *clientStreamWrapper) SendMsg(m any) error {
+	err := w.ClientStream.SendMsg(m)
+	if !w.desc.ClientStreams {
+		if err == io.EOF {
+			// For non-client-streaming RPCs, we return nil instead of EOF on error
+			// because the generated code requires it. finish is not called; RecvMsg()
+			// will call it with the stream's status independently.
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		// CloseSend is a no-op for the underlying transport because SendMsg already
+		// sent Last=true for non-client-streaming RPCs. This call is solely to
+		// signal interceptors.
+		if err := w.ClientStream.CloseSend(); err != nil {
+			return err
+		}
+		return nil
+	}
+	return err
+}
+
+// CloseSend closes the sending side of the stream. For non-client-streaming
+// RPCs, it converts io.EOF to nil.
+func (w *clientStreamWrapper) CloseSend() error {
+	err := w.ClientStream.CloseSend()
+	if !w.desc.ClientStreams && err == io.EOF {
+		return nil
+	}
+	return err
+}
+
+// RecvMsg receives message m from the stream. For non-server-streaming RPCs, it
+// calls the underlying RecvMsg a second time after receiving the first message
+// to verify that the stream terminates cleanly with io.EOF and without any
+// cardinality violations.
+func (w *clientStreamWrapper) RecvMsg(m any) error {
+	err := w.ClientStream.RecvMsg(m)
+	if err != nil {
+		return err
+	}
+	if !w.desc.ServerStreams {
+		err = w.ClientStream.RecvMsg(m)
+		if err == io.EOF {
+			return nil
+		}
+		if err == nil {
+			return status.Error(codes.Internal, "cardinality violation: expected <EOF> for non server-streaming RPCs, but received another message")
+		}
+		return err
+	}
+	return nil
+}
+
+// defaultStreamInterceptor is a StreamClientInterceptor which wraps the
+// ClientStream and is always invoked as the first interceptor.
+func defaultStreamInterceptor(ctx context.Context, desc *StreamDesc, cc *ClientConn, method string, streamer Streamer, opts ...CallOption) (ClientStream, error) {
+	cs, err := streamer(ctx, desc, cc, method, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &clientStreamWrapper{ClientStream: cs, desc: desc}, nil
+}
+
 // NewStream creates a new Stream for the client side. This is typically
 // called by generated code. ctx is used for the lifetime of the stream.
 //
@@ -1044,8 +1119,8 @@ func (cs *clientStream) RecvMsg(m any) error {
 			binlog.Log(cs.ctx, sm)
 		}
 	}
-	if err != nil || !cs.desc.ServerStreams {
-		// err != nil or non-server-streaming indicates end of stream.
+	if err != nil {
+		// err != nil indicates end of stream.
 		cs.finish(err)
 	}
 	return err
@@ -1145,12 +1220,6 @@ func (a *csAttempt) sendMsg(m any, hdr []byte, payld mem.BufferSlice, dataLength
 		a.mu.Unlock()
 	}
 	if err := a.transportStream.Write(hdr, payld, &transport.WriteOptions{Last: !cs.desc.ClientStreams}); err != nil {
-		if !cs.desc.ClientStreams {
-			// For non-client-streaming RPCs, we return nil instead of EOF on error
-			// because the generated code requires it.  finish is not called; RecvMsg()
-			// will call it with the stream's status independently.
-			return nil
-		}
 		return io.EOF
 	}
 	if a.statsHandler != nil {
@@ -1218,18 +1287,7 @@ func (a *csAttempt) recvMsg(m any, payInfo *payloadInfo) (err error) {
 			Length:           payInfo.uncompressedBytes.Len(),
 		})
 	}
-	if cs.desc.ServerStreams {
-		// Subsequent messages should be received by subsequent RecvMsg calls.
-		return nil
-	}
-	// Special handling for non-server-stream rpcs.
-	// This recv expects EOF or errors, so we don't collect inPayload.
-	if err := recv(&a.parser, cs.codec, a.transportStream, a.decompressorV0, m, *cs.callInfo.maxReceiveMessageSize, nil, a.decompressorV1, false); err == io.EOF {
-		return a.transportStream.Status().Err() // non-server streaming Recv returns nil on success
-	} else if err != nil {
-		return toRPCErr(err)
-	}
-	return status.Error(codes.Internal, "cardinality violation: expected <EOF> for non server-streaming RPCs, but received another message")
+	return nil
 }
 
 func (a *csAttempt) finish(err error) {
@@ -1399,7 +1457,7 @@ func newNonRetryClientStream(ctx context.Context, desc *StreamDesc, method strin
 			}
 		}()
 	}
-	return as, nil
+	return &clientStreamWrapper{ClientStream: as, desc: desc}, nil
 }
 
 type addrConnStream struct {
@@ -1497,12 +1555,6 @@ func (as *addrConnStream) SendMsg(m any) (err error) {
 	}
 
 	if err := as.transportStream.Write(hdr, payload, &transport.WriteOptions{Last: !as.desc.ClientStreams}); err != nil {
-		if !as.desc.ClientStreams {
-			// For non-client-streaming RPCs, we return nil instead of EOF on error
-			// because the generated code requires it.  finish is not called; RecvMsg()
-			// will call it with the stream's status independently.
-			return nil
-		}
 		return io.EOF
 	}
 
@@ -1511,8 +1563,8 @@ func (as *addrConnStream) SendMsg(m any) (err error) {
 
 func (as *addrConnStream) RecvMsg(m any) (err error) {
 	defer func() {
-		if err != nil || !as.desc.ServerStreams {
-			// err != nil or non-server-streaming indicates end of stream.
+		if err != nil {
+			// err != nil indicates end of stream.
 			as.finish(err)
 		}
 	}()
@@ -1551,20 +1603,7 @@ func (as *addrConnStream) RecvMsg(m any) (err error) {
 		return toRPCErr(err)
 	}
 	as.receivedFirstMsg = true
-
-	if as.desc.ServerStreams {
-		// Subsequent messages should be received by subsequent RecvMsg calls.
-		return nil
-	}
-
-	// Special handling for non-server-stream rpcs.
-	// This recv expects EOF or errors, so we don't collect inPayload.
-	if err := recv(&as.parser, as.codec, as.transportStream, as.decompressorV0, m, *as.callInfo.maxReceiveMessageSize, nil, as.decompressorV1, false); err == io.EOF {
-		return as.transportStream.Status().Err() // non-server streaming Recv returns nil on success
-	} else if err != nil {
-		return toRPCErr(err)
-	}
-	return status.Error(codes.Internal, "cardinality violation: expected <EOF> for non server-streaming RPCs, but received another message")
+	return nil
 }
 
 func (as *addrConnStream) finish(err error) {

--- a/stream.go
+++ b/stream.go
@@ -170,22 +170,10 @@ func (w *clientStreamWrapper) SendMsg(m any) error {
 		if err != nil {
 			return err
 		}
-		// CloseSend is a no-op for the underlying transport because SendMsg already
-		// sent Last=true for non-client-streaming RPCs. This call is solely to
-		// signal interceptors.
-		if err := w.ClientStream.CloseSend(); err != nil {
+		// CloseSend is called to signal the interceptors.
+		if err := w.ClientStream.CloseSend(); err != nil && err != io.EOF {
 			return err
 		}
-		return nil
-	}
-	return err
-}
-
-// CloseSend closes the sending side of the stream. For non-client-streaming
-// RPCs, it converts io.EOF to nil.
-func (w *clientStreamWrapper) CloseSend() error {
-	err := w.ClientStream.CloseSend()
-	if !w.desc.ClientStreams && err == io.EOF {
 		return nil
 	}
 	return err

--- a/stream_test.go
+++ b/stream_test.go
@@ -147,18 +147,12 @@ func (s) TestUnaryClient_ServerStreamingMismatch(t *testing.T) {
 	}
 }
 
-// interceptorStream wraps a ClientStream to record invocations of SendMsg,
-// RecvMsg, and CloseSend hooks across downstream interceptors.
+// interceptorStream wraps a ClientStream to record invocations of RecvMsg and
+// CloseSend hooks across downstream interceptors.
 type interceptorStream struct {
 	grpc.ClientStream
-	sendMsgCount int
 	recvMsgCount int
 	closeSend    bool
-}
-
-func (s *interceptorStream) SendMsg(m any) error {
-	s.sendMsgCount++
-	return s.ClientStream.SendMsg(m)
 }
 
 func (s *interceptorStream) RecvMsg(m any) error {
@@ -171,21 +165,14 @@ func (s *interceptorStream) CloseSend() error {
 	return s.ClientStream.CloseSend()
 }
 
-// TestDefaultStreamInterceptor_ServerStreaming_CloseSend verifies that for
-// non-client-streaming RPCs (e.g., server streaming), defaultStreamInterceptor
-// automatically triggers the CloseSend hook on downstream interceptor streams
-// right after SendMsg is called on the client side.
-func (s) TestDefaultStreamInterceptor_ServerStreaming_CloseSend(t *testing.T) {
+// TestDefaultStreamInterceptor verifies that defaultStreamInterceptor
+// automatically triggers CloseSend on non-client-streaming RPCs right after
+// SendMsg, and calls RecvMsg a second time on non-server-streaming RPCs to
+// consume trailers and io.EOF.
+func (s) TestDefaultStreamInterceptor(t *testing.T) {
 	var iStream *interceptorStream
-	// Setup a simple server-streaming service that sends one response message and
-	// exits.
-	ss := &stubserver.StubServer{
-		StreamingOutputCallF: func(_ *testpb.StreamingOutputCallRequest, stream testgrpc.TestService_StreamingOutputCallServer) error {
-			return stream.Send(&testpb.StreamingOutputCallResponse{})
-		},
-	}
 	// Define a client-side stream interceptor that wraps the ClientStream to
-	// monitor hooks.
+	// monitor hook invocations across RPC calls.
 	clientInt := func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 		cs, err := streamer(ctx, desc, cc, method, opts...)
 		if err != nil {
@@ -195,39 +182,12 @@ func (s) TestDefaultStreamInterceptor_ServerStreaming_CloseSend(t *testing.T) {
 		return iStream, nil
 	}
 
-	if err := ss.Start(nil, grpc.WithStreamInterceptor(clientInt)); err != nil {
-		t.Fatal("Error starting server:", err)
-	}
-	defer ss.Stop()
-
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-
-	_, err := ss.Client.StreamingOutputCall(ctx, &testpb.StreamingOutputCallRequest{})
-	if err != nil {
-		t.Fatal("Error calling StreamingOutputCall:", err)
-	}
-	if iStream == nil {
-		t.Fatal("Interceptor stream was not created")
-	}
-
-	// Since StreamingOutputCall is not client-streaming, defaultStreamInterceptor
-	// (via clientStreamWrapper.SendMsg) immediately invokes CloseSend right after
-	// sending the request message to signal downstream client interceptors.
-	if !iStream.closeSend {
-		t.Fatal("CloseSend not called after SendMsg on non-client-streaming RPC")
-	}
-}
-
-// TestDefaultStreamInterceptor_ClientStreaming_RecvMsg verifies that for
-// non-server-streaming RPCs (i.e., client streaming only),
-// defaultStreamInterceptor automatically calls RecvMsg a second time on
-// downstream client interceptor streams to collect trailers and io.EOF.
-func (s) TestDefaultStreamInterceptor_ClientStreaming_RecvMsg(t *testing.T) {
-	var iStream *interceptorStream
-	// Setup a simple client-streaming service that consumes messages until EOF,
-	// then sends a response.
+	// Setup a service implementing both a client-streaming RPC and a
+	// server-streaming RPC.
 	ss := &stubserver.StubServer{
+		StreamingOutputCallF: func(_ *testpb.StreamingOutputCallRequest, stream testgrpc.TestService_StreamingOutputCallServer) error {
+			return stream.Send(&testpb.StreamingOutputCallResponse{})
+		},
 		StreamingInputCallF: func(stream testgrpc.TestService_StreamingInputCallServer) error {
 			for {
 				if _, err := stream.Recv(); err != nil {
@@ -239,17 +199,6 @@ func (s) TestDefaultStreamInterceptor_ClientStreaming_RecvMsg(t *testing.T) {
 			}
 		},
 	}
-	// Define a client-side stream interceptor that wraps the ClientStream to
-	// monitor hooks.
-	clientInt := func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-		cs, err := streamer(ctx, desc, cc, method, opts...)
-		if err != nil {
-			return nil, err
-		}
-		iStream = &interceptorStream{ClientStream: cs}
-		return iStream, nil
-	}
-
 	if err := ss.Start(nil, grpc.WithStreamInterceptor(clientInt)); err != nil {
 		t.Fatal("Error starting server:", err)
 	}
@@ -258,6 +207,10 @@ func (s) TestDefaultStreamInterceptor_ClientStreaming_RecvMsg(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
+	// Make a client-streaming RPC. When CloseAndRecv invokes RecvMsg once to get
+	// the single reply message on a non-server-streaming RPC,
+	// defaultStreamInterceptor automatically calls a second RecvMsg on the
+	// underlying client stream to consume io.EOF and receive trailers.
 	stream, err := ss.Client.StreamingInputCall(ctx)
 	if err != nil {
 		t.Fatal("Error calling StreamingInputCall:", err)
@@ -268,15 +221,17 @@ func (s) TestDefaultStreamInterceptor_ClientStreaming_RecvMsg(t *testing.T) {
 	if _, err := stream.CloseAndRecv(); err != nil {
 		t.Fatal("Error running CloseAndRecv:", err)
 	}
-	if iStream == nil {
-		t.Fatal("Interceptor stream was not created")
+	if iStream.recvMsgCount != 2 {
+		t.Fatalf("StreamingInputCall RecvMsg was called %v times, want 2 times", iStream.recvMsgCount)
 	}
 
-	// When CloseAndRecv() invokes RecvMsg once to get the single reply message on
-	// a non-server-streaming RPC, defaultStreamInterceptor automatically calls a
-	// second RecvMsg on the underlying client stream to consume io.EOF and
-	// receive trailers.
-	if iStream.recvMsgCount != 2 {
-		t.Fatalf("RecvMsg was called %v times, want 2 times", iStream.recvMsgCount)
+	// Make a server-streaming RPC. Since StreamingOutputCall is not
+	// client-streaming, defaultStreamInterceptor immediately invokes CloseSend
+	// right after sending the request message to signal downstream interceptors.
+	if _, err := ss.Client.StreamingOutputCall(ctx, &testpb.StreamingOutputCallRequest{}); err != nil {
+		t.Fatal("Error calling StreamingOutputCall:", err)
+	}
+	if !iStream.closeSend {
+		t.Fatal("CloseSend not called after SendMsg on non-client-streaming RPC")
 	}
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -20,6 +20,7 @@ package grpc_test
 
 import (
 	"context"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -143,5 +144,139 @@ func (s) TestUnaryClient_ServerStreamingMismatch(t *testing.T) {
 				t.Errorf("Unexpected error message: got %v, want %v", err.Error(), test.wantErrorContains)
 			}
 		})
+	}
+}
+
+// interceptorStream wraps a ClientStream to record invocations of SendMsg,
+// RecvMsg, and CloseSend hooks across downstream interceptors.
+type interceptorStream struct {
+	grpc.ClientStream
+	sendMsgCount int
+	recvMsgCount int
+	closeSend    bool
+}
+
+func (s *interceptorStream) SendMsg(m any) error {
+	s.sendMsgCount++
+	return s.ClientStream.SendMsg(m)
+}
+
+func (s *interceptorStream) RecvMsg(m any) error {
+	s.recvMsgCount++
+	return s.ClientStream.RecvMsg(m)
+}
+
+func (s *interceptorStream) CloseSend() error {
+	s.closeSend = true
+	return s.ClientStream.CloseSend()
+}
+
+// TestDefaultStreamInterceptor_ServerStreaming_CloseSend verifies that for
+// non-client-streaming RPCs (e.g., server streaming), defaultStreamInterceptor
+// automatically triggers the CloseSend hook on downstream interceptor streams
+// right after SendMsg is called on the client side.
+func (s) TestDefaultStreamInterceptor_ServerStreaming_CloseSend(t *testing.T) {
+	var iStream *interceptorStream
+	// Setup a simple server-streaming service that sends one response message and
+	// exits.
+	ss := &stubserver.StubServer{
+		StreamingOutputCallF: func(_ *testpb.StreamingOutputCallRequest, stream testgrpc.TestService_StreamingOutputCallServer) error {
+			return stream.Send(&testpb.StreamingOutputCallResponse{})
+		},
+	}
+	// Define a client-side stream interceptor that wraps the ClientStream to
+	// monitor hooks.
+	clientInt := func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		cs, err := streamer(ctx, desc, cc, method, opts...)
+		if err != nil {
+			return nil, err
+		}
+		iStream = &interceptorStream{ClientStream: cs}
+		return iStream, nil
+	}
+
+	if err := ss.Start(nil, grpc.WithStreamInterceptor(clientInt)); err != nil {
+		t.Fatal("Error starting server:", err)
+	}
+	defer ss.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	_, err := ss.Client.StreamingOutputCall(ctx, &testpb.StreamingOutputCallRequest{})
+	if err != nil {
+		t.Fatal("Error calling StreamingOutputCall:", err)
+	}
+	if iStream == nil {
+		t.Fatal("Interceptor stream was not created")
+	}
+
+	// Since StreamingOutputCall is not client-streaming, defaultStreamInterceptor
+	// (via clientStreamWrapper.SendMsg) immediately invokes CloseSend right after
+	// sending the request message to signal downstream client interceptors.
+	if !iStream.closeSend {
+		t.Fatal("CloseSend not called after SendMsg on non-client-streaming RPC")
+	}
+}
+
+// TestDefaultStreamInterceptor_ClientStreaming_RecvMsg verifies that for
+// non-server-streaming RPCs (i.e., client streaming only),
+// defaultStreamInterceptor automatically calls RecvMsg a second time on
+// downstream client interceptor streams to collect trailers and io.EOF.
+func (s) TestDefaultStreamInterceptor_ClientStreaming_RecvMsg(t *testing.T) {
+	var iStream *interceptorStream
+	// Setup a simple client-streaming service that consumes messages until EOF,
+	// then sends a response.
+	ss := &stubserver.StubServer{
+		StreamingInputCallF: func(stream testgrpc.TestService_StreamingInputCallServer) error {
+			for {
+				if _, err := stream.Recv(); err != nil {
+					if err == io.EOF {
+						return stream.SendAndClose(&testpb.StreamingInputCallResponse{})
+					}
+					return err
+				}
+			}
+		},
+	}
+	// Define a client-side stream interceptor that wraps the ClientStream to
+	// monitor hooks.
+	clientInt := func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		cs, err := streamer(ctx, desc, cc, method, opts...)
+		if err != nil {
+			return nil, err
+		}
+		iStream = &interceptorStream{ClientStream: cs}
+		return iStream, nil
+	}
+
+	if err := ss.Start(nil, grpc.WithStreamInterceptor(clientInt)); err != nil {
+		t.Fatal("Error starting server:", err)
+	}
+	defer ss.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	stream, err := ss.Client.StreamingInputCall(ctx)
+	if err != nil {
+		t.Fatal("Error calling StreamingInputCall:", err)
+	}
+	if err := stream.Send(&testpb.StreamingInputCallRequest{}); err != nil {
+		t.Fatal("Error sending request:", err)
+	}
+	if _, err := stream.CloseAndRecv(); err != nil {
+		t.Fatal("Error running CloseAndRecv:", err)
+	}
+	if iStream == nil {
+		t.Fatal("Interceptor stream was not created")
+	}
+
+	// When CloseAndRecv() invokes RecvMsg once to get the single reply message on
+	// a non-server-streaming RPC, defaultStreamInterceptor automatically calls a
+	// second RecvMsg on the underlying client stream to consume io.EOF and
+	// receive trailers.
+	if iStream.recvMsgCount != 2 {
+		t.Fatalf("RecvMsg was called %v times, want 2 times", iStream.recvMsgCount)
 	}
 }


### PR DESCRIPTION
This PR refactors and extracts stream-type-specific logic into a dedicated interceptor and stream wrapper to simplify the underlying stream transport implementations and also simplify these xDS http filter implementations.

- Introduced `clientStreamWrapper`: Added a wrapper in `stream.go` that intercepts `SendMsg`, `CloseSend`, and `RecvMsg`. It inspects the `StreamDesc` to conditionally apply specific behaviors, like converting `io.EOF` to nil on `SendMsg` for non-client-streaming RPCs, auto-calling CloseSend, and checking for cardinality violations after receiving a message in non-server-streaming RPCs.

- Added `defaultStreamInterceptor`: Created a default interceptor that applies this wrapper to all client streams.

- Registered the Default Interceptor: Updated `chainStreamClientInterceptors` in `clientconn.go` to prepend `defaultStreamInterceptor` to the interceptor chain.

- Cleaned up `call.go` and internal streams: Removed the now-redundant EOF checking, Recv calls and cardinality checks from the lower-level transport functions in `stream.go`

RELEASE NOTES: None
