### PR TITLE
Cherry-pick commits

### DIFF
--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -141,6 +141,17 @@ var (
 	// feature if unforeseen issues arise, and it will be removed in a future
 	// release.
 	EnableHTTPFramerReadBufferPooling = boolFromEnv("GRPC_GO_EXPERIMENTAL_HTTP_FRAMER_READ_BUFFER_POOLING", true)
+
+	// ControlBufferThrottleLimit is the maximum number of control frames that can
+	// be queued in the control buffer before throttling is applied. The value
+	// must be between 1 and 10,000, and is set to 100 by default.
+	//
+	// This environment variable serves as an escape hatch to increase the
+	// throttling limit if unforeseen issues arise, and it will be removed in a
+	// future release.
+	//
+	// TODO: Remove this env var once v1.83.0 is release.
+	ControlBufferThrottleLimit = uint64FromEnv("GRPC_GO_EXPERIMENTAL_CONTROL_BUFFER_THROTTLE_LIMIT", 100, 1, 10000)
 )
 
 func boolFromEnv(envVar string, def bool) bool {

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -29,6 +29,7 @@ import (
 
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
+	"google.golang.org/grpc/internal/envconfig"
 	"google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/mem"
 )
@@ -96,60 +97,69 @@ func (il *itemList) isEmpty() bool {
 	return il.head == nil
 }
 
+// maxQueuedControlBufferItems is the maximum number of frames (other than
+// HEADERS and DATA) that we will buffer before preventing new reads from
+// occurring on the transport.  These are control frames sent in response to
+// client requests, or frames that result in work being scheduled, such as
+// RST_STREAM due to bad headers or settings acks.
+var maxQueuedControlBufferItems = int(envconfig.ControlBufferThrottleLimit)
+
+type cbItem interface {
+	isThrottled() bool
+}
+
+// throttledItem represents every item in the controlBuffer to which the overall
+// throttling limit applies, other than outgoing HEADERS and DATA frames.
+type throttledItem struct{}
+
+func (throttledItem) isThrottled() bool { return true }
+
 // The following defines various control items which could flow through
 // the control buffer of transport. They represent different aspects of
 // control tasks, e.g., flow control, settings, streaming resetting, etc.
 
-// maxQueuedTransportResponseFrames is the most queued "transport response"
-// frames we will buffer before preventing new reads from occurring on the
-// transport.  These are control frames sent in response to client requests,
-// such as RST_STREAM due to bad headers or settings acks.
-const maxQueuedTransportResponseFrames = 50
-
-type cbItem interface {
-	isTransportResponseFrame() bool
-}
-
 // registerStream is used to register an incoming stream with loopy writer.
 type registerStream struct {
+	throttledItem
 	streamID uint32
 	wq       *writeQuota
 }
 
-func (*registerStream) isTransportResponseFrame() bool { return false }
-
-// headerFrame is also used to register stream on the client-side.
-type headerFrame struct {
+type clientHeaders struct {
 	streamID   uint32
 	hf         []hpack.HeaderField
-	endStream  bool               // Valid on server side.
-	initStream func(uint32) error // Used only on the client side.
+	initStream func(uint32) error
 	onWrite    func()
-	wq         *writeQuota    // write quota for the stream created.
-	cleanup    *cleanupStream // Valid on the server side.
-	onOrphaned func(error)    // Valid on client-side
+	wq         *writeQuota
+	onOrphaned func(error)
 }
 
-func (h *headerFrame) isTransportResponseFrame() bool {
-	return h.cleanup != nil && h.cleanup.rst // Results in a RST_STREAM
+func (*clientHeaders) isThrottled() bool { return false }
+
+type serverHeaders struct {
+	streamID  uint32
+	hf        []hpack.HeaderField
+	endStream bool
+	onWrite   func()
+	cleanup   *cleanupStream
 }
+
+func (h *serverHeaders) isThrottled() bool { return false }
 
 type cleanupStream struct {
+	throttledItem
 	streamID uint32
 	rst      bool
 	rstCode  http2.ErrCode
 	onWrite  func()
 }
 
-func (c *cleanupStream) isTransportResponseFrame() bool { return c.rst } // Results in a RST_STREAM
-
 type earlyAbortStream struct {
+	throttledItem
 	streamID uint32
 	rst      bool
 	hf       []hpack.HeaderField // Pre-built header fields
 }
-
-func (*earlyAbortStream) isTransportResponseFrame() bool { return false }
 
 type dataFrame struct {
 	streamID   uint32
@@ -162,70 +172,60 @@ type dataFrame struct {
 	onEachWrite func()
 }
 
-func (*dataFrame) isTransportResponseFrame() bool { return false }
+func (*dataFrame) isThrottled() bool { return false }
 
 type incomingWindowUpdate struct {
+	throttledItem
 	streamID  uint32
 	increment uint32
 }
-
-func (*incomingWindowUpdate) isTransportResponseFrame() bool { return false }
 
 type outgoingWindowUpdate struct {
+	throttledItem
 	streamID  uint32
 	increment uint32
-}
-
-func (*outgoingWindowUpdate) isTransportResponseFrame() bool {
-	return false // window updates are throttled by thresholds
 }
 
 type incomingSettings struct {
+	throttledItem
 	ss []http2.Setting
 }
-
-func (*incomingSettings) isTransportResponseFrame() bool { return true } // Results in a settings ACK
 
 type outgoingSettings struct {
+	throttledItem
 	ss []http2.Setting
 }
 
-func (*outgoingSettings) isTransportResponseFrame() bool { return false }
-
 type incomingGoAway struct {
+	throttledItem
 }
 
-func (*incomingGoAway) isTransportResponseFrame() bool { return false }
-
 type goAway struct {
+	throttledItem
 	code      http2.ErrCode
 	debugData []byte
 	headsUp   bool
 	closeConn error // if set, loopyWriter will exit with this error
 }
 
-func (*goAway) isTransportResponseFrame() bool { return false }
-
 type ping struct {
+	throttledItem
 	ack  bool
 	data [8]byte
 }
 
-func (*ping) isTransportResponseFrame() bool { return true }
-
 type outFlowControlSizeRequest struct {
+	throttledItem
 	resp chan uint32
 }
-
-func (*outFlowControlSizeRequest) isTransportResponseFrame() bool { return false }
 
 // closeConnection is an instruction to tell the loopy writer to flush the
 // framer and exit, which will cause the transport's connection to be closed
 // (by the client or server).  The transport itself will close after the reader
 // encounters the EOF caused by the connection closure.
-type closeConnection struct{}
-
-func (closeConnection) isTransportResponseFrame() bool { return false }
+type closeConnection struct {
+	throttledItem
+}
 
 type outStreamState int
 
@@ -379,9 +379,9 @@ func (c *controlBuffer) executeAndPut(f func() bool, it cbItem) (bool, error) {
 		c.consumerWaiting = false
 	}
 	c.list.enqueue(it)
-	if it.isTransportResponseFrame() {
+	if it.isThrottled() {
 		c.transportResponseFrames++
-		if c.transportResponseFrames == maxQueuedTransportResponseFrames {
+		if c.transportResponseFrames == maxQueuedControlBufferItems {
 			// We are adding the frame that puts us over the threshold; create
 			// a throttling channel.
 			ch := make(chan struct{})
@@ -436,8 +436,8 @@ func (c *controlBuffer) getOnceLocked() (any, error) {
 		return nil, nil
 	}
 	h := c.list.dequeue().(cbItem)
-	if h.isTransportResponseFrame() {
-		if c.transportResponseFrames == maxQueuedTransportResponseFrames {
+	if h.isThrottled() {
+		if c.transportResponseFrames == maxQueuedControlBufferItems {
 			// We are removing the frame that put us over the
 			// threshold; close and clear the throttling channel.
 			ch := c.trfChan.Swap(nil)
@@ -464,10 +464,8 @@ func (c *controlBuffer) finish() {
 	// is still not aware of these yet.
 	for head := c.list.dequeueAll(); head != nil; head = head.next {
 		switch v := head.it.(type) {
-		case *headerFrame:
-			if v.onOrphaned != nil { // It will be nil on the server-side.
-				v.onOrphaned(ErrConnClosing)
-			}
+		case *clientHeaders:
+			v.onOrphaned(ErrConnClosing)
 		case *dataFrame:
 			if !v.processing {
 				v.data.Free()
@@ -680,42 +678,38 @@ func (l *loopyWriter) registerStreamHandler(h *registerStream) {
 	l.estdStreams[h.streamID] = str
 }
 
-func (l *loopyWriter) headerHandler(h *headerFrame) error {
-	if l.side == serverSide {
-		str, ok := l.estdStreams[h.streamID]
-		if !ok {
-			if l.logger.V(logLevel) {
-				l.logger.Infof("Unrecognized streamID %d in loopyWriter", h.streamID)
-			}
-			return nil
+func (l *loopyWriter) serverHeaderHandler(hdr *serverHeaders) error {
+	str, ok := l.estdStreams[hdr.streamID]
+	if !ok {
+		if l.logger.V(logLevel) {
+			l.logger.Infof("Unrecognized streamID %d in loopyWriter", hdr.streamID)
 		}
-		// Case 1.A: Server is responding back with headers.
-		if !h.endStream {
-			return l.writeHeader(h.streamID, h.endStream, h.hf, h.onWrite)
-		}
-		// else:  Case 1.B: Server wants to close stream.
+		return nil
+	}
 
-		if str.state != empty { // either active or waiting on stream quota.
-			// add it str's list of items.
-			str.itl.enqueue(h)
-			return nil
-		}
-		if err := l.writeHeader(h.streamID, h.endStream, h.hf, h.onWrite); err != nil {
-			return err
-		}
-		return l.cleanupStreamHandler(h.cleanup)
+	// Case 1: Server is responding back with headers.
+	if !hdr.endStream {
+		return l.writeHeader(hdr.streamID, hdr.endStream, hdr.hf, hdr.onWrite)
 	}
-	// Case 2: Client wants to originate stream.
-	str := &outStream{
-		id:    h.streamID,
-		state: empty,
-		itl:   &itemList{},
-		wq:    h.wq,
+
+	// Case 2: Server is closing the stream.
+	if str.state != empty { // either active or waiting on stream quota.
+		str.itl.enqueue(hdr)
+		return nil
 	}
-	return l.originateStream(str, h)
+	if err := l.writeHeader(hdr.streamID, hdr.endStream, hdr.hf, hdr.onWrite); err != nil {
+		return err
+	}
+	return l.cleanupStreamHandler(hdr.cleanup)
 }
 
-func (l *loopyWriter) originateStream(str *outStream, hdr *headerFrame) error {
+func (l *loopyWriter) clientHeaderHandler(hdr *clientHeaders) error {
+	str := &outStream{
+		id:    hdr.streamID,
+		state: empty,
+		itl:   &itemList{},
+		wq:    hdr.wq,
+	}
 	// l.draining is set when handling GoAway. In which case, we want to avoid
 	// creating new streams.
 	if l.draining {
@@ -726,7 +720,7 @@ func (l *loopyWriter) originateStream(str *outStream, hdr *headerFrame) error {
 	if err := hdr.initStream(str.id); err != nil {
 		return err
 	}
-	if err := l.writeHeader(str.id, hdr.endStream, hdr.hf, hdr.onWrite); err != nil {
+	if err := l.writeHeader(str.id, false, hdr.hf, hdr.onWrite); err != nil {
 		return err
 	}
 	l.estdStreams[str.id] = str
@@ -882,8 +876,10 @@ func (l *loopyWriter) handle(i any) error {
 		return l.incomingSettingsHandler(i)
 	case *outgoingSettings:
 		return l.outgoingSettingsHandler(i)
-	case *headerFrame:
-		return l.headerHandler(i)
+	case *clientHeaders:
+		return l.clientHeaderHandler(i)
+	case *serverHeaders:
+		return l.serverHeaderHandler(i)
 	case *registerStream:
 		l.registerStreamHandler(i)
 	case *cleanupStream:
@@ -1022,7 +1018,7 @@ func (l *loopyWriter) processData() (bool, error) {
 func (l *loopyWriter) updateStreamAfterWrite(str *outStream) error {
 	if str.itl.isEmpty() {
 		str.state = empty
-	} else if trailer, ok := str.itl.peek().(*headerFrame); ok { // the next item is trailers.
+	} else if trailer, ok := str.itl.peek().(*serverHeaders); ok { // the next item is trailers.
 		if err := l.writeHeader(trailer.streamID, trailer.endStream, trailer.hf, trailer.onWrite); err != nil {
 			return err
 		}

--- a/internal/transport/controlbuf_test.go
+++ b/internal/transport/controlbuf_test.go
@@ -1,0 +1,85 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package transport
+
+import (
+	"testing"
+	"time"
+)
+
+func (s) TestControlBuffer_Throttle(t *testing.T) {
+	done := make(chan struct{})
+	defer close(done)
+	cb := newControlBuffer(done)
+
+	// Fill the control buffer up to the limit with throttled items.
+	for i := 0; i < maxQueuedControlBufferItems; i++ {
+		cb.put(&ping{})
+	}
+
+	// The next call to throttle should block.
+	throttleDone := make(chan struct{})
+	go func() {
+		cb.throttle()
+		close(throttleDone)
+	}()
+
+	select {
+	case <-throttleDone:
+		t.Fatal("throttle() did not block when the buffer was full")
+	case <-time.After(defaultTestShortTimeout):
+	}
+
+	// Consume one item from the control buffer.
+	if _, err := cb.get(true); err != nil {
+		t.Fatalf("cb.get(true) failed: %v", err)
+	}
+
+	// Now throttle() should unblock.
+	select {
+	case <-throttleDone:
+	case <-time.After(time.Second):
+		t.Fatal("throttle() did not unblock after an item was consumed")
+	}
+}
+
+func (s) TestControlBuffer_NoThrottleForNonThrottledItems(t *testing.T) {
+	done := make(chan struct{})
+	defer close(done)
+	cb := newControlBuffer(done)
+
+	// Fill the control buffer with many more than limit number of non-throttled
+	// items.
+	for i := 0; i < maxQueuedControlBufferItems+10; i++ {
+		cb.put(&dataFrame{})
+	}
+
+	// throttle() should not block.
+	throttled := make(chan struct{})
+	go func() {
+		cb.throttle()
+		close(throttled)
+	}()
+
+	select {
+	case <-throttled:
+	case <-time.After(defaultTestShortTimeout):
+		t.Fatal("throttle() blocked for non-throttled items")
+	}
+}

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -806,9 +806,8 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr, handler s
 			close(s.headerChan)
 		}
 	}
-	hdr := &headerFrame{
-		hf:        headerFields,
-		endStream: false,
+	hdr := &clientHeaders{
+		hf: headerFields,
 		initStream: func(uint32) error {
 			t.mu.Lock()
 			// TODO: handle transport closure in loopy instead and remove this
@@ -1251,7 +1250,10 @@ func (t *http2Client) handleData(f *parsedDataFrame) {
 		dataLen := f.data.Len()
 		if f.Header().Flags.Has(http2.FlagDataPadded) {
 			if w := s.fc.onRead(size - uint32(dataLen)); w > 0 {
-				t.controlBuf.put(&outgoingWindowUpdate{s.id, w})
+				t.controlBuf.put(&outgoingWindowUpdate{
+					streamID:  s.id,
+					increment: w,
+				})
 			}
 		}
 		if dataLen > 0 {
@@ -1879,7 +1881,7 @@ func (t *http2Client) getOutFlowWindow() int64 {
 	resp := make(chan uint32, 1)
 	timer := time.NewTimer(time.Second)
 	defer timer.Stop()
-	t.controlBuf.put(&outFlowControlSizeRequest{resp})
+	t.controlBuf.put(&outFlowControlSizeRequest{resp: resp})
 	select {
 	case sz := <-resp:
 		return int64(sz)

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -810,7 +810,10 @@ func (t *http2Server) handleData(f *parsedDataFrame) {
 		dataLen := f.data.Len()
 		if f.Header().Flags.Has(http2.FlagDataPadded) {
 			if w := s.fc.onRead(size - uint32(dataLen)); w > 0 {
-				t.controlBuf.put(&outgoingWindowUpdate{s.id, w})
+				t.controlBuf.put(&outgoingWindowUpdate{
+					streamID:  s.id,
+					increment: w,
+				})
 			}
 		}
 		if dataLen > 0 {
@@ -1047,7 +1050,7 @@ func (t *http2Server) writeHeaderLocked(s *ServerStream) error {
 		headerFields = append(headerFields, hpack.HeaderField{Name: "grpc-encoding", Value: s.sendCompress})
 	}
 	headerFields = appendHeaderFieldsFromMD(headerFields, s.header)
-	hf := &headerFrame{
+	hf := &serverHeaders{
 		streamID:  s.id,
 		hf:        headerFields,
 		endStream: false,
@@ -1115,7 +1118,7 @@ func (t *http2Server) writeStatus(s *ServerStream, st *status.Status) error {
 
 	// Attach the trailer metadata.
 	headerFields = appendHeaderFieldsFromMD(headerFields, s.trailer)
-	trailingHeader := &headerFrame{
+	trailingHeader := &serverHeaders{
 		streamID:  s.id,
 		hf:        headerFields,
 		endStream: true,
@@ -1325,7 +1328,7 @@ func (t *http2Server) deleteStream(s *ServerStream, eosReceived bool) {
 }
 
 // finishStream closes the stream and puts the trailing headerFrame into controlbuf.
-func (t *http2Server) finishStream(s *ServerStream, rst bool, rstCode http2.ErrCode, hdr *headerFrame, eosReceived bool) {
+func (t *http2Server) finishStream(s *ServerStream, rst bool, rstCode http2.ErrCode, hdr *serverHeaders, eosReceived bool) {
 	// In case stream sending and receiving are invoked in separate
 	// goroutines (e.g., bi-directional streaming), cancel needs to be
 	// called to interrupt the potential blocking on other goroutines.
@@ -1464,7 +1467,7 @@ func (t *http2Server) getOutFlowWindow() int64 {
 	resp := make(chan uint32, 1)
 	timer := time.NewTimer(time.Second)
 	defer timer.Stop()
-	t.controlBuf.put(&outFlowControlSizeRequest{resp})
+	t.controlBuf.put(&outFlowControlSizeRequest{resp: resp})
 	select {
 	case sz := <-resp:
 		return int64(sz)

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -225,7 +225,7 @@ func (h *testStreamHandler) handleStreamEncodingRequiredStatus(s *ServerStream) 
 func (h *testStreamHandler) handleStreamInvalidContentType(s *ServerStream) {
 	headerFields := []hpack.HeaderField{}
 	headerFields = append(headerFields, hpack.HeaderField{Name: "content-type", Value: expectedInvalidHeaderField})
-	h.t.controlBuf.put(&headerFrame{
+	h.t.controlBuf.put(&serverHeaders{
 		streamID:  s.id,
 		hf:        headerFields,
 		endStream: true,
@@ -239,7 +239,7 @@ func (h *testStreamHandler) handleStreamInvalidContentType(s *ServerStream) {
 func (h *testStreamHandler) handleStreamInvalidContentTypeWithMultipleFrame(s *ServerStream) {
 	headerFields := []hpack.HeaderField{}
 	headerFields = append(headerFields, hpack.HeaderField{Name: "content-type", Value: expectedInvalidHeaderField})
-	h.t.controlBuf.put(&headerFrame{
+	h.t.controlBuf.put(&serverHeaders{
 		streamID:  s.id,
 		hf:        headerFields,
 		endStream: false,
@@ -271,7 +271,7 @@ func (h *testStreamHandler) handleStreamMalformedHeader(s *ServerStream) {
 		{Name: "content-type", Value: "application/grpc"},
 		{Name: "x-bad-bin", Value: "!!!invalid-base64!!!"},
 	}
-	h.t.controlBuf.put(&headerFrame{
+	h.t.controlBuf.put(&serverHeaders{
 		streamID:  s.id,
 		hf:        headerFields,
 		endStream: false,

--- a/internal/xds/rbac/matchers.go
+++ b/internal/xds/rbac/matchers.go
@@ -78,7 +78,7 @@ func (pm *policyMatcher) match(data *rpcData) bool {
 func matchersFromPermissions(permissions []*v3rbacpb.Permission) ([]matcher, error) {
 	var matchers []matcher
 	for _, permission := range permissions {
-		switch permission.GetRule().(type) {
+		switch p := permission.GetRule().(type) {
 		case *v3rbacpb.Permission_AndRules:
 			mList, err := matchersFromPermissions(permission.GetAndRules().Rules)
 			if err != nil {
@@ -120,16 +120,24 @@ func matchersFromPermissions(permissions []*v3rbacpb.Permission) ([]matcher, err
 			if err != nil {
 				return nil, err
 			}
+			if len(mList) != 1 {
+				return nil, fmt.Errorf("NotRule must contain exactly one rule")
+			}
 			matchers = append(matchers, &notMatcher{matcherToNot: mList[0]})
 		case *v3rbacpb.Permission_Metadata:
-			// Never matches - so no-op if not inverted, always match if
-			// inverted.
-			if permission.GetMetadata().GetInvert() { // Test metadata being no-op and also metadata with invert always matching
+			if permission.GetMetadata().GetInvert() {
 				matchers = append(matchers, &alwaysMatcher{})
+			} else {
+				matchers = append(matchers, &neverMatcher{})
 			}
 		case *v3rbacpb.Permission_RequestedServerName:
-			// Not supported in gRPC RBAC currently - a permission typed as
-			// requested server name in the initial config will be a no-op.
+			m, err := newRequestedServerNameMatcher(permission.GetRequestedServerName())
+			if err != nil {
+				return nil, err
+			}
+			matchers = append(matchers, m)
+		default:
+			return nil, fmt.Errorf("unsupported permission rule type: %T", p)
 		}
 	}
 	return matchers, nil
@@ -138,7 +146,7 @@ func matchersFromPermissions(permissions []*v3rbacpb.Permission) ([]matcher, err
 func matchersFromPrincipals(principals []*v3rbacpb.Principal) ([]matcher, error) {
 	var matchers []matcher
 	for _, principal := range principals {
-		switch principal.GetIdentifier().(type) {
+		switch p := principal.GetIdentifier().(type) {
 		case *v3rbacpb.Principal_AndIds:
 			mList, err := matchersFromPrincipals(principal.GetAndIds().Ids)
 			if err != nil {
@@ -178,16 +186,29 @@ func matchersFromPrincipals(principals []*v3rbacpb.Principal) ([]matcher, error)
 				return nil, err
 			}
 			matchers = append(matchers, m)
+		case *v3rbacpb.Principal_Metadata:
+			if principal.GetMetadata().GetInvert() {
+				matchers = append(matchers, &alwaysMatcher{})
+			} else {
+				matchers = append(matchers, &neverMatcher{})
+			}
 		case *v3rbacpb.Principal_NotId:
 			mList, err := matchersFromPrincipals([]*v3rbacpb.Principal{{Identifier: principal.GetNotId().Identifier}})
 			if err != nil {
 				return nil, err
 			}
+			if len(mList) != 1 {
+				return nil, fmt.Errorf("NotId must contain exactly one identifier")
+			}
 			matchers = append(matchers, &notMatcher{matcherToNot: mList[0]})
 		case *v3rbacpb.Principal_SourceIp:
-			// The source ip principal identifier is deprecated. Thus, a
-			// principal typed as a source ip in the identifier will be a no-op.
-			// The config should use DirectRemoteIp instead.
+			// The source ip principal identifier is deprecated, but gRPC RBAC
+			// treats it as equivalent to direct_remote_ip as per A41.
+			m, err := newRemoteIPMatcher(principal.GetSourceIp())
+			if err != nil {
+				return nil, err
+			}
+			matchers = append(matchers, m)
 		case *v3rbacpb.Principal_RemoteIp:
 			// RBAC in gRPC treats direct_remote_ip and remote_ip as logically
 			// equivalent, as per A41.
@@ -196,9 +217,8 @@ func matchersFromPrincipals(principals []*v3rbacpb.Principal) ([]matcher, error)
 				return nil, err
 			}
 			matchers = append(matchers, m)
-		case *v3rbacpb.Principal_Metadata:
-			// Not supported in gRPC RBAC currently - a principal typed as
-			// Metadata in the initial config will be a no-op.
+		default:
+			return nil, fmt.Errorf("unsupported principal identifier type: %T", p)
 		}
 	}
 	return matchers, nil
@@ -246,6 +266,16 @@ type alwaysMatcher struct {
 
 func (am *alwaysMatcher) match(*rpcData) bool {
 	return true
+}
+
+// neverMatcher is a matcher that will never match. This logically represents a
+// permission or principal that is unsupported in gRPC. neverMatcher implements
+// the matcher interface.
+type neverMatcher struct {
+}
+
+func (nm *neverMatcher) match(*rpcData) bool {
+	return false
 }
 
 // notMatcher is a matcher that nots an underlying matcher. notMatcher
@@ -395,6 +425,25 @@ func newPortMatcher(destinationPort uint32) *portMatcher {
 
 func (pm *portMatcher) match(data *rpcData) bool {
 	return data.destinationPort == pm.destinationPort
+}
+
+// requestedServerNameMatcher matches on if the given string matcher matches
+// on "", as per A41-xds-rbac.md. requestedServerNameMatcher implements
+// the matcher interface.
+type requestedServerNameMatcher struct {
+	stringMatcher internalmatcher.StringMatcher
+}
+
+func newRequestedServerNameMatcher(stringMatcherProto *v3matcherpb.StringMatcher) (*requestedServerNameMatcher, error) {
+	stringMatcher, err := internalmatcher.StringMatcherFromProto(stringMatcherProto)
+	if err != nil {
+		return nil, err
+	}
+	return &requestedServerNameMatcher{stringMatcher: stringMatcher}, nil
+}
+
+func (r *requestedServerNameMatcher) match(*rpcData) bool {
+	return r.stringMatcher.Match("")
 }
 
 // authenticatedMatcher matches on the name of the Principal. If set, the URI

--- a/internal/xds/rbac/rbac_engine_test.go
+++ b/internal/xds/rbac/rbac_engine_test.go
@@ -667,6 +667,185 @@ func (s) TestNewChainEngine(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "Unsupported_field_in_NotRule",
+			policies: []*v3rbacpb.RBAC{
+				{
+					Action: v3rbacpb.RBAC_ALLOW,
+					Policies: map[string]*v3rbacpb.Policy{
+						"anyone": {
+							Permissions: []*v3rbacpb.Permission{
+								{
+									Rule: &v3rbacpb.Permission_NotRule{
+										NotRule: &v3rbacpb.Permission{
+											Rule: &v3rbacpb.Permission_SourcedMetadata{
+												SourcedMetadata: &v3rbacpb.SourcedMetadata{},
+											},
+										},
+									},
+								},
+							},
+							Principals: []*v3rbacpb.Principal{
+								{Identifier: &v3rbacpb.Principal_Any{Any: true}},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "supported_and_unsupported_fields_in_NotRule",
+			policies: []*v3rbacpb.RBAC{
+				{
+					Action: v3rbacpb.RBAC_ALLOW,
+					Policies: map[string]*v3rbacpb.Policy{
+						"anyone": {
+							Permissions: []*v3rbacpb.Permission{
+								{
+									Rule: &v3rbacpb.Permission_NotRule{
+										NotRule: &v3rbacpb.Permission{
+											Rule: &v3rbacpb.Permission_AndRules{
+												AndRules: &v3rbacpb.Permission_Set{
+													Rules: []*v3rbacpb.Permission{
+														{
+															Rule: &v3rbacpb.Permission_UrlPath{
+																UrlPath: &v3matcherpb.PathMatcher{
+																	Rule: &v3matcherpb.PathMatcher_Path{
+																		Path: &v3matcherpb.StringMatcher{
+																			MatchPattern: &v3matcherpb.StringMatcher_Exact{Exact: "allowed"},
+																		},
+																	},
+																},
+															},
+														},
+														{
+															Rule: &v3rbacpb.Permission_SourcedMetadata{
+																SourcedMetadata: &v3rbacpb.SourcedMetadata{},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Principals: []*v3rbacpb.Principal{
+								{Identifier: &v3rbacpb.Principal_Any{Any: true}},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Unsupported_field_in_NotId",
+			policies: []*v3rbacpb.RBAC{
+				{
+					Action: v3rbacpb.RBAC_ALLOW,
+					Policies: map[string]*v3rbacpb.Policy{
+						"anyone": {
+							Permissions: []*v3rbacpb.Permission{
+								{Rule: &v3rbacpb.Permission_Any{Any: true}},
+							},
+							Principals: []*v3rbacpb.Principal{
+								{
+									Identifier: &v3rbacpb.Principal_NotId{
+										NotId: &v3rbacpb.Principal{
+											Identifier: &v3rbacpb.Principal_SourcedMetadata{
+												SourcedMetadata: &v3rbacpb.SourcedMetadata{},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "supported_and_unsupported_fields_in_NotId",
+			policies: []*v3rbacpb.RBAC{
+				{
+					Action: v3rbacpb.RBAC_ALLOW,
+					Policies: map[string]*v3rbacpb.Policy{
+						"anyone": {
+							Permissions: []*v3rbacpb.Permission{
+								{Rule: &v3rbacpb.Permission_Any{Any: true}},
+							},
+							Principals: []*v3rbacpb.Principal{
+								{
+									Identifier: &v3rbacpb.Principal_NotId{
+										NotId: &v3rbacpb.Principal{
+											Identifier: &v3rbacpb.Principal_AndIds{
+												AndIds: &v3rbacpb.Principal_Set{
+													Ids: []*v3rbacpb.Principal{
+														{
+															Identifier: &v3rbacpb.Principal_DirectRemoteIp{
+																DirectRemoteIp: &v3corepb.CidrRange{
+																	AddressPrefix: "0.0.0.0",
+																	PrefixLen:     &wrapperspb.UInt32Value{Value: uint32(10)},
+																},
+															},
+														},
+														{
+															Identifier: &v3rbacpb.Principal_SourcedMetadata{
+																SourcedMetadata: &v3rbacpb.SourcedMetadata{},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "PermissionMetadata",
+			policies: []*v3rbacpb.RBAC{
+				{
+					Action: v3rbacpb.RBAC_ALLOW,
+					Policies: map[string]*v3rbacpb.Policy{
+						"metadata-permission": {
+							Permissions: []*v3rbacpb.Permission{
+								{Rule: &v3rbacpb.Permission_Metadata{Metadata: &v3matcherpb.MetadataMatcher{}}},
+							},
+							Principals: []*v3rbacpb.Principal{
+								{Identifier: &v3rbacpb.Principal_Any{Any: true}},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "PrincipalMetadata",
+			policies: []*v3rbacpb.RBAC{
+				{
+					Action: v3rbacpb.RBAC_ALLOW,
+					Policies: map[string]*v3rbacpb.Policy{
+						"metadata-principal": {
+							Permissions: []*v3rbacpb.Permission{
+								{Rule: &v3rbacpb.Permission_Any{Any: true}},
+							},
+							Principals: []*v3rbacpb.Principal{
+								{Identifier: &v3rbacpb.Principal_Metadata{Metadata: &v3matcherpb.MetadataMatcher{}}},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -702,6 +881,180 @@ func (s) TestChainEngine(t *testing.T) {
 		rbacQueries []rbacQuery
 		policyName  string
 	}{
+		{
+			name: "PermissionMetadata",
+			rbacConfigs: []*v3rbacpb.RBAC{
+				{
+					Policies: map[string]*v3rbacpb.Policy{
+						"metadata-permission": {
+							Permissions: []*v3rbacpb.Permission{
+								{Rule: &v3rbacpb.Permission_Metadata{Metadata: &v3matcherpb.MetadataMatcher{Invert: false}}},
+							},
+							Principals: []*v3rbacpb.Principal{
+								{Identifier: &v3rbacpb.Principal_Any{Any: true}},
+							},
+						},
+					},
+				},
+			},
+			rbacQueries: []rbacQuery{
+				{
+					rpcData: &rpcData{
+						peerInfo: &peer.Peer{
+							Addr: &addr{ipAddress: "0.0.0.0"},
+						},
+					},
+					wantStatusCode: codes.PermissionDenied,
+				},
+			},
+		},
+		{
+			name: "PermissionMetadataInvert",
+			rbacConfigs: []*v3rbacpb.RBAC{
+				{
+					Policies: map[string]*v3rbacpb.Policy{
+						"metadata-permission-invert": {
+							Permissions: []*v3rbacpb.Permission{
+								{Rule: &v3rbacpb.Permission_Metadata{Metadata: &v3matcherpb.MetadataMatcher{Invert: true}}},
+							},
+							Principals: []*v3rbacpb.Principal{
+								{Identifier: &v3rbacpb.Principal_Any{Any: true}},
+							},
+						},
+					},
+				},
+			},
+			rbacQueries: []rbacQuery{
+				{
+					rpcData: &rpcData{
+						peerInfo: &peer.Peer{
+							Addr: &addr{ipAddress: "0.0.0.0"},
+						},
+					},
+					wantStatusCode: codes.OK,
+				},
+			},
+		},
+		{
+			name: "PrincipalMetadata",
+			rbacConfigs: []*v3rbacpb.RBAC{
+				{
+					Policies: map[string]*v3rbacpb.Policy{
+						"metadata-principal": {
+							Permissions: []*v3rbacpb.Permission{
+								{Rule: &v3rbacpb.Permission_Any{Any: true}},
+							},
+							Principals: []*v3rbacpb.Principal{
+								{Identifier: &v3rbacpb.Principal_Metadata{Metadata: &v3matcherpb.MetadataMatcher{Invert: false}}},
+							},
+						},
+					},
+				},
+			},
+			rbacQueries: []rbacQuery{
+				{
+					rpcData: &rpcData{
+						peerInfo: &peer.Peer{
+							Addr: &addr{ipAddress: "0.0.0.0"},
+						},
+					},
+					wantStatusCode: codes.PermissionDenied,
+				},
+			},
+		},
+		{
+			name: "PrincipalMetadataInvert",
+			rbacConfigs: []*v3rbacpb.RBAC{
+				{
+					Policies: map[string]*v3rbacpb.Policy{
+						"metadata-principal-invert": {
+							Permissions: []*v3rbacpb.Permission{
+								{Rule: &v3rbacpb.Permission_Any{Any: true}},
+							},
+							Principals: []*v3rbacpb.Principal{
+								{Identifier: &v3rbacpb.Principal_Metadata{Metadata: &v3matcherpb.MetadataMatcher{Invert: true}}},
+							},
+						},
+					},
+				},
+			},
+			rbacQueries: []rbacQuery{
+				{
+					rpcData: &rpcData{
+						peerInfo: &peer.Peer{
+							Addr: &addr{ipAddress: "0.0.0.0"},
+						},
+					},
+					wantStatusCode: codes.OK,
+				},
+			},
+		},
+		{
+			name: "RequestedServerNameNotMatching",
+			rbacConfigs: []*v3rbacpb.RBAC{
+				{
+					Policies: map[string]*v3rbacpb.Policy{
+						"requested-server-name": {
+							Permissions: []*v3rbacpb.Permission{
+								{
+									Rule: &v3rbacpb.Permission_RequestedServerName{
+										RequestedServerName: &v3matcherpb.StringMatcher{
+											MatchPattern: &v3matcherpb.StringMatcher_Exact{Exact: "foo"},
+										},
+									},
+								},
+							},
+							Principals: []*v3rbacpb.Principal{
+								{Identifier: &v3rbacpb.Principal_Any{Any: true}},
+							},
+						},
+					},
+				},
+			},
+			rbacQueries: []rbacQuery{
+				{
+					rpcData: &rpcData{
+						peerInfo: &peer.Peer{
+							Addr: &addr{ipAddress: "0.0.0.0"},
+						},
+					},
+					wantStatusCode: codes.PermissionDenied,
+				},
+			},
+		},
+		{
+			name: "RequestedServerNameMatching",
+			rbacConfigs: []*v3rbacpb.RBAC{
+				{
+					Policies: map[string]*v3rbacpb.Policy{
+						"requested-server-name": {
+							Permissions: []*v3rbacpb.Permission{
+								{
+									Rule: &v3rbacpb.Permission_RequestedServerName{
+										RequestedServerName: &v3matcherpb.StringMatcher{
+											MatchPattern: &v3matcherpb.StringMatcher_Exact{Exact: ""},
+										},
+									},
+								},
+							},
+							Principals: []*v3rbacpb.Principal{
+								{Identifier: &v3rbacpb.Principal_Any{Any: true}},
+							},
+						},
+					},
+				},
+			},
+			rbacQueries: []rbacQuery{
+				{
+					rpcData: &rpcData{
+						peerInfo: &peer.Peer{
+							Addr: &addr{ipAddress: "0.0.0.0"},
+						},
+					},
+					wantStatusCode: codes.OK,
+				},
+			},
+		},
 		// SuccessCaseAnyMatch tests a single RBAC Engine instantiated with
 		// a config with a policy with any rules for both permissions and
 		// principals, meaning that any data about incoming RPC's that the RBAC
@@ -1002,6 +1355,47 @@ func (s) TestChainEngine(t *testing.T) {
 				},
 			},
 		},
+		// This test tests a RBAC policy configured with a source-ip policy.
+		// This should be logically equivalent to configuring a Engine with a
+		// direct-remote-ip or remote-ip policy, as per A41 - "allow equating
+		// RBAC's direct_remote_ip and remote_ip."
+		{
+			name: "SourceIpMatcher",
+			rbacConfigs: []*v3rbacpb.RBAC{
+				{
+					Policies: map[string]*v3rbacpb.Policy{
+						"certain-source-ip": {
+							Permissions: []*v3rbacpb.Permission{
+								{Rule: &v3rbacpb.Permission_Any{Any: true}},
+							},
+							Principals: []*v3rbacpb.Principal{
+								{Identifier: &v3rbacpb.Principal_SourceIp{SourceIp: &v3corepb.CidrRange{AddressPrefix: "0.0.0.0", PrefixLen: &wrapperspb.UInt32Value{Value: uint32(10)}}}},
+							},
+						},
+					},
+				},
+			},
+			rbacQueries: []rbacQuery{
+				// This incoming RPC Call should match with the certain-source-ip policy.
+				{
+					rpcData: &rpcData{
+						peerInfo: &peer.Peer{
+							Addr: &addr{ipAddress: "0.0.0.0"},
+						},
+					},
+					wantStatusCode: codes.OK,
+				},
+				// This incoming RPC Call shouldn't match with the certain-source-ip policy.
+				{
+					rpcData: &rpcData{
+						peerInfo: &peer.Peer{
+							Addr: &addr{ipAddress: "10.0.0.0:8080"},
+						},
+					},
+					wantStatusCode: codes.PermissionDenied,
+				},
+			},
+		},
 		{
 			name: "DestinationIpMatcher",
 			rbacConfigs: []*v3rbacpb.RBAC{
@@ -1165,71 +1559,6 @@ func (s) TestChainEngine(t *testing.T) {
 							AuthInfo: credentials.TLSInfo{
 								State: tls.ConnectionState{},
 							},
-						},
-					},
-					wantStatusCode: codes.OK,
-				},
-			},
-		},
-		// This test tests that an RBAC policy configured with a metadata
-		// matcher as a permission doesn't match with any incoming RPC.
-		{
-			name: "metadata-never-matches",
-			rbacConfigs: []*v3rbacpb.RBAC{
-				{
-					Policies: map[string]*v3rbacpb.Policy{
-						"metadata-never-matches": {
-							Permissions: []*v3rbacpb.Permission{
-								{Rule: &v3rbacpb.Permission_Metadata{
-									Metadata: &v3matcherpb.MetadataMatcher{},
-								}},
-							},
-							Principals: []*v3rbacpb.Principal{
-								{Identifier: &v3rbacpb.Principal_Any{Any: true}},
-							},
-						},
-					},
-				},
-			},
-			rbacQueries: []rbacQuery{
-				{
-					rpcData: &rpcData{
-						fullMethod: "some method",
-						peerInfo: &peer.Peer{
-							Addr: &addr{ipAddress: "0.0.0.0"},
-						},
-					},
-					wantStatusCode: codes.PermissionDenied,
-				},
-			},
-		},
-		// This test tests that an RBAC policy configured with a metadata
-		// matcher with invert set to true as a permission always matches with
-		// any incoming RPC.
-		{
-			name: "metadata-invert-always-matches",
-			rbacConfigs: []*v3rbacpb.RBAC{
-				{
-					Policies: map[string]*v3rbacpb.Policy{
-						"metadata-invert-always-matches": {
-							Permissions: []*v3rbacpb.Permission{
-								{Rule: &v3rbacpb.Permission_Metadata{
-									Metadata: &v3matcherpb.MetadataMatcher{Invert: true},
-								}},
-							},
-							Principals: []*v3rbacpb.Principal{
-								{Identifier: &v3rbacpb.Principal_Any{Any: true}},
-							},
-						},
-					},
-				},
-			},
-			rbacQueries: []rbacQuery{
-				{
-					rpcData: &rpcData{
-						fullMethod: "some method",
-						peerInfo: &peer.Peer{
-							Addr: &addr{ipAddress: "0.0.0.0:8080"},
 						},
 					},
 					wantStatusCode: codes.OK,

--- a/scripts/vet.sh
+++ b/scripts/vet.sh
@@ -198,6 +198,7 @@ GetMatchSubjectAltNames
 GetPrefixMatch
 GetSafeRegexMatch
 GetSuffixMatch
+GetSourceIp
 GetTlsCertificateCertificateProviderInstance
 GetValidationContextCertificateProviderInstance
 XXXXX PleaseIgnoreUnused'


### PR DESCRIPTION
RELEASE NOTES:
- transport: Enforce overall limit on the number of items that need processing. HEADERS and DATA frames don't count towards this limit. The default value for this limit is `100` and may be changed by setting environment variable `GRPC_GO_EXPERIMENTAL_CONTROL_BUFFER_THROTTLE_LIMIT`.
- xds/rbac: Handle `Metadata` and `RequestedServerName` permissions.
- xds/rbac: Fix panic when parsing unsupported fields in `NotRule`/`NotId` permissions.
- xds/rbac: Support the deprecated `source_ip` principal identifier by treating it as equivalent to `direct_remote_ip`.
