### PR TITLE
interop/client: Allow GCE Metadata OAuth credentials with custom TLS transport

### DIFF
--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -252,7 +252,7 @@ func main() {
 		logger.Fatal("Invalid creds")
 	}
 	if credsChosen == credsTLS {
-		if *testCase == "compute_engine_creds" {
+		if *testCase == "compute_engine_creds" || *defaultServiceAccount != "" {
 			opts = append(opts, grpc.WithPerRPCCredentials(oauth.NewComputeEngine()))
 		} else if *testCase == "service_account_creds" {
 			jwtCreds, err := oauth.NewServiceAccountFromFile(*serviceAccountKeyFile, *oauthScope)


### PR DESCRIPTION
Update interop client to attach oauth.NewComputeEngine() as WithPerRPCCredentials when --use_tls=true and --default_service_account="default" are supplied, enabling OAuth token authentication over DirectPath TLS connections.

RELEASE NOTES: n/a