### PR TITLE
transport: Fix data race on loopyWriter.estdStreams in AccountCheck tests

### DIFF
--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -219,6 +219,17 @@ type outFlowControlSizeRequest struct {
 	resp chan uint32
 }
 
+// outStreamRequestForTesting is used by tests to retrieve a pointer to an outStream
+// safely inside the loopyWriter goroutine without racing on loopyWriter.estdStreams.
+// By holding the *outStream pointer while streams and transports close down, tests
+// can inspect settled accounting values (such as bytesOutStanding) after loopyWriter
+// has run to completion without any data races.
+type outStreamRequestForTesting struct {
+	throttledItem
+	streamID uint32
+	resp     chan *outStream
+}
+
 // closeConnection is an instruction to tell the loopy writer to flush the
 // framer and exit, which will cause the transport's connection to be closed
 // (by the client or server).  The transport itself will close after the reader
@@ -799,6 +810,10 @@ func (l *loopyWriter) outFlowControlSizeRequestHandler(o *outFlowControlSizeRequ
 	o.resp <- l.sendQuota
 }
 
+func (l *loopyWriter) outStreamRequestHandler(o *outStreamRequestForTesting) {
+	o.resp <- l.estdStreams[o.streamID]
+}
+
 func (l *loopyWriter) cleanupStreamHandler(c *cleanupStream) error {
 	c.onWrite()
 	if str, ok := l.estdStreams[c.streamID]; ok {
@@ -896,6 +911,8 @@ func (l *loopyWriter) handle(i any) error {
 		return l.goAwayHandler(i)
 	case *outFlowControlSizeRequest:
 		l.outFlowControlSizeRequestHandler(i)
+	case *outStreamRequestForTesting:
+		l.outStreamRequestHandler(i)
 	case closeConnection:
 		// Just return a non-I/O error and run() will flush and close the
 		// connection.

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -1885,6 +1885,32 @@ func (s) TestAccountCheckDynamicWindowLargeMessage(t *testing.T) {
 	testFlowControlAccountCheck(t, 1024*1024, windowSizeConfig{}, defaultTestTimeout)
 }
 
+func (t *http2Server) getOutStream(ctx context.Context, id uint32) *outStream {
+	resp := make(chan *outStream, 1)
+	t.controlBuf.put(&outStreamRequestForTesting{streamID: id, resp: resp})
+	select {
+	case s := <-resp:
+		return s
+	case <-t.done:
+		return nil
+	case <-ctx.Done():
+		return nil
+	}
+}
+
+func (t *http2Client) getOutStream(ctx context.Context, id uint32) *outStream {
+	resp := make(chan *outStream, 1)
+	t.controlBuf.put(&outStreamRequestForTesting{streamID: id, resp: resp})
+	select {
+	case s := <-resp:
+		return s
+	case <-t.ctxDone:
+		return nil
+	case <-ctx.Done():
+		return nil
+	}
+}
+
 func testFlowControlAccountCheck(t *testing.T, msgSize int, wc windowSizeConfig, timeout time.Duration) {
 	sc := &ServerConfig{
 		InitialWindowSize:     wc.serverStream,
@@ -1963,21 +1989,28 @@ func testFlowControlAccountCheck(t *testing.T, msgSize int, wc windowSizeConfig,
 		}(stream)
 	}
 	wg.Wait()
+
+	// Fail early if any of the above goroutines failed.
+	if t.Failed() {
+		t.FailNow()
+	}
+
 	serverStreams := map[uint32]*ServerStream{}
 	loopyClientStreams := map[uint32]*outStream{}
 	loopyServerStreams := map[uint32]*outStream{}
-	// Get all the streams from server reader and writer and client writer.
+	// Get all the active streams from the server transport.
 	st.mu.Lock()
-	client.mu.Lock()
 	for _, stream := range clientStreams {
 		id := stream.id
 		serverStreams[id] = st.activeStreams[id]
-		loopyServerStreams[id] = st.loopy.estdStreams[id]
-		loopyClientStreams[id] = client.loopy.estdStreams[id]
-
 	}
-	client.mu.Unlock()
 	st.mu.Unlock()
+
+	for _, stream := range clientStreams {
+		id := stream.id
+		loopyServerStreams[id] = st.getOutStream(ctx, id)
+		loopyClientStreams[id] = client.getOutStream(ctx, id)
+	}
 	// Close all streams
 	for _, stream := range clientStreams {
 		stream.Write(nil, nil, &WriteOptions{Last: true})
@@ -2000,6 +2033,9 @@ func testFlowControlAccountCheck(t *testing.T, msgSize int, wc windowSizeConfig,
 		loopyClientStream := loopyClientStreams[id]
 		if loopyServerStream == nil {
 			t.Fatalf("Unexpected nil loopyServerStream")
+		}
+		if loopyClientStream == nil {
+			t.Fatalf("Unexpected nil loopyClientStream")
 		}
 		// Check stream flow control.
 		if int(cstream.fc.limit+cstream.fc.delta-cstream.fc.pendingData-cstream.fc.pendingUpdate) != int(st.loopy.oiws)-loopyServerStream.bytesOutStanding {

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -1885,9 +1885,11 @@ func (s) TestAccountCheckDynamicWindowLargeMessage(t *testing.T) {
 	testFlowControlAccountCheck(t, 1024*1024, windowSizeConfig{}, defaultTestTimeout)
 }
 
-func (t *http2Server) getOutStream(ctx context.Context, id uint32) *outStream {
-	resp := make(chan *outStream, 1)
-	t.controlBuf.put(&outStreamRequestForTesting{streamID: id, resp: resp})
+func (t *http2Server) getOutStreamForTesting(ctx context.Context, id uint32) *outStream {
+	resp := make(chan *outStream)
+	if err := t.controlBuf.put(&outStreamRequestForTesting{streamID: id, resp: resp}); err != nil {
+		return nil
+	}
 	select {
 	case s := <-resp:
 		return s
@@ -1898,9 +1900,11 @@ func (t *http2Server) getOutStream(ctx context.Context, id uint32) *outStream {
 	}
 }
 
-func (t *http2Client) getOutStream(ctx context.Context, id uint32) *outStream {
-	resp := make(chan *outStream, 1)
-	t.controlBuf.put(&outStreamRequestForTesting{streamID: id, resp: resp})
+func (t *http2Client) getOutStreamForTesting(ctx context.Context, id uint32) *outStream {
+	resp := make(chan *outStream)
+	if err := t.controlBuf.put(&outStreamRequestForTesting{streamID: id, resp: resp}); err != nil {
+		return nil
+	}
 	select {
 	case s := <-resp:
 		return s
@@ -2008,8 +2012,8 @@ func testFlowControlAccountCheck(t *testing.T, msgSize int, wc windowSizeConfig,
 
 	for _, stream := range clientStreams {
 		id := stream.id
-		loopyServerStreams[id] = st.getOutStream(ctx, id)
-		loopyClientStreams[id] = client.getOutStream(ctx, id)
+		loopyServerStreams[id] = st.getOutStreamForTesting(ctx, id)
+		loopyClientStreams[id] = client.getOutStreamForTesting(ctx, id)
 	}
 	// Close all streams
 	for _, stream := range clientStreams {


### PR DESCRIPTION
#### Root Cause:
- When ping-pong loops finished, `testFlowControlAccountCheck` accessed `st.loopy.estdStreams[id]` and `client.loopy.estdStreams[id]` directly.
- Because `loopyWriter.estdStreams` is private and unsynchronized (`loopyWriter.run(`) assumes sole ownership), reading from this map across goroutines raced with `cleanupStreamHandler` deleting streams during timeouts or stream shutdown.
 - Furthermore, when client stream goroutines encountered errors (e.g. DeadlineExceeded) during ping-pongs, wg.Wait() returned while t.Errorf() allowed the main test goroutine to continue inspecting broken streams.

#### Solution:
- Added `outStreamRequestForTesting` to `controlBuf`. This allows tests to retrieve `*outStream` pointers safely from within `loopyWriter.run()` without racing on `estdStreams`.
- Fail early on ping-pong goroutine failures.

RELEASE NOTES: none