### PR TITLE
metadata: re-add MD.String with redaction of sensitive metadata

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -24,6 +24,7 @@ package metadata // import "google.golang.org/grpc/metadata"
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"google.golang.org/grpc/internal"
@@ -88,6 +89,69 @@ func Pairs(kv ...string) MD {
 		md[key] = append(md[key], kv[i+1])
 	}
 	return md
+}
+
+// loggableMetadataKeys is the set of metadata keys whose values are known not
+// to carry credentials or other sensitive data, and are therefore safe to print
+// verbatim in String. Values for any key not in this set are redacted. Keys are
+// in metadata's canonical lowercase form.
+//
+// The list is intentionally restricted to standardized gRPC and HTTP/2 protocol
+// headers. Everything else, including all application-defined keys, is
+// censored.
+var loggableMetadataKeys = map[string]bool{
+	"content-type":               true,
+	"te":                         true,
+	"user-agent":                 true,
+	"grpc-encoding":              true,
+	"grpc-accept-encoding":       true,
+	"grpc-timeout":               true,
+	"grpc-status":                true,
+	"grpc-message-type":          true,
+	"grpc-previous-rpc-attempts": true,
+	"grpc-retry-pushback-ms":     true,
+}
+
+// String implements fmt.Stringer to allow metadata to be printed when stored in
+// a context.
+//
+// To avoid accidentally leaking credentials or other sensitive data (for
+// example via log(md), or by logging a value that happens to contain metadata),
+// String reports only keys on an allowlist of standardized, non-sensitive
+// protocol headers (see loggableMetadataKeys). Every other key is omitted
+// entirely, along with its values, because a key name may itself be sensitive;
+// only the number of omitted keys is reported, as "<N redacted>". This is a
+// best-effort guard against accidents, not a security boundary: a caller that
+// genuinely wants the full contents can still print map[string][]string(md)
+// directly.
+//
+// Note that this only affects verbs that use the Stringer, such as %v and %s.
+// The %#v verb prints the underlying map with all values and is not redacted.
+func (md MD) String() string {
+	keys := make([]string, 0, len(md))
+	for k := range md {
+		if loggableMetadataKeys[strings.ToLower(k)] {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+
+	var sb strings.Builder
+	sb.WriteString("map[")
+	for i, k := range keys {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%s:%v", k, md[k])
+	}
+	if redacted := len(md) - len(keys); redacted > 0 {
+		if len(keys) > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "<%d redacted>", redacted)
+	}
+	sb.WriteByte(']')
+	return sb.String()
 }
 
 // Len returns the number of items in md.

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -99,6 +99,8 @@ func Pairs(kv ...string) MD {
 // The list is intentionally restricted to standardized gRPC and HTTP/2 protocol
 // headers. Everything else, including all application-defined keys, is
 // censored.
+// Note that this list might change as we add/remove support for
+// metadata types.
 var loggableMetadataKeys = map[string]bool{
 	"content-type":               true,
 	"te":                         true,
@@ -112,6 +114,10 @@ var loggableMetadataKeys = map[string]bool{
 	"grpc-retry-pushback-ms":     true,
 }
 
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a later
+// release.
 // String implements fmt.Stringer to allow metadata to be printed when stored in
 // a context.
 //

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -114,10 +114,6 @@ var loggableMetadataKeys = map[string]bool{
 	"grpc-retry-pushback-ms":     true,
 }
 
-// # Experimental
-//
-// Notice: This API is EXPERIMENTAL and may be changed or removed in a later
-// release.
 // String implements fmt.Stringer to allow metadata to be printed when stored in
 // a context.
 //
@@ -133,6 +129,11 @@ var loggableMetadataKeys = map[string]bool{
 //
 // Note that this only affects verbs that use the Stringer, such as %v and %s.
 // The %#v verb prints the underlying map with all values and is not redacted.
+// Users should not rely on the output of this method to be stable
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a later
+// release.
 func (md MD) String() string {
 	keys := make([]string, 0, len(md))
 	for k := range md {

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -415,3 +415,110 @@ func BenchmarkValueFromIncomingContext(b *testing.B) {
 		}
 	})
 }
+
+// TestString verifies that String shows keys and values only for keys known to
+// be safe to log, omits every other key (including its name) and reports only
+// the count of omitted keys, and never panics on nil/empty inputs.
+func (s) TestString(t *testing.T) {
+	tests := []struct {
+		name string
+		md   MD
+		want string
+	}{
+		{
+			name: "empty",
+			md:   MD{},
+			want: "map[]",
+		},
+		{
+			name: "nil",
+			md:   nil,
+			want: "map[]",
+		},
+		{
+			name: "safe-key-shown",
+			md:   Pairs("content-type", "application/grpc"),
+			want: "map[content-type:[application/grpc]]",
+		},
+		{
+			// A safe key with multiple values shows all of them.
+			name: "safe-key-multi-value",
+			md:   Pairs("grpc-accept-encoding", "gzip", "grpc-accept-encoding", "snappy"),
+			want: "map[grpc-accept-encoding:[gzip snappy]]",
+		},
+		{
+			// nil/empty value slices must not panic; a safe key shows [].
+			name: "safe-key-nil-value",
+			md:   MD{"content-type": nil},
+			want: "map[content-type:[]]",
+		},
+		{
+			// A redacted key with a nil value slice still redacts, no panic.
+			name: "redacted-key-nil-value",
+			md:   MD{"authorization": nil},
+			want: "map[<1 redacted>]",
+		},
+		{
+			// Bracket characters in a safe value are passed through verbatim.
+			name: "safe-value-with-brackets",
+			md:   MD{"content-type": []string{"a]b ["}},
+			want: "map[content-type:[a]b []]",
+		},
+		{
+			// Keys differing only in case are sorted byte-wise (uppercase
+			// first); both still match the case-insensitive safelist.
+			name: "case-only-collision",
+			md:   MD{"Content-Type": []string{"a"}, "content-type": []string{"b"}},
+			want: "map[Content-Type:[a] content-type:[b]]",
+		},
+		{
+			// A sensitive key is omitted entirely, including its name; only the
+			// count is reported.
+			name: "sensitive-key-redacted",
+			md:   Pairs("authorization", "Bearer super-secret-token"),
+			want: "map[<1 redacted>]",
+		},
+		{
+			// Application-defined keys are omitted; the key name (which may
+			// itself be sensitive) is never shown.
+			name: "custom-key-redacted",
+			md:   Pairs("x-my-app-secret", "hunter2"),
+			want: "map[<1 redacted>]",
+		},
+		{
+			// A single key with multiple values counts as one redacted key, and
+			// the value count is not leaked.
+			name: "multi-value-redacted",
+			md:   Pairs("cookie", "a=1", "cookie", "b=2"),
+			want: "map[<1 redacted>]",
+		},
+		{
+			// Multiple redacted keys are reported by count only.
+			name: "multiple-redacted-keys",
+			md:   Pairs("authorization", "tok", "cookie", "x"),
+			want: "map[<2 redacted>]",
+		},
+		{
+			// Safe keys are shown (sorted) and non-safe keys are summarized by a
+			// trailing count.
+			name: "mixed-safe-and-redacted",
+			md:   Pairs("grpc-encoding", "gzip", "authorization", "tok", "user-agent", "grpc-go/x"),
+			want: "map[grpc-encoding:[gzip] user-agent:[grpc-go/x] <1 redacted>]",
+		},
+		{
+			// Keys built via map literal are not canonicalized to lowercase;
+			// the safelist match is case-insensitive so a safe key is still
+			// shown.
+			name: "uppercase-safe-key-shown",
+			md:   MD{"Content-Type": []string{"application/grpc"}},
+			want: "map[Content-Type:[application/grpc]]",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.md.String(); got != test.want {
+				t.Errorf("MD.String() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #7395

MD.String was removed in #7372 because it could leak credentials orother sensitive metadata when an MD was logged (e.g. via log(md)).etcd, the main consumer relying on the old behavior, has since stoppeddepending on it, so it is safe to re-add. This restores MD.String in aredacting form: it prints keys and values only for a fixed allowlist ofnon-sensitive gRPC/HTTP2 protocol headers, and omits (best effort) every other keyentirely (key name included, since a key name may itself be sensitive),reporting only the count as <N redacted>.

RELEASE NOTES:
* metadata: re-add MD.String, which now prints only an allowlist of  non-sensitive protocol headers and redacts all other metadata, to help  avoid accidentally logging credentials or other sensitive data