### PR TITLE
transport: avoid allocation when releasing shared write buffers

### DIFF
--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -299,12 +299,13 @@ func decodeGrpcMessageUnchecked(msg string) string {
 }
 
 type bufWriter struct {
-	pool      *imem.SimpleBufferPool
-	buf       []byte
-	offset    int
-	batchSize int
-	conn      io.Writer
-	err       error
+	pool       *imem.SimpleBufferPool
+	poolHandle *[]byte
+	buf        []byte
+	offset     int
+	batchSize  int
+	conn       io.Writer
+	err        error
 }
 
 func newBufWriter(conn io.Writer, batchSize int, pool *imem.SimpleBufferPool) *bufWriter {
@@ -329,8 +330,8 @@ func (w *bufWriter) Write(b []byte) (int, error) {
 		return n, toIOError(err)
 	}
 	if w.buf == nil {
-		b := w.pool.Get(w.batchSize)
-		w.buf = *b
+		w.poolHandle = w.pool.Get(w.batchSize)
+		w.buf = *w.poolHandle
 	}
 	written := 0
 	for len(b) > 0 {
@@ -350,13 +351,17 @@ func (w *bufWriter) Write(b []byte) (int, error) {
 
 func (w *bufWriter) Flush() error {
 	err := w.flushKeepBuffer()
-	// Only release the buffer if we are in a "shared" mode
-	if w.buf != nil && w.pool != nil {
-		b := w.buf
-		w.pool.Put(&b)
-		w.buf = nil
-	}
+	w.releaseBuffer()
 	return err
+}
+
+func (w *bufWriter) releaseBuffer() {
+	if w.poolHandle != nil {
+		poolHandle := w.poolHandle
+		w.poolHandle = nil
+		w.buf = nil
+		w.pool.Put(poolHandle)
+	}
 }
 
 func (w *bufWriter) flushKeepBuffer() error {
@@ -369,6 +374,9 @@ func (w *bufWriter) flushKeepBuffer() error {
 	_, w.err = w.conn.Write(w.buf[:w.offset])
 	w.err = toIOError(w.err)
 	w.offset = 0
+	if w.err != nil {
+		w.releaseBuffer()
+	}
 	return w.err
 }
 

--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -299,26 +299,30 @@ func decodeGrpcMessageUnchecked(msg string) string {
 }
 
 type bufWriter struct {
-	pool       *imem.SimpleBufferPool
-	poolHandle *[]byte
-	buf        []byte
-	offset     int
-	batchSize  int
-	conn       io.Writer
-	err        error
+	pool      *imem.SimpleBufferPool
+	bufHandle *[]byte
+	offset    int
+	batchSize int
+	conn      io.Writer
+	err       error
+}
+
+// unsharedBufWriter keeps the unshared slice header in the writer allocation.
+type unsharedBufWriter struct {
+	bufWriter
+	buf []byte
 }
 
 func newBufWriter(conn io.Writer, batchSize int, pool *imem.SimpleBufferPool) *bufWriter {
-	w := &bufWriter{
-		batchSize: batchSize,
-		conn:      conn,
-		pool:      pool,
+	if pool == nil && batchSize > 0 {
+		w := &unsharedBufWriter{
+			bufWriter: bufWriter{batchSize: batchSize, conn: conn},
+			buf:       make([]byte, batchSize),
+		}
+		w.bufHandle = &w.buf
+		return &w.bufWriter
 	}
-	// this indicates that we should use non shared buf
-	if pool == nil {
-		w.buf = make([]byte, batchSize)
-	}
-	return w
+	return &bufWriter{batchSize: batchSize, conn: conn, pool: pool}
 }
 
 func (w *bufWriter) Write(b []byte) (int, error) {
@@ -329,13 +333,13 @@ func (w *bufWriter) Write(b []byte) (int, error) {
 		n, err := w.conn.Write(b)
 		return n, toIOError(err)
 	}
-	if w.buf == nil {
-		w.poolHandle = w.pool.Get(w.batchSize)
-		w.buf = *w.poolHandle
+	if w.bufHandle == nil {
+		w.bufHandle = w.pool.Get(w.batchSize)
 	}
+	buf := *w.bufHandle
 	written := 0
 	for len(b) > 0 {
-		copied := copy(w.buf[w.offset:], b)
+		copied := copy(buf[w.offset:], b)
 		b = b[copied:]
 		written += copied
 		w.offset += copied
@@ -356,11 +360,9 @@ func (w *bufWriter) Flush() error {
 }
 
 func (w *bufWriter) releaseBuffer() {
-	if w.poolHandle != nil {
-		poolHandle := w.poolHandle
-		w.poolHandle = nil
-		w.buf = nil
-		w.pool.Put(poolHandle)
+	if w.pool != nil && w.bufHandle != nil {
+		w.pool.Put(w.bufHandle)
+		w.bufHandle = nil
 	}
 }
 
@@ -371,7 +373,8 @@ func (w *bufWriter) flushKeepBuffer() error {
 	if w.offset == 0 {
 		return nil
 	}
-	_, w.err = w.conn.Write(w.buf[:w.offset])
+	buf := *w.bufHandle
+	_, w.err = w.conn.Write(buf[:w.offset])
 	w.err = toIOError(w.err)
 	w.offset = 0
 	if w.err != nil {

--- a/internal/transport/http_util_test.go
+++ b/internal/transport/http_util_test.go
@@ -33,6 +33,7 @@ import (
 
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc/internal/envconfig"
+	imem "google.golang.org/grpc/internal/mem"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/transport/readyreader"
 	"google.golang.org/grpc/mem"
@@ -278,6 +279,156 @@ func (s) TestWriteBadConnection(t *testing.T) {
 		if !errors.Is(err, io.EOF) {
 			t.Fatalf("Write() = %v, want error presence = %v", err, io.EOF)
 		}
+	}
+	if writer.poolHandle != nil || writer.buf != nil {
+		t.Fatalf("failed Write() retained pooled buffer: handle=%p, buf=%p", writer.poolHandle, writer.buf)
+	}
+}
+
+func TestBufWriterSharedFlushAllocations(t *testing.T) {
+	pool := imem.NewDirtySimplePool()
+	writer := newBufWriter(io.Discard, defaultWriteBufSize, pool)
+	payload := make([]byte, 128)
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		if _, err := writer.Write(payload); err != nil {
+			t.Fatalf("Write() failed: %v", err)
+		}
+		if err := writer.Flush(); err != nil {
+			t.Fatalf("Flush() failed: %v", err)
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("shared Write()+Flush() allocated %v times, want 0", allocs)
+	}
+}
+
+func TestBufWriterSharedBufferOwnership(t *testing.T) {
+	const batchSize = 8
+	pool := imem.NewDirtySimplePool()
+	var conn bytes.Buffer
+	writer := newBufWriter(&conn, batchSize, pool)
+
+	if _, err := writer.Write([]byte("abc")); err != nil {
+		t.Fatalf("Write() failed: %v", err)
+	}
+	if writer.poolHandle == nil {
+		t.Fatal("Write() did not retain the pooled buffer handle")
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("Flush() failed: %v", err)
+	}
+	if writer.poolHandle != nil || writer.buf != nil {
+		t.Fatalf("Flush() retained pooled buffer: handle=%p, buf=%p", writer.poolHandle, writer.buf)
+	}
+	if got := conn.String(); got != "abc" {
+		t.Fatalf("conn data = %q, want %q", got, "abc")
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("second Flush() failed: %v", err)
+	}
+
+	if _, err := writer.Write([]byte("12345678")); err != nil {
+		t.Fatalf("full-buffer Write() failed: %v", err)
+	}
+	if writer.poolHandle == nil {
+		t.Fatal("full-buffer Write() released the handle during its internal flush")
+	}
+	if writer.offset != 0 {
+		t.Fatalf("full-buffer Write() offset = %d, want 0", writer.offset)
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("Flush() after full-buffer Write() failed: %v", err)
+	}
+	if writer.poolHandle != nil || writer.buf != nil {
+		t.Fatalf("Flush() retained pooled buffer: handle=%p, buf=%p", writer.poolHandle, writer.buf)
+	}
+}
+
+func TestBufWriterFlushErrorReleasesSharedBuffer(t *testing.T) {
+	pool := imem.NewDirtySimplePool()
+	writer := newBufWriter(&badNetworkConn{}, 8, pool)
+
+	if _, err := writer.Write([]byte("abc")); err != nil {
+		t.Fatalf("Write() failed before flush: %v", err)
+	}
+	if writer.poolHandle == nil {
+		t.Fatal("Write() did not retain the pooled buffer handle")
+	}
+	if err := writer.Flush(); !errors.Is(err, io.EOF) {
+		t.Fatalf("Flush() error = %v, want %v", err, io.EOF)
+	}
+	if writer.poolHandle != nil || writer.buf != nil {
+		t.Fatalf("failed Flush() retained pooled buffer: handle=%p, buf=%p", writer.poolHandle, writer.buf)
+	}
+	if _, err := writer.Write([]byte("def")); !errors.Is(err, io.EOF) {
+		t.Fatalf("Write() after failed Flush() error = %v, want %v", err, io.EOF)
+	}
+	if writer.poolHandle != nil {
+		t.Fatal("Write() after failed Flush() acquired another pooled buffer")
+	}
+}
+
+var benchmarkBufWriterSink *bufWriter
+
+func BenchmarkBufWriter(b *testing.B) {
+	const payloadSize = 128
+	payload := make([]byte, payloadSize)
+
+	for _, test := range []struct {
+		name string
+		pool *imem.SimpleBufferPool
+	}{
+		{name: "Shared", pool: imem.NewDirtySimplePool()},
+		{name: "Unshared"},
+	} {
+		b.Run(test.name, func(b *testing.B) {
+			b.Run("New", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					benchmarkBufWriterSink = newBufWriter(io.Discard, defaultWriteBufSize, test.pool)
+				}
+			})
+
+			b.Run("WriteAndFlush", func(b *testing.B) {
+				writer := newBufWriter(io.Discard, defaultWriteBufSize, test.pool)
+				b.ReportAllocs()
+				b.SetBytes(payloadSize)
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					if _, err := writer.Write(payload); err != nil {
+						b.Fatal(err)
+					}
+					if err := writer.Flush(); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+
+			b.Run("EmptyFlush", func(b *testing.B) {
+				writer := newBufWriter(io.Discard, defaultWriteBufSize, test.pool)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					if err := writer.Flush(); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+
+			b.Run("FullBufferWrite", func(b *testing.B) {
+				writer := newBufWriter(io.Discard, defaultWriteBufSize, test.pool)
+				fullBuffer := make([]byte, defaultWriteBufSize)
+				b.ReportAllocs()
+				b.SetBytes(defaultWriteBufSize)
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					if _, err := writer.Write(fullBuffer); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		})
 	}
 }
 

--- a/internal/transport/http_util_test.go
+++ b/internal/transport/http_util_test.go
@@ -285,7 +285,7 @@ func (s) TestWriteBadConnection(t *testing.T) {
 	}
 }
 
-func TestBufWriterSharedFlushAllocations(t *testing.T) {
+func (s) TestBufWriterSharedFlushAllocations(t *testing.T) {
 	pool := imem.NewDirtySimplePool()
 	writer := newBufWriter(io.Discard, defaultWriteBufSize, pool)
 	payload := make([]byte, 128)
@@ -303,7 +303,7 @@ func TestBufWriterSharedFlushAllocations(t *testing.T) {
 	}
 }
 
-func TestBufWriterSharedBufferOwnership(t *testing.T) {
+func (s) TestBufWriterSharedBufferOwnership(t *testing.T) {
 	const batchSize = 8
 	pool := imem.NewDirtySimplePool()
 	var conn bytes.Buffer
@@ -345,7 +345,7 @@ func TestBufWriterSharedBufferOwnership(t *testing.T) {
 	}
 }
 
-func TestBufWriterFlushErrorReleasesSharedBuffer(t *testing.T) {
+func (s) TestBufWriterFlushErrorReleasesSharedBuffer(t *testing.T) {
 	pool := imem.NewDirtySimplePool()
 	writer := newBufWriter(&badNetworkConn{}, 8, pool)
 
@@ -369,8 +369,6 @@ func TestBufWriterFlushErrorReleasesSharedBuffer(t *testing.T) {
 	}
 }
 
-var benchmarkBufWriterSink *bufWriter
-
 func BenchmarkBufWriter(b *testing.B) {
 	const payloadSize = 128
 	payload := make([]byte, payloadSize)
@@ -385,8 +383,9 @@ func BenchmarkBufWriter(b *testing.B) {
 		b.Run(test.name, func(b *testing.B) {
 			b.Run("New", func(b *testing.B) {
 				b.ReportAllocs()
-				for i := 0; i < b.N; i++ {
-					benchmarkBufWriterSink = newBufWriter(io.Discard, defaultWriteBufSize, test.pool)
+				for b.Loop() {
+					writer := newBufWriter(io.Discard, defaultWriteBufSize, test.pool)
+					_ = writer
 				}
 			})
 
@@ -394,8 +393,7 @@ func BenchmarkBufWriter(b *testing.B) {
 				writer := newBufWriter(io.Discard, defaultWriteBufSize, test.pool)
 				b.ReportAllocs()
 				b.SetBytes(payloadSize)
-				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					if _, err := writer.Write(payload); err != nil {
 						b.Fatal(err)
 					}
@@ -408,8 +406,7 @@ func BenchmarkBufWriter(b *testing.B) {
 			b.Run("EmptyFlush", func(b *testing.B) {
 				writer := newBufWriter(io.Discard, defaultWriteBufSize, test.pool)
 				b.ReportAllocs()
-				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					if err := writer.Flush(); err != nil {
 						b.Fatal(err)
 					}
@@ -421,8 +418,7 @@ func BenchmarkBufWriter(b *testing.B) {
 				fullBuffer := make([]byte, defaultWriteBufSize)
 				b.ReportAllocs()
 				b.SetBytes(defaultWriteBufSize)
-				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					if _, err := writer.Write(fullBuffer); err != nil {
 						b.Fatal(err)
 					}

--- a/internal/transport/http_util_test.go
+++ b/internal/transport/http_util_test.go
@@ -280,8 +280,8 @@ func (s) TestWriteBadConnection(t *testing.T) {
 			t.Fatalf("Write() = %v, want error presence = %v", err, io.EOF)
 		}
 	}
-	if writer.poolHandle != nil || writer.buf != nil {
-		t.Fatalf("failed Write() retained pooled buffer: handle=%p, buf=%p", writer.poolHandle, writer.buf)
+	if writer.bufHandle != nil {
+		t.Fatalf("failed Write() retained pooled buffer: handle=%p", writer.bufHandle)
 	}
 }
 
@@ -312,14 +312,14 @@ func TestBufWriterSharedBufferOwnership(t *testing.T) {
 	if _, err := writer.Write([]byte("abc")); err != nil {
 		t.Fatalf("Write() failed: %v", err)
 	}
-	if writer.poolHandle == nil {
+	if writer.bufHandle == nil {
 		t.Fatal("Write() did not retain the pooled buffer handle")
 	}
 	if err := writer.Flush(); err != nil {
 		t.Fatalf("Flush() failed: %v", err)
 	}
-	if writer.poolHandle != nil || writer.buf != nil {
-		t.Fatalf("Flush() retained pooled buffer: handle=%p, buf=%p", writer.poolHandle, writer.buf)
+	if writer.bufHandle != nil {
+		t.Fatalf("Flush() retained pooled buffer: handle=%p", writer.bufHandle)
 	}
 	if got := conn.String(); got != "abc" {
 		t.Fatalf("conn data = %q, want %q", got, "abc")
@@ -331,7 +331,7 @@ func TestBufWriterSharedBufferOwnership(t *testing.T) {
 	if _, err := writer.Write([]byte("12345678")); err != nil {
 		t.Fatalf("full-buffer Write() failed: %v", err)
 	}
-	if writer.poolHandle == nil {
+	if writer.bufHandle == nil {
 		t.Fatal("full-buffer Write() released the handle during its internal flush")
 	}
 	if writer.offset != 0 {
@@ -340,8 +340,8 @@ func TestBufWriterSharedBufferOwnership(t *testing.T) {
 	if err := writer.Flush(); err != nil {
 		t.Fatalf("Flush() after full-buffer Write() failed: %v", err)
 	}
-	if writer.poolHandle != nil || writer.buf != nil {
-		t.Fatalf("Flush() retained pooled buffer: handle=%p, buf=%p", writer.poolHandle, writer.buf)
+	if writer.bufHandle != nil {
+		t.Fatalf("Flush() retained pooled buffer: handle=%p", writer.bufHandle)
 	}
 }
 
@@ -352,19 +352,19 @@ func TestBufWriterFlushErrorReleasesSharedBuffer(t *testing.T) {
 	if _, err := writer.Write([]byte("abc")); err != nil {
 		t.Fatalf("Write() failed before flush: %v", err)
 	}
-	if writer.poolHandle == nil {
+	if writer.bufHandle == nil {
 		t.Fatal("Write() did not retain the pooled buffer handle")
 	}
 	if err := writer.Flush(); !errors.Is(err, io.EOF) {
 		t.Fatalf("Flush() error = %v, want %v", err, io.EOF)
 	}
-	if writer.poolHandle != nil || writer.buf != nil {
-		t.Fatalf("failed Flush() retained pooled buffer: handle=%p, buf=%p", writer.poolHandle, writer.buf)
+	if writer.bufHandle != nil {
+		t.Fatalf("failed Flush() retained pooled buffer: handle=%p", writer.bufHandle)
 	}
 	if _, err := writer.Write([]byte("def")); !errors.Is(err, io.EOF) {
 		t.Fatalf("Write() after failed Flush() error = %v, want %v", err, io.EOF)
 	}
-	if writer.poolHandle != nil {
+	if writer.bufHandle != nil {
 		t.Fatal("Write() after failed Flush() acquired another pooled buffer")
 	}
 }


### PR DESCRIPTION
Shared write buffers currently add one heap allocation whenever `bufWriter` returns a buffer to the pool. This PR removes that allocation. It does not change when buffers are shared or released, and it does not change Go's GC pacing.

After upgrading a service with many long lived gRPC connections and streaming responses, we saw more time spent in garbage collection. The investigation found two separate effects:

1. Shared write buffers reduce retained heap, which can cause Go to collect more frequently depending on the application's GC settings.
2. `bufWriter.Flush` copies the buffer's slice header into a local variable and passes its address to the pool. That local variable escapes to the heap, adding one 24-byte allocation to every write and flush cycle.

This PR only fixes the second issue.

The writer now keeps the pointer returned by the pool while the buffer is in use and returns that same pointer after flushing. It also releases the buffer when a network write fails before the normal `Flush` path.

The benchmark added in this change can be run with:

```console
go test ./internal/transport -run '^$' -bench '^BenchmarkBufWriter/Shared/WriteAndFlush$' -benchmem -count=10
```

Results on an Apple M4 Pro with Go 1.26.5:

```text
before: 24.2-26.2 ns/op, 24 B/op, 1 alloc/op
after:  13.5-13.9 ns/op,  0 B/op, 0 alloc/op
```

Tests run:

```console
go test -cpu 1,4 -timeout 7m ./internal/transport
go test -race -cpu 1,4 -timeout 7m ./internal/transport
```

RELEASE NOTES:
* transport: Avoid a heap allocation when flushing the write buffer.
