### PR TITLE
alts: natively hardcode 1MB for max frame negotiation

### DIFF
--- a/credentials/alts/internal/conn/record.go
+++ b/credentials/alts/internal/conn/record.go
@@ -67,7 +67,7 @@ const (
 	altsRecordMsgType = uint32(0x06)
 	// The maximum write buffer size. This *must* be multiple of
 	// altsRecordDefaultLength.
-	altsWriteBufferMaxSize = 512 * 1024 // 512KiB
+	altsWriteBufferMaxSize = 1024 * 1024 // 1 MiB
 	// The initial buffer used to read from the network.
 	// It includes an additional 512 Bytes to hold two 16KiB records plus
 	// small framing overheads.
@@ -95,7 +95,8 @@ func init() {
 		15, // 32KB (default buffer size for gRPC)
 		16, // 64KB
 		17, // 128KB
-		19, // 512KB, max write buffer size
+		19, // 512KB
+		20, // 1024KB (1MB), max write buffer size
 	)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to create write buffer pool: %v", err))
@@ -136,7 +137,7 @@ type conn struct {
 
 // NewConn creates a new secure channel instance given the other party role and
 // handshaking result.
-func NewConn(c net.Conn, side core.Side, recordProtocol string, key []byte, protected []byte) (net.Conn, error) {
+func NewConn(c net.Conn, side core.Side, recordProtocol string, key []byte, protected []byte, negotiatedFrameSize int) (net.Conn, error) {
 	newCrypto := protocols[recordProtocol]
 	if newCrypto == nil {
 		return nil, fmt.Errorf("negotiated unknown next_protocol %q", recordProtocol)
@@ -146,7 +147,17 @@ func NewConn(c net.Conn, side core.Side, recordProtocol string, key []byte, prot
 		return nil, fmt.Errorf("protocol %q: %v", recordProtocol, err)
 	}
 	overhead := MsgLenFieldSize + msgTypeFieldSize + crypto.EncryptionOverhead()
-	payloadLengthLimit := altsRecordDefaultLength - overhead
+
+	maxRecordLen := altsRecordDefaultLength
+	if negotiatedFrameSize > altsWriteBufferMaxSize {
+		// Prevent infinite loops during buffer fragmentation
+		maxRecordLen = altsWriteBufferMaxSize
+	} else if negotiatedFrameSize > altsRecordDefaultLength {
+		// Only trust appropriately scaled max frame sizes
+		maxRecordLen = negotiatedFrameSize
+	}
+
+	payloadLengthLimit := maxRecordLen - overhead
 	// We pre-allocate protected to be of size 32KB during initialization.
 	// We increase the size of the buffer by the required amount if it can't
 	// hold a complete encrypted record.
@@ -321,7 +332,7 @@ func (p *conn) Write(b []byte) (n int, err error) {
 	partialBSize := len(b)
 	if size > altsWriteBufferMaxSize {
 		size = altsWriteBufferMaxSize
-		const numOfFramesInMaxWriteBuf = altsWriteBufferMaxSize / altsRecordDefaultLength
+		numOfFramesInMaxWriteBuf := altsWriteBufferMaxSize / (p.payloadLengthLimit + p.overhead)
 		partialBSize = numOfFramesInMaxWriteBuf * p.payloadLengthLimit
 	}
 	// Get a writeBuf of the required length.
@@ -363,7 +374,7 @@ func (p *conn) Write(b []byte) (n int, err error) {
 			// written. This means we need to remove header,
 			// encryption overheads, and any partially-written
 			// frame data.
-			numOfWrittenFrames := int(math.Floor(float64(nn) / float64(altsRecordDefaultLength)))
+			numOfWrittenFrames := int(math.Floor(float64(nn) / float64(p.payloadLengthLimit+p.overhead)))
 			return partialBStart + numOfWrittenFrames*p.payloadLengthLimit, err
 		}
 	}

--- a/credentials/alts/internal/conn/record_test.go
+++ b/credentials/alts/internal/conn/record_test.go
@@ -90,7 +90,7 @@ func newTestALTSRecordConn(in, out *bytes.Buffer, side core.Side, rp string, pro
 		in:  in,
 		out: out,
 	}
-	c, err := NewConn(&tc, side, rp, key, protected)
+	c, err := NewConn(&tc, side, rp, key, protected, 0)
 	if err != nil {
 		panic(fmt.Sprintf("Unexpected error creating test ALTS record connection: %v", err))
 	}
@@ -381,7 +381,7 @@ func BenchmarkWriteMemoryUsage(b *testing.B) {
 	conn := &noopConn{}
 
 	for b.Loop() {
-		c, err := NewConn(conn, core.ClientSide, rekeyRecordProtocol, key, nil)
+		c, err := NewConn(conn, core.ClientSide, rekeyRecordProtocol, key, nil, 0)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -433,7 +433,7 @@ func (s) TestParseFramedMsgVulnerability(t *testing.T) {
 	// bytes happen to start with `0x06` (altsRecordMsgType), the vulnerable
 	// code will try to slice `msg[4:]` which panics because len(msg) is 0.
 	malformedProtected := []byte{0x00, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00}
-	c, err := NewConn(&tc, core.ServerSide, rekeyRecordProtocol, key, malformedProtected)
+	c, err := NewConn(&tc, core.ServerSide, rekeyRecordProtocol, key, malformedProtected, 0)
 	if err != nil {
 		t.Fatalf("NewConn failed: %v", err)
 	}
@@ -441,5 +441,34 @@ func (s) TestParseFramedMsgVulnerability(t *testing.T) {
 	const wantErr = "shorter than message type field size"
 	if _, err := c.Read(buf); err == nil || !strings.Contains(err.Error(), wantErr) {
 		t.Fatalf("c.Read(buf) returned error: %v, want error containing %q", err, wantErr)
+	}
+}
+
+func (s) TestNewConnNegotiatedFrameSize(t *testing.T) {
+	key := make([]byte, 32)
+	for _, tc := range []struct {
+		name                string
+		negotiatedFrameSize int
+		wantMaxRecordLen    int
+	}{
+		{"zero", 0, altsRecordDefaultLength},
+		{"too small", altsRecordDefaultLength - 1, altsRecordDefaultLength},
+		{"exact default", altsRecordDefaultLength, altsRecordDefaultLength},
+		{"middle", altsRecordDefaultLength + 1024, altsRecordDefaultLength + 1024},
+		{"too large", altsWriteBufferMaxSize + 1, altsWriteBufferMaxSize},
+		{"exact max", altsWriteBufferMaxSize, altsWriteBufferMaxSize},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tcConn := testConn{}
+			c, err := NewConn(&tcConn, core.ClientSide, rekeyRecordProtocol, key, nil, tc.negotiatedFrameSize)
+			if err != nil {
+				t.Fatalf("NewConn failed: %v", err)
+			}
+			altsC := c.(*conn)
+			expectedPayloadLimit := tc.wantMaxRecordLen - altsC.overhead
+			if altsC.payloadLengthLimit != expectedPayloadLimit {
+				t.Errorf("payloadLengthLimit = %v, want %v", altsC.payloadLengthLimit, expectedPayloadLimit)
+			}
+		})
 	}
 }

--- a/credentials/alts/internal/handshaker/handshaker.go
+++ b/credentials/alts/internal/handshaker/handshaker.go
@@ -42,6 +42,8 @@ import (
 const (
 	// The maximum byte size of receive frames.
 	frameLimit              = 64 * 1024 // 64 KB
+	// The maximum frame size negotiated natively by ALTS for optimal throughput.
+	maxFrameSize            = 1024 * 1024 // 1 MB
 	rekeyRecordProtocolName = "ALTSRP_GCM_AES128_REKEY"
 )
 
@@ -194,6 +196,7 @@ func (h *altsHandshaker) ClientHandshake(ctx context.Context) (net.Conn, credent
 				LocalIdentity:             h.clientOpts.ClientIdentity,
 				TargetName:                h.clientOpts.TargetName,
 				RpcVersions:               h.clientOpts.RPCVersions,
+				MaxFrameSize:              maxFrameSize,
 			},
 		},
 	}
@@ -248,6 +251,7 @@ func (h *altsHandshaker) ServerHandshake(ctx context.Context) (net.Conn, credent
 				HandshakeParameters:  params,
 				InBytes:              p[:n],
 				RpcVersions:          h.serverOpts.RPCVersions,
+				MaxFrameSize:         maxFrameSize,
 			},
 		},
 	}
@@ -289,7 +293,8 @@ func (h *altsHandshaker) doHandshake(req *altspb.HandshakerReq) (net.Conn, *alts
 	if !ok {
 		return nil, nil, fmt.Errorf("unknown resulted record protocol %v", result.RecordProtocol)
 	}
-	sc, err := conn.NewConn(h.conn, h.side, result.GetRecordProtocol(), result.KeyData[:keyLen], extra)
+	negotiatedFrameSize := computeNegotiatedFrameSize(int(result.GetMaxFrameSize()), maxFrameSize)
+	sc, err := conn.NewConn(h.conn, h.side, result.GetRecordProtocol(), result.KeyData[:keyLen], extra, negotiatedFrameSize)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -374,4 +379,11 @@ func (h *altsHandshaker) Close() {
 func ResetConcurrentHandshakeSemaphoreForTesting(numberOfAllowedHandshakes int64) {
 	clientHandshakes = semaphore.NewWeighted(numberOfAllowedHandshakes)
 	serverHandshakes = semaphore.NewWeighted(numberOfAllowedHandshakes)
+}
+
+func computeNegotiatedFrameSize(peerFrameSize, localMaxFrameSize int) int {
+	if peerFrameSize > 0 {
+		return min(peerFrameSize, localMaxFrameSize)
+	}
+	return 0
 }

--- a/credentials/alts/internal/handshaker/handshaker_test.go
+++ b/credentials/alts/internal/handshaker/handshaker_test.go
@@ -372,3 +372,22 @@ func (s) TestNewServerHandshaker(t *testing.T) {
 	}
 	hs.Close()
 }
+
+func TestComputeNegotiatedFrameSize(t *testing.T) {
+	for _, tc := range []struct {
+		peerFrameSize     int
+		localMaxFrameSize int
+		want              int
+	}{
+		{0, 512, 0},
+		{1024, 512, 512},
+		{256, 512, 256},
+		{-1, 512, 0},
+	} {
+		got := computeNegotiatedFrameSize(tc.peerFrameSize, tc.localMaxFrameSize)
+		if got != tc.want {
+			t.Errorf("computeNegotiatedFrameSize(%v, %v) = %v, want %v",
+				tc.peerFrameSize, tc.localMaxFrameSize, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Background
The ALTS maxFrameSize limit imposes a hard cryptographic framing cap on payloads processed by the record protocol. While the current defaults comfortably support standard microservice architectures, they heavily bottleneck throughput on massive bulk payload transfers (such as pushing large byte streams to Google Cloud Storage). The current scaling constraints force the ALTS crypto engine into extremely high context-switching and encapsulation overhead across thousands of tiny framed chunks.

## Proposed Changes
This PR raises the natively hardcoded limit for maxFrameSize negotiation within ALTS to 1MB. By aggressively unlocking the 1MB capability ceiling, the grpc-go transport layer becomes natively capable of passing substantially larger, contiguous memory slices directly into the cryptographic pipeline.

## Client Implementation Constraints
Because grpc-go inherently enforces a conservative 32KB transport write chunk limit before data even hits ALTS, merging this PR does not change the default runtime memory footprint for standard, un-tuned clients. This ensures total memory safety for thousands of lean microservices!

To actually harness this 1MB ALTS frame optimization, client applications or SDKs (like GCS) prioritizing heavy throughput must explicitly opt-in by overriding the transport buffer threshold during initialization, for example, set the WriteBufferSize to 1MB:

```
// Calling applications or SDKs must explicitly opt-in to large ALTS framing by overriding the gRPC write threshold.
grpcOpts := []option.ClientOption{
    option.WithGRPCDialOption(grpc.WithWriteBufferSize(1024 * 1024)), 
}
client, err := storage.NewGRPCClient(ctx, grpcOpts...)
```

RELEASE NOTES:
alts: Raised maxFrameSize negotiation limit to 1MB to support high-throughput, large payload batch streaming.