### PR TITLE
transport: presize header slice for outgoing metadata

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -554,8 +554,6 @@ func (t *http2Client) createHeaderFields(ctx context.Context, callHdr *CallHdr) 
 	if err != nil {
 		return nil, err
 	}
-	// TODO(mmukhi): Benchmark if the performance gets better if count the metadata and other header fields
-	// first and create a slice of that exact size.
 	// Make the slice of certain predictable size to reduce allocations made by append.
 	hfLen := 7 // :method, :scheme, :path, :authority, content-type, user-agent, te
 	hfLen += len(authData) + len(callAuthData)
@@ -574,6 +572,21 @@ func (t *http2Client) createHeaderFields(ctx context.Context, callHdr *CallHdr) 
 	}
 	if _, ok := ctx.Deadline(); ok {
 		hfLen++
+	}
+	// Count the metadata header fields as well so the slice is not reallocated
+	// while they are appended below. Reserved headers are dropped when writing,
+	// so this may slightly over-count, which is preferable to growing the slice.
+	md, added, mdOK := metadataFromOutgoingContextRaw(ctx)
+	if mdOK {
+		for _, vv := range md {
+			hfLen += len(vv)
+		}
+		for _, vv := range added {
+			hfLen += len(vv) / 2
+		}
+	}
+	for _, vv := range t.md {
+		hfLen += len(vv)
 	}
 	headerFields := make([]hpack.HeaderField, 0, hfLen)
 	headerFields = append(headerFields, hpack.HeaderField{Name: ":method", Value: "POST"})
@@ -619,7 +632,7 @@ func (t *http2Client) createHeaderFields(ctx context.Context, callHdr *CallHdr) 
 		headerFields = append(headerFields, hpack.HeaderField{Name: k, Value: encodeMetadataHeader(k, v)})
 	}
 
-	if md, added, ok := metadataFromOutgoingContextRaw(ctx); ok {
+	if mdOK {
 		var k string
 		for k, vv := range md {
 			// HTTP doesn't allow you to set pseudoheaders after non pseudoheaders were set.

--- a/internal/transport/http2_client_header_bench_test.go
+++ b/internal/transport/http2_client_header_bench_test.go
@@ -1,0 +1,96 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package transport
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/metadata"
+)
+
+// BenchmarkCreateHeaderFields measures header-slice construction as the amount
+// of outgoing metadata varies.
+func BenchmarkCreateHeaderFields(b *testing.B) {
+	for _, mdCount := range []int{0, 4, 12} {
+		b.Run(fmt.Sprintf("mdCount=%d", mdCount), func(b *testing.B) {
+			t := &http2Client{
+				scheme:    "https",
+				userAgent: "grpc-go/benchmark",
+				md:        metadata.MD{},
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+			defer cancel()
+			if mdCount > 0 {
+				md := make(metadata.MD, mdCount)
+				for i := 0; i < mdCount; i++ {
+					md[fmt.Sprintf("header-%d", i)] = []string{fmt.Sprintf("value-%d", i)}
+				}
+				ctx = metadata.NewOutgoingContext(ctx, md)
+			}
+			callHdr := &CallHdr{
+				Method: "/grpc.testing.BenchmarkService/UnaryCall",
+				Host:   "server:443",
+			}
+
+			b.ReportAllocs()
+			for b.Loop() {
+				hf, err := t.createHeaderFields(ctx, callHdr)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(hf) == 0 {
+					b.Fatal("no header fields produced")
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("mdCount=%d-appended", mdCount), func(b *testing.B) {
+			t := &http2Client{
+				scheme:    "https",
+				userAgent: "grpc-go/benchmark",
+				md:        metadata.MD{},
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+			defer cancel()
+			kvs := make([]string, 0, mdCount*2)
+			for i := 0; i < mdCount; i++ {
+				kvs = append(kvs, fmt.Sprintf("header-%d", i), fmt.Sprintf("value-%d", i))
+			}
+			ctx = metadata.AppendToOutgoingContext(ctx, kvs...)
+			callHdr := &CallHdr{
+				Method: "/grpc.testing.BenchmarkService/UnaryCall",
+				Host:   "server:443",
+			}
+
+			b.ReportAllocs()
+			for b.Loop() {
+				hf, err := t.createHeaderFields(ctx, callHdr)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(hf) == 0 {
+					b.Fatal("no header fields produced")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
`createHeaderFields` pre-sizes the `headerFields` slice, but the estimate omits the outgoing metadata (`md` and `added` from the outgoing context, plus `t.md`). For RPCs that propagate context headers (tracing, tenancy, routing, etc.), the slice starts at capacity ~8 and grows once or twice via `append` on nearly every call.

This change fetches the raw outgoing metadata once, adds its field count to `hfLen`, and reuses the fetched maps in the append loop below. Reserved headers are dropped when writing, so this may slightly over-count, which is preferable to growing the slice.

RELEASE NOTES: none