### PR TITLE
  xds: fix certificate provider closure race during concurrent TLS handshakes

### DIFF
--- a/credentials/xds/xds.go
+++ b/credentials/xds/xds.go
@@ -113,31 +113,16 @@ func (c *credsImpl) ClientHandshake(ctx context.Context, authority string, rawCo
 		return c.fallback.ClientHandshake(ctx, authority, rawConn)
 	}
 
-	hi := xdsinternal.HandshakeInfoFromAttributes(chi.Attributes).Load()
-	if hi == nil {
-		return c.fallback.ClientHandshake(ctx, authority, rawConn)
-	}
-	if hi.UseFallbackCreds() {
-		return c.fallback.ClientHandshake(ctx, authority, rawConn)
-	}
-
-	// We build the tls.Config with the following values
-	// 1. Root certificate as returned by the root provider.
-	// 2. Identity certificate as returned by the identity provider. This may be
-	//    empty on the client side, if the client is not doing mTLS.
-	// 3. InsecureSkipVerify to true. Certificates used in Mesh environments
-	//    usually contains the identity of the workload presenting the
-	//    certificate as a SAN (instead of a hostname in the CommonName field).
-	//    This means that normal certificate verification as done by the
-	//    standard library will fail.
-	// 4. Key usage to match whether client/server usage.
-	// 5. A `VerifyPeerCertificate` function which performs normal peer
-	// 	  cert verification using configured roots, and the custom SAN checks.
+	hiPtr := xdsinternal.HandshakeInfoFromAttributes(chi.Attributes)
 	hostname := xdsinternal.Hostname(chi.Attributes)
-	cfg, err := hi.ClientSideTLSConfig(ctx, hostname)
+	cfg, useFallback, done, err := xdsinternal.ClientSideTLSConfig(ctx, hiPtr, hostname)
 	if err != nil {
 		return nil, nil, err
 	}
+	if useFallback {
+		return c.fallback.ClientHandshake(ctx, authority, rawConn)
+	}
+	defer done()
 
 	// Perform the TLS handshake with the tls.Config that we have. We run the
 	// actual Handshake() function in a goroutine because we need to respect the
@@ -191,9 +176,6 @@ func (c *credsImpl) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.Aut
 	if err != nil {
 		return nil, nil, err
 	}
-	if hi.UseFallbackCreds() {
-		return c.fallback.ServerHandshake(rawConn)
-	}
 
 	// An xds-enabled gRPC server is expected to wrap the underlying raw
 	// net.Conn in a type which provides a way to retrieve the deadline set on
@@ -206,10 +188,15 @@ func (c *credsImpl) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.Aut
 	}
 	ctx, cancel := context.WithDeadline(context.Background(), deadline)
 	defer cancel()
-	cfg, err := hi.ServerSideTLSConfig(ctx)
+
+	cfg, useFallback, done, err := xdsinternal.ServerSideTLSConfig(ctx, hi)
 	if err != nil {
 		return nil, nil, err
 	}
+	if useFallback {
+		return c.fallback.ServerHandshake(rawConn)
+	}
+	defer done()
 
 	conn := tls.Server(rawConn, cfg)
 	if err := conn.Handshake(); err != nil {

--- a/credentials/xds/xds.go
+++ b/credentials/xds/xds.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	credinternal "google.golang.org/grpc/internal/credentials"
 	xdsinternal "google.golang.org/grpc/internal/credentials/xds"
+	"google.golang.org/grpc/internal/grpcsync"
 )
 
 // ClientOptions contains parameters to configure a new client-side xDS
@@ -167,7 +168,7 @@ func (c *credsImpl) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.Aut
 	// `HandshakeInfo` does not contain the information we are looking for, we
 	// delegate the handshake to the fallback credentials.
 	hiConn, ok := rawConn.(interface {
-		XDSHandshakeInfo() (*xdsinternal.HandshakeInfo, error)
+		XDSHandshakeInfo() (*grpcsync.RefCounted[xdsinternal.HandshakeInfo], error)
 	})
 	if !ok {
 		return c.fallback.ServerHandshake(rawConn)

--- a/credentials/xds/xds_client_test.go
+++ b/credentials/xds/xds_client_test.go
@@ -36,6 +36,7 @@ import (
 	icredentials "google.golang.org/grpc/internal/credentials"
 	xdsinternal "google.golang.org/grpc/internal/credentials/xds"
 	"google.golang.org/grpc/internal/envconfig"
+	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/xds/matcher"
@@ -228,8 +229,8 @@ func newTestContextWithHandshakeInfo(parent context.Context, root, identity cert
 	if sanExactMatch != "" {
 		sms = []matcher.StringMatcher{matcher.NewExactStringMatcher(sanExactMatch, false)}
 	}
-	var hiPtr atomic.Pointer[xdsinternal.HandshakeInfo]
-	info := xdsinternal.NewHandshakeInfo(root, identity, sms, false, sni, validateSANUsingSNI, false)
+	var hiPtr atomic.Pointer[grpcsync.RefCounted[xdsinternal.HandshakeInfo]]
+	info := xdsinternal.NewHandshakeInfo(root, identity, sms, sni, false, validateSANUsingSNI, false)
 	hiPtr.Store(info)
 	addr := xdsinternal.SetHandshakeInfo(resolver.Address{}, &hiPtr)
 
@@ -618,11 +619,11 @@ func (s) TestClientCredsProviderSwitch(t *testing.T) {
 	// Create a root provider which will fail the handshake because it does not
 	// use the correct trust roots.
 	root1 := makeRootProvider(t, "x509/client_ca_cert.pem")
-	handshakeInfo := xdsinternal.NewHandshakeInfo(root1, nil, []matcher.StringMatcher{matcher.NewExactStringMatcher(defaultTestCertSAN, false)}, false, "", false, false)
+	handshakeInfo := xdsinternal.NewHandshakeInfo(root1, nil, []matcher.StringMatcher{matcher.NewExactStringMatcher(defaultTestCertSAN, false)}, "", false, false, false)
 	// We need to repeat most of what newTestContextWithHandshakeInfo() does
 	// here because we need access to the underlying HandshakeInfo so that we
 	// can update it before the next call to ClientHandshake().
-	var hiPtr atomic.Pointer[xdsinternal.HandshakeInfo]
+	var hiPtr atomic.Pointer[grpcsync.RefCounted[xdsinternal.HandshakeInfo]]
 	hiPtr.Store(handshakeInfo)
 	addr := xdsinternal.SetHandshakeInfo(resolver.Address{}, &hiPtr)
 	ctx = icredentials.NewClientHandshakeInfoContext(ctx, credentials.ClientHandshakeInfo{Attributes: addr.Attributes})
@@ -645,7 +646,7 @@ func (s) TestClientCredsProviderSwitch(t *testing.T) {
 	// Create a new root provider which uses the correct trust roots. And update
 	// the HandshakeInfo with the new provider.
 	root2 := makeRootProvider(t, "x509/server_ca_cert.pem")
-	handshakeInfo = xdsinternal.NewHandshakeInfo(root2, nil, []matcher.StringMatcher{matcher.NewExactStringMatcher(defaultTestCertSAN, false)}, false, "", false, false)
+	handshakeInfo = xdsinternal.NewHandshakeInfo(root2, nil, []matcher.StringMatcher{matcher.NewExactStringMatcher(defaultTestCertSAN, false)}, "", false, false, false)
 	// Update the existing pointer, which address attribute will continue to
 	// point to.
 	hiPtr.Store(handshakeInfo)

--- a/credentials/xds/xds_server_test.go
+++ b/credentials/xds/xds_server_test.go
@@ -33,6 +33,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/tls/certprovider"
 	xdsinternal "google.golang.org/grpc/internal/credentials/xds"
+	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/testdata"
 )
 
@@ -96,12 +97,12 @@ func (s) TestServerCredsWithoutFallback(t *testing.T) {
 
 type wrapperConn struct {
 	net.Conn
-	xdsHI            *xdsinternal.HandshakeInfo
+	xdsHI            *grpcsync.RefCounted[xdsinternal.HandshakeInfo]
 	deadline         time.Time
 	handshakeInfoErr error
 }
 
-func (wc *wrapperConn) XDSHandshakeInfo() (*xdsinternal.HandshakeInfo, error) {
+func (wc *wrapperConn) XDSHandshakeInfo() (*grpcsync.RefCounted[xdsinternal.HandshakeInfo], error) {
 	return wc.xdsHI, wc.handshakeInfoErr
 }
 
@@ -109,7 +110,7 @@ func (wc *wrapperConn) GetDeadline() time.Time {
 	return wc.deadline
 }
 
-func newWrappedConn(conn net.Conn, xdsHI *xdsinternal.HandshakeInfo, deadline time.Time) *wrapperConn {
+func newWrappedConn(conn net.Conn, xdsHI *grpcsync.RefCounted[xdsinternal.HandshakeInfo], deadline time.Time) *wrapperConn {
 	return &wrapperConn{Conn: conn, xdsHI: xdsHI, deadline: deadline}
 }
 
@@ -123,7 +124,7 @@ func (s) TestServerCredsInvalidHandshakeInfo(t *testing.T) {
 		t.Fatalf("NewServerCredentials(%v) failed: %v", opts, err)
 	}
 
-	info := xdsinternal.NewHandshakeInfo(&fakeProvider{}, nil, nil, false, "", false, false)
+	info := xdsinternal.NewHandshakeInfo(&fakeProvider{}, nil, nil, "", false, false, false)
 	conn := newWrappedConn(nil, info, time.Time{})
 	if _, _, err := creds.ServerHandshake(conn); err == nil {
 		t.Fatal("ServerHandshake succeeded without identity certificate provider in HandshakeInfo")
@@ -159,7 +160,7 @@ func (s) TestServerCredsProviderFailure(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			info := xdsinternal.NewHandshakeInfo(test.rootProvider, test.identityProvider, nil, false, "", false, false)
+			info := xdsinternal.NewHandshakeInfo(test.rootProvider, test.identityProvider, nil, "", false, false, false)
 			conn := newWrappedConn(nil, info, time.Time{})
 			if _, _, err := creds.ServerHandshake(conn); err == nil || !strings.Contains(err.Error(), test.wantErr) {
 				t.Fatalf("ServerHandshake() returned error: %q, wantErr: %q", err, test.wantErr)
@@ -235,7 +236,7 @@ func (s) TestServerCredsHandshakeTimeout(t *testing.T) {
 	// Create a test server which uses the xDS server credentials created above
 	// to perform TLS handshake on incoming connections.
 	ts := newTestServerWithHandshakeFunc(ctx, func(rawConn net.Conn) handshakeResult {
-		hi := xdsinternal.NewHandshakeInfo(makeRootProvider(t, "x509/client_ca_cert.pem"), makeIdentityProvider(t, "x509/server2_cert.pem", "x509/server2_key.pem"), nil, true, "", false, false)
+		hi := xdsinternal.NewHandshakeInfo(makeRootProvider(t, "x509/client_ca_cert.pem"), makeIdentityProvider(t, "x509/server2_cert.pem", "x509/server2_key.pem"), nil, "", true, false, false)
 
 		// Create a wrapped conn which can return the HandshakeInfo created
 		// above with a very small deadline.
@@ -287,7 +288,7 @@ func (s) TestServerCredsHandshakeFailure(t *testing.T) {
 	ts := newTestServerWithHandshakeFunc(ctx, func(rawConn net.Conn) handshakeResult {
 		// Create a HandshakeInfo which has a root provider which does not match
 		// the certificate sent by the client.
-		hi := xdsinternal.NewHandshakeInfo(makeRootProvider(t, "x509/server_ca_cert.pem"), makeIdentityProvider(t, "x509/client2_cert.pem", "x509/client2_key.pem"), nil, true, "", false, false)
+		hi := xdsinternal.NewHandshakeInfo(makeRootProvider(t, "x509/server_ca_cert.pem"), makeIdentityProvider(t, "x509/client2_cert.pem", "x509/client2_key.pem"), nil, "", true, false, false)
 
 		// Create a wrapped conn which can return the HandshakeInfo and
 		// configured deadline to the xDS credentials' ServerHandshake()
@@ -368,7 +369,7 @@ func (s) TestServerCredsHandshakeSuccess(t *testing.T) {
 			// created above to perform TLS handshake on incoming connections.
 			ts := newTestServerWithHandshakeFunc(ctx, func(rawConn net.Conn) handshakeResult {
 				// Create a HandshakeInfo with information from the test table.
-				hi := xdsinternal.NewHandshakeInfo(test.rootProvider, test.identityProvider, nil, test.requireClientCert, "", false, false)
+				hi := xdsinternal.NewHandshakeInfo(test.rootProvider, test.identityProvider, nil, "", test.requireClientCert, false, false)
 
 				// Create a wrapped conn which can return the HandshakeInfo and
 				// configured deadline to the xDS credentials' ServerHandshake()
@@ -444,11 +445,11 @@ func (s) TestServerCredsProviderSwitch(t *testing.T) {
 	// to perform TLS handshake on incoming connections.
 	ts := newTestServerWithHandshakeFunc(ctx, func(rawConn net.Conn) handshakeResult {
 		cnt++
-		var hi *xdsinternal.HandshakeInfo
+		var hi *grpcsync.RefCounted[xdsinternal.HandshakeInfo]
 		if cnt == 1 {
 			// Create a HandshakeInfo which has a root provider which does not match
 			// the certificate sent by the client.
-			hi = xdsinternal.NewHandshakeInfo(makeRootProvider(t, "x509/server_ca_cert.pem"), makeIdentityProvider(t, "x509/client2_cert.pem", "x509/client2_key.pem"), nil, true, "", false, false)
+			hi = xdsinternal.NewHandshakeInfo(makeRootProvider(t, "x509/server_ca_cert.pem"), makeIdentityProvider(t, "x509/client2_cert.pem", "x509/client2_key.pem"), nil, "", true, false, false)
 
 			// Create a wrapped conn which can return the HandshakeInfo and
 			// configured deadline to the xDS credentials' ServerHandshake()
@@ -462,7 +463,7 @@ func (s) TestServerCredsProviderSwitch(t *testing.T) {
 			return handshakeResult{}
 		}
 
-		hi = xdsinternal.NewHandshakeInfo(makeRootProvider(t, "x509/client_ca_cert.pem"), makeIdentityProvider(t, "x509/server1_cert.pem", "x509/server1_key.pem"), nil, true, "", false, false)
+		hi = xdsinternal.NewHandshakeInfo(makeRootProvider(t, "x509/client_ca_cert.pem"), makeIdentityProvider(t, "x509/server1_cert.pem", "x509/server1_key.pem"), nil, "", true, false, false)
 
 		// Create a wrapped conn which can return the HandshakeInfo and
 		// configured deadline to the xDS credentials' ServerHandshake()

--- a/internal/credentials/xds/handshake_info.go
+++ b/internal/credentials/xds/handshake_info.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"google.golang.org/grpc/attributes"
@@ -66,31 +67,6 @@ func Hostname(attr *attributes.Attributes) string {
 	return hn
 }
 
-// Equal reports whether the handshake info structs are identical.
-func (hi *HandshakeInfo) Equal(other *HandshakeInfo) bool {
-	if hi == nil && other == nil {
-		return true
-	}
-	if hi == nil || other == nil {
-		return false
-	}
-	if hi.rootProvider != other.rootProvider ||
-		hi.identityProvider != other.identityProvider ||
-		hi.requireClientCert != other.requireClientCert ||
-		hi.sni != other.sni ||
-		hi.validateSANUsingSNI != other.validateSANUsingSNI ||
-		hi.useAutoHostSNI != other.useAutoHostSNI ||
-		len(hi.sanMatchers) != len(other.sanMatchers) {
-		return false
-	}
-	for i := range hi.sanMatchers {
-		if !hi.sanMatchers[i].Equal(other.sanMatchers[i]) {
-			return false
-		}
-	}
-	return true
-}
-
 // SetHandshakeInfo returns a copy of addr in which the Attributes field is
 // updated with hiPtr.
 func SetHandshakeInfo(addr resolver.Address, hiPtr *atomic.Pointer[HandshakeInfo]) resolver.Address {
@@ -109,15 +85,20 @@ func HandshakeInfoFromAttributes(attr *attributes.Attributes) *atomic.Pointer[Ha
 // server handshake methods in xds credentials. The xDS implementation will be
 // responsible for populating these fields.
 type HandshakeInfo struct {
-	// All fields written at init time and read only after that, so no
-	// synchronization needed.
-	rootProvider        certprovider.Provider
-	identityProvider    certprovider.Provider
+	// The fields below are initialized when the HandshakeInfo is created, and are
+	// not changed thereafter.
 	sanMatchers         []matcher.StringMatcher // Only on the client side.
 	requireClientCert   bool                    // Only on server side.
 	sni                 string                  // Only on client side, used for Server Name Indication in TLS handshake.
 	validateSANUsingSNI bool                    // Only on client side, indicates whether to perform validation of SANs based on SNI value.
 	useAutoHostSNI      bool                    // Only on client side, indicates whether to use endpoint hostname as SNI.
+
+	// Guards the fields below.
+	mu               sync.Mutex
+	closed           bool
+	activeHandshakes int
+	rootProvider     certprovider.Provider
+	identityProvider certprovider.Provider
 }
 
 // NewHandshakeInfo returns a new handshake info configured with the provided
@@ -134,12 +115,129 @@ func NewHandshakeInfo(rootProvider certprovider.Provider, identityProvider certp
 	}
 }
 
+// use increments the active handshake count on hi, preventing its certificate
+// providers from being closed until Done() is called. Returns false if hi
+// has already been closed via Close().
+func (hi *HandshakeInfo) use() bool {
+	hi.mu.Lock()
+	defer hi.mu.Unlock()
+	if hi.closed {
+		return false
+	}
+	hi.activeHandshakes++
+	return true
+}
+
+// done decrements the active handshake count on hi. If hi has already been
+// closed via hi.Close() and the count drops to zero, the certificate providers
+// are closed.
+func (hi *HandshakeInfo) done() {
+	hi.mu.Lock()
+	if hi.activeHandshakes > 0 {
+		hi.activeHandshakes--
+	}
+
+	// Return early if hi is not closed or if there are still active handshakes.
+	if !hi.closed || hi.activeHandshakes != 0 {
+		hi.mu.Unlock()
+		return
+	}
+
+	r, i := hi.rootProvider, hi.identityProvider
+	hi.rootProvider = nil
+	hi.identityProvider = nil
+	hi.mu.Unlock()
+
+	if r != nil {
+		r.Close()
+	}
+	if i != nil {
+		i.Close()
+	}
+}
+
+// Close marks hi as closed. If no handshakes are currently in progress using hi,
+// its certificate providers are closed immediately. Otherwise, the providers will
+// be closed when the last active handshake calls hi.Done().
+func (hi *HandshakeInfo) Close() {
+	hi.mu.Lock()
+	if hi.closed {
+		hi.mu.Unlock()
+		return
+	}
+	hi.closed = true
+	if hi.activeHandshakes != 0 {
+		hi.mu.Unlock()
+		return
+	}
+	r, i := hi.rootProvider, hi.identityProvider
+	hi.rootProvider = nil
+	hi.identityProvider = nil
+	hi.mu.Unlock()
+
+	if r != nil {
+		r.Close()
+	}
+	if i != nil {
+		i.Close()
+	}
+}
+
+// ClientSideTLSConfig loads the HandshakeInfo from hiPtr, marks it as in-use,
+// and returns the tls.Config along with a done callback that MUST be invoked
+// when the handshake completes. If no HandshakeInfo is stored in hiPtr or if
+// fallback credentials should be used, useFallback returns true.
+func ClientSideTLSConfig(ctx context.Context, hiPtr *atomic.Pointer[HandshakeInfo], hostname string) (cfg *tls.Config, useFallback bool, done func(), err error) {
+	if hiPtr == nil {
+		return nil, true, func() {}, nil
+	}
+	for {
+		hi := hiPtr.Load()
+		if hi == nil || hi.UseFallbackCreds() {
+			return nil, true, func() {}, nil
+		}
+		if !hi.use() {
+			if hiPtr.Load() != hi {
+				continue
+			}
+			return nil, true, func() {}, nil
+		}
+		cfg, err := hi.clientSideTLSConfigInternal(ctx, hostname)
+		if err != nil {
+			hi.done()
+			return nil, false, func() {}, err
+		}
+		return cfg, false, hi.done, nil
+	}
+}
+
+// ServerSideTLSConfig checks if hi is configured and marks it as in-use,
+// returning the tls.Config along with a done callback that MUST be invoked when
+// the handshake completes. If hi is nil or fallback credentials should be used,
+// useFallback returns true.
+func ServerSideTLSConfig(ctx context.Context, hi *HandshakeInfo) (cfg *tls.Config, useFallback bool, done func(), err error) {
+	if hi == nil || hi.UseFallbackCreds() {
+		return nil, true, func() {}, nil
+	}
+	if !hi.use() {
+		return nil, true, func() {}, nil
+	}
+	cfg, err = hi.serverSideTLSConfigInternal(ctx)
+	if err != nil {
+		hi.done()
+		return nil, false, func() {}, err
+	}
+	return cfg, false, hi.done, nil
+}
+
 // UseFallbackCreds returns true when fallback credentials are to be used based
 // on the contents of the HandshakeInfo.
 func (hi *HandshakeInfo) UseFallbackCreds() bool {
 	if hi == nil {
 		return true
 	}
+	hi.mu.Lock()
+	defer hi.mu.Unlock()
 	return hi.identityProvider == nil && hi.rootProvider == nil
 }
 
@@ -149,23 +247,26 @@ func (hi *HandshakeInfo) GetSANMatchersForTesting() []matcher.StringMatcher {
 	return append([]matcher.StringMatcher{}, hi.sanMatchers...)
 }
 
-// ClientSideTLSConfig constructs a tls.Config to be used in a client-side
-// handshake based on the contents of the HandshakeInfo.
+// clientSideTLSConfigInternal constructs a tls.Config to be used in a
+// client-side handshake based on the contents of the HandshakeInfo.
 //
 // hostname is passed as a parameter here instead of being part of the
 // HandshakeInfo because HandshakeInfo contains cluster-level security
 // configuration that applies to all endpoints in the cluster, while hostname is
 // specific to each endpoint. This allows sharing a single HandshakeInfo
 // instance across multiple endpoints in the same cluster.
-func (hi *HandshakeInfo) ClientSideTLSConfig(ctx context.Context, hostname string) (*tls.Config, error) {
+func (hi *HandshakeInfo) clientSideTLSConfigInternal(ctx context.Context, hostname string) (*tls.Config, error) {
 	// On the client side, rootProvider is mandatory. IdentityProvider is
 	// optional based on whether the client is doing TLS or mTLS.
+	hi.mu.Lock()
 	if hi.rootProvider == nil {
+		hi.mu.Unlock()
 		return nil, errors.New("xds: CertificateProvider to fetch trusted roots is missing, cannot perform TLS handshake. Please check configuration on the management server")
 	}
 	// Since the call to KeyMaterial() can block, we read the providers under
 	// the lock but call the actual function after releasing the lock.
 	rootProv, idProv := hi.rootProvider, hi.identityProvider
+	hi.mu.Unlock()
 
 	// InsecureSkipVerify needs to be set to true because we need to perform
 	// custom verification to check the SAN on the received certificate.
@@ -279,21 +380,24 @@ func (hi *HandshakeInfo) buildVerifyFunc(km *certprovider.KeyMaterial, isClient 
 	}
 }
 
-// ServerSideTLSConfig constructs a tls.Config to be used in a server-side
-// handshake based on the contents of the HandshakeInfo.
-func (hi *HandshakeInfo) ServerSideTLSConfig(ctx context.Context) (*tls.Config, error) {
+// serverSideTLSConfigInternal constructs a tls.Config to be used in a
+// server-side handshake based on the contents of the HandshakeInfo.
+func (hi *HandshakeInfo) serverSideTLSConfigInternal(ctx context.Context) (*tls.Config, error) {
 	cfg := &tls.Config{
 		ClientAuth: tls.NoClientCert,
 		NextProtos: []string{"h2"},
 	}
+	hi.mu.Lock()
 	// On the server side, identityProvider is mandatory. RootProvider is
 	// optional based on whether the server is doing TLS or mTLS.
 	if hi.identityProvider == nil {
+		hi.mu.Unlock()
 		return nil, errors.New("xds: CertificateProvider to fetch identity certificate is missing, cannot perform TLS handshake. Please check configuration on the management server")
 	}
 	// Since the call to KeyMaterial() can block, we read the providers under
 	// the lock but call the actual function after releasing the lock.
 	rootProv, idProv := hi.rootProvider, hi.identityProvider
+	hi.mu.Unlock()
 	if hi.requireClientCert {
 		cfg.ClientAuth = tls.RequireAndVerifyClientCert
 	}

--- a/internal/credentials/xds/handshake_info.go
+++ b/internal/credentials/xds/handshake_info.go
@@ -169,7 +169,7 @@ func ServerSideTLSConfig(ctx context.Context, hiRC *grpcsync.RefCounted[Handshak
 		return nil, true, func() {}, nil
 	}
 	if !hiRC.TryIncrement() {
-		return nil, true, func() {}, nil
+		return nil, false, func() {}, errors.New("xds: connection closed or HandshakeInfo dead")
 	}
 	cfg, err = hi.serverSideTLSConfigInternal(ctx)
 	if err != nil {

--- a/internal/credentials/xds/handshake_info.go
+++ b/internal/credentials/xds/handshake_info.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 	"sync/atomic"
 
 	"google.golang.org/grpc/attributes"
@@ -34,6 +33,7 @@ import (
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/credentials/spiffe"
 	"google.golang.org/grpc/internal/envconfig"
+	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/xds/matcher"
 	"google.golang.org/grpc/resolver"
 )
@@ -69,15 +69,15 @@ func Hostname(attr *attributes.Attributes) string {
 
 // SetHandshakeInfo returns a copy of addr in which the Attributes field is
 // updated with hiPtr.
-func SetHandshakeInfo(addr resolver.Address, hiPtr *atomic.Pointer[HandshakeInfo]) resolver.Address {
+func SetHandshakeInfo(addr resolver.Address, hiPtr *atomic.Pointer[grpcsync.RefCounted[HandshakeInfo]]) resolver.Address {
 	addr.Attributes = addr.Attributes.WithValue(handshakeAttrKey{}, hiPtr)
 	return addr
 }
 
 // HandshakeInfoFromAttributes returns a pointer to the *HandshakeInfo stored in attr.
-func HandshakeInfoFromAttributes(attr *attributes.Attributes) *atomic.Pointer[HandshakeInfo] {
+func HandshakeInfoFromAttributes(attr *attributes.Attributes) *atomic.Pointer[grpcsync.RefCounted[HandshakeInfo]] {
 	v := attr.Value(handshakeAttrKey{})
-	hi, _ := v.(*atomic.Pointer[HandshakeInfo])
+	hi, _ := v.(*atomic.Pointer[grpcsync.RefCounted[HandshakeInfo]])
 	return hi
 }
 
@@ -93,93 +93,32 @@ type HandshakeInfo struct {
 	validateSANUsingSNI bool                    // Only on client side, indicates whether to perform validation of SANs based on SNI value.
 	useAutoHostSNI      bool                    // Only on client side, indicates whether to use endpoint hostname as SNI.
 
-	// Guards the fields below.
-	mu               sync.Mutex
-	closed           bool
-	activeHandshakes int
 	rootProvider     certprovider.Provider
 	identityProvider certprovider.Provider
 }
 
-// NewHandshakeInfo returns a new handshake info configured with the provided
-// options.
-func NewHandshakeInfo(rootProvider certprovider.Provider, identityProvider certprovider.Provider, sanMatchers []matcher.StringMatcher, requireClientCert bool, sni string, validateSANUsingSNI bool, useAutoHostSNI bool) *HandshakeInfo {
-	return &HandshakeInfo{
+// NewHandshakeInfo returns a new reference counted HandshakeInfo configured
+// with the provided options.
+func NewHandshakeInfo(rootProvider, identityProvider certprovider.Provider, sanMatchers []matcher.StringMatcher, sni string, requireClientCert, validateSANUsingSNI, useAutoHostSNI bool) *grpcsync.RefCounted[HandshakeInfo] {
+	hi := &HandshakeInfo{
 		rootProvider:        rootProvider,
 		identityProvider:    identityProvider,
 		sanMatchers:         sanMatchers,
-		requireClientCert:   requireClientCert,
 		sni:                 sni,
+		requireClientCert:   requireClientCert,
 		validateSANUsingSNI: validateSANUsingSNI,
 		useAutoHostSNI:      useAutoHostSNI,
 	}
+
+	return grpcsync.NewRefCounted(hi, hi.close)
 }
 
-// use increments the active handshake count on hi, preventing its certificate
-// providers from being closed until Done() is called. Returns false if hi
-// has already been closed via Close().
-func (hi *HandshakeInfo) use() bool {
-	hi.mu.Lock()
-	defer hi.mu.Unlock()
-	if hi.closed {
-		return false
+func (hi *HandshakeInfo) close() {
+	if hi.rootProvider != nil {
+		hi.rootProvider.Close()
 	}
-	hi.activeHandshakes++
-	return true
-}
-
-// done decrements the active handshake count on hi. If hi has already been
-// closed via hi.Close() and the count drops to zero, the certificate providers
-// are closed.
-func (hi *HandshakeInfo) done() {
-	hi.mu.Lock()
-	if hi.activeHandshakes > 0 {
-		hi.activeHandshakes--
-	}
-
-	// Return early if hi is not closed or if there are still active handshakes.
-	if !hi.closed || hi.activeHandshakes != 0 {
-		hi.mu.Unlock()
-		return
-	}
-
-	r, i := hi.rootProvider, hi.identityProvider
-	hi.rootProvider = nil
-	hi.identityProvider = nil
-	hi.mu.Unlock()
-
-	if r != nil {
-		r.Close()
-	}
-	if i != nil {
-		i.Close()
-	}
-}
-
-// Close marks hi as closed. If no handshakes are currently in progress using hi,
-// its certificate providers are closed immediately. Otherwise, the providers will
-// be closed when the last active handshake calls hi.Done().
-func (hi *HandshakeInfo) Close() {
-	hi.mu.Lock()
-	if hi.closed {
-		hi.mu.Unlock()
-		return
-	}
-	hi.closed = true
-	if hi.activeHandshakes != 0 {
-		hi.mu.Unlock()
-		return
-	}
-	r, i := hi.rootProvider, hi.identityProvider
-	hi.rootProvider = nil
-	hi.identityProvider = nil
-	hi.mu.Unlock()
-
-	if r != nil {
-		r.Close()
-	}
-	if i != nil {
-		i.Close()
+	if hi.identityProvider != nil {
+		hi.identityProvider.Close()
 	}
 }
 
@@ -187,27 +126,29 @@ func (hi *HandshakeInfo) Close() {
 // and returns the tls.Config along with a done callback that MUST be invoked
 // when the handshake completes. If no HandshakeInfo is stored in hiPtr or if
 // fallback credentials should be used, useFallback returns true.
-func ClientSideTLSConfig(ctx context.Context, hiPtr *atomic.Pointer[HandshakeInfo], hostname string) (cfg *tls.Config, useFallback bool, done func(), err error) {
+func ClientSideTLSConfig(ctx context.Context, hiPtr *atomic.Pointer[grpcsync.RefCounted[HandshakeInfo]], hostname string) (cfg *tls.Config, useFallback bool, done func(), err error) {
 	if hiPtr == nil {
 		return nil, true, func() {}, nil
 	}
 	for {
-		hi := hiPtr.Load()
-		if hi == nil || hi.UseFallbackCreds() {
-			return nil, true, func() {}, nil
-		}
-		if !hi.use() {
-			if hiPtr.Load() != hi {
+		hiRC := hiPtr.Load()
+		if !hiRC.TryIncrement() {
+			if hiPtr.Load() != hiRC {
 				continue
 			}
 			return nil, true, func() {}, nil
 		}
+
+		hi := hiRC.Value()
+		if hi == nil || hi.UseFallbackCreds() {
+			return nil, true, func() {}, nil
+		}
 		cfg, err := hi.clientSideTLSConfigInternal(ctx, hostname)
 		if err != nil {
-			hi.done()
+			hiRC.Decrement()
 			return nil, false, func() {}, err
 		}
-		return cfg, false, hi.done, nil
+		return cfg, false, hiRC.Decrement, nil
 	}
 }
 
@@ -215,19 +156,20 @@ func ClientSideTLSConfig(ctx context.Context, hiPtr *atomic.Pointer[HandshakeInf
 // returning the tls.Config along with a done callback that MUST be invoked when
 // the handshake completes. If hi is nil or fallback credentials should be used,
 // useFallback returns true.
-func ServerSideTLSConfig(ctx context.Context, hi *HandshakeInfo) (cfg *tls.Config, useFallback bool, done func(), err error) {
+func ServerSideTLSConfig(ctx context.Context, hiRC *grpcsync.RefCounted[HandshakeInfo]) (cfg *tls.Config, useFallback bool, done func(), err error) {
+	hi := hiRC.Value()
 	if hi == nil || hi.UseFallbackCreds() {
 		return nil, true, func() {}, nil
 	}
-	if !hi.use() {
+	if !hiRC.TryIncrement() {
 		return nil, true, func() {}, nil
 	}
 	cfg, err = hi.serverSideTLSConfigInternal(ctx)
 	if err != nil {
-		hi.done()
+		hiRC.Decrement()
 		return nil, false, func() {}, err
 	}
-	return cfg, false, hi.done, nil
+	return cfg, false, hiRC.Decrement, nil
 }
 
 // UseFallbackCreds returns true when fallback credentials are to be used based
@@ -236,8 +178,6 @@ func (hi *HandshakeInfo) UseFallbackCreds() bool {
 	if hi == nil {
 		return true
 	}
-	hi.mu.Lock()
-	defer hi.mu.Unlock()
 	return hi.identityProvider == nil && hi.rootProvider == nil
 }
 
@@ -258,15 +198,9 @@ func (hi *HandshakeInfo) GetSANMatchersForTesting() []matcher.StringMatcher {
 func (hi *HandshakeInfo) clientSideTLSConfigInternal(ctx context.Context, hostname string) (*tls.Config, error) {
 	// On the client side, rootProvider is mandatory. IdentityProvider is
 	// optional based on whether the client is doing TLS or mTLS.
-	hi.mu.Lock()
 	if hi.rootProvider == nil {
-		hi.mu.Unlock()
 		return nil, errors.New("xds: CertificateProvider to fetch trusted roots is missing, cannot perform TLS handshake. Please check configuration on the management server")
 	}
-	// Since the call to KeyMaterial() can block, we read the providers under
-	// the lock but call the actual function after releasing the lock.
-	rootProv, idProv := hi.rootProvider, hi.identityProvider
-	hi.mu.Unlock()
 
 	// InsecureSkipVerify needs to be set to true because we need to perform
 	// custom verification to check the SAN on the received certificate.
@@ -278,7 +212,7 @@ func (hi *HandshakeInfo) clientSideTLSConfigInternal(ctx context.Context, hostna
 		NextProtos:         []string{"h2"},
 	}
 
-	km, err := rootProv.KeyMaterial(ctx)
+	km, err := hi.rootProvider.KeyMaterial(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("xds: fetching trusted roots from CertificateProvider failed: %v", err)
 	}
@@ -295,8 +229,8 @@ func (hi *HandshakeInfo) clientSideTLSConfigInternal(ctx context.Context, hostna
 
 	cfg.VerifyPeerCertificate = hi.buildVerifyFunc(km, true, sni)
 
-	if idProv != nil {
-		km, err := idProv.KeyMaterial(ctx)
+	if hi.identityProvider != nil {
+		km, err := hi.identityProvider.KeyMaterial(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("xds: fetching identity certificates from CertificateProvider failed: %v", err)
 		}
@@ -387,30 +321,24 @@ func (hi *HandshakeInfo) serverSideTLSConfigInternal(ctx context.Context) (*tls.
 		ClientAuth: tls.NoClientCert,
 		NextProtos: []string{"h2"},
 	}
-	hi.mu.Lock()
 	// On the server side, identityProvider is mandatory. RootProvider is
 	// optional based on whether the server is doing TLS or mTLS.
 	if hi.identityProvider == nil {
-		hi.mu.Unlock()
 		return nil, errors.New("xds: CertificateProvider to fetch identity certificate is missing, cannot perform TLS handshake. Please check configuration on the management server")
 	}
-	// Since the call to KeyMaterial() can block, we read the providers under
-	// the lock but call the actual function after releasing the lock.
-	rootProv, idProv := hi.rootProvider, hi.identityProvider
-	hi.mu.Unlock()
 	if hi.requireClientCert {
 		cfg.ClientAuth = tls.RequireAndVerifyClientCert
 	}
 
 	// identityProvider is mandatory on the server side.
-	km, err := idProv.KeyMaterial(ctx)
+	km, err := hi.identityProvider.KeyMaterial(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("xds: fetching identity certificates from CertificateProvider failed: %v", err)
 	}
 	cfg.Certificates = km.Certs
 
-	if rootProv != nil {
-		km, err := rootProv.KeyMaterial(ctx)
+	if hi.rootProvider != nil {
+		km, err := hi.rootProvider.KeyMaterial(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("xds: fetching trusted roots from CertificateProvider failed: %v", err)
 		}

--- a/internal/credentials/xds/handshake_info.go
+++ b/internal/credentials/xds/handshake_info.go
@@ -132,6 +132,9 @@ func ClientSideTLSConfig(ctx context.Context, hiPtr *atomic.Pointer[grpcsync.Ref
 	}
 	for {
 		hiRC := hiPtr.Load()
+		if hiRC == nil {
+			return nil, true, func() {}, nil
+		}
 		if !hiRC.TryIncrement() {
 			if hiPtr.Load() != hiRC {
 				continue
@@ -141,6 +144,7 @@ func ClientSideTLSConfig(ctx context.Context, hiPtr *atomic.Pointer[grpcsync.Ref
 
 		hi := hiRC.Value()
 		if hi == nil || hi.UseFallbackCreds() {
+			hiRC.Decrement()
 			return nil, true, func() {}, nil
 		}
 		cfg, err := hi.clientSideTLSConfigInternal(ctx, hostname)
@@ -157,6 +161,9 @@ func ClientSideTLSConfig(ctx context.Context, hiPtr *atomic.Pointer[grpcsync.Ref
 // the handshake completes. If hi is nil or fallback credentials should be used,
 // useFallback returns true.
 func ServerSideTLSConfig(ctx context.Context, hiRC *grpcsync.RefCounted[HandshakeInfo]) (cfg *tls.Config, useFallback bool, done func(), err error) {
+	if hiRC == nil {
+		return nil, true, func() {}, nil
+	}
 	hi := hiRC.Value()
 	if hi == nil || hi.UseFallbackCreds() {
 		return nil, true, func() {}, nil

--- a/internal/credentials/xds/handshake_info.go
+++ b/internal/credentials/xds/handshake_info.go
@@ -133,13 +133,13 @@ func ClientSideTLSConfig(ctx context.Context, hiPtr *atomic.Pointer[grpcsync.Ref
 	for {
 		hiRC := hiPtr.Load()
 		if hiRC == nil {
-			return nil, true, func() {}, nil
+			return nil, false, func() {}, errors.New("xds: connection closed or HandshakeInfo dead")
 		}
 		if !hiRC.TryIncrement() {
 			if hiPtr.Load() != hiRC {
 				continue
 			}
-			return nil, true, func() {}, nil
+			return nil, false, func() {}, errors.New("xds: connection closed or HandshakeInfo dead")
 		}
 
 		hi := hiRC.Value()

--- a/internal/credentials/xds/handshake_info_test.go
+++ b/internal/credentials/xds/handshake_info_test.go
@@ -31,6 +31,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -335,6 +336,37 @@ func (s) TestMatchingSANExists_Success(t *testing.T) {
 	}
 }
 
+// Equal reports whether the handshake info structs are identical.
+func (hi *HandshakeInfo) Equal(other *HandshakeInfo) bool {
+	if hi == nil && other == nil {
+		return true
+	}
+	if hi == nil || other == nil {
+		return false
+	}
+	hi.mu.Lock()
+	r1, i1 := hi.rootProvider, hi.identityProvider
+	hi.mu.Unlock()
+	other.mu.Lock()
+	r2, i2 := other.rootProvider, other.identityProvider
+	other.mu.Unlock()
+	if r1 != r2 ||
+		i1 != i2 ||
+		hi.requireClientCert != other.requireClientCert ||
+		hi.sni != other.sni ||
+		hi.validateSANUsingSNI != other.validateSANUsingSNI ||
+		hi.useAutoHostSNI != other.useAutoHostSNI ||
+		len(hi.sanMatchers) != len(other.sanMatchers) {
+		return false
+	}
+	for i := range hi.sanMatchers {
+		if !hi.sanMatchers[i].Equal(other.sanMatchers[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 func (s) TestEqual(t *testing.T) {
 	tests := []struct {
 		desc      string
@@ -504,10 +536,13 @@ func (s) TestBuildVerifyFuncFailures(t *testing.T) {
 	hi := NewHandshakeInfo(&testProvider, &testProvider, nil, true, "", false, false)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-	cfg, err := hi.ClientSideTLSConfig(ctx, "")
+	hiPtr := new(atomic.Pointer[HandshakeInfo])
+	hiPtr.Store(hi)
+	cfg, _, done, err := ClientSideTLSConfig(ctx, hiPtr, "")
 	if err != nil {
-		t.Fatalf("hi.ClientSideTLSConfig() failed with err %v", err)
+		t.Fatalf("GetClientSideTLSConfig() failed with err %v", err)
 	}
+	defer done()
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			err = cfg.VerifyPeerCertificate(tc.peerCertChain, nil)
@@ -579,11 +614,13 @@ func (s) TestAutoHostSNI_DNS_SANValidation_Failures(t *testing.T) {
 	hi := NewHandshakeInfo(provider, nil, nil, true, "wrong.sni.domain", true, false)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-
-	cfg, err := hi.ClientSideTLSConfig(ctx, "")
+	hiPtr := new(atomic.Pointer[HandshakeInfo])
+	hiPtr.Store(hi)
+	cfg, _, done, err := ClientSideTLSConfig(ctx, hiPtr, "")
 	if err != nil {
-		t.Fatalf("hi.ClientSideTLSConfig() failed: %v", err)
+		t.Fatalf("GetClientSideTLSConfig() failed: %v", err)
 	}
+	defer done()
 
 	err = cfg.VerifyPeerCertificate([][]byte{derBytes}, nil)
 	if err == nil {
@@ -599,11 +636,13 @@ func (s) TestVerifyPeerCertificateZeroCerts(t *testing.T) {
 	hi := NewHandshakeInfo(provider, nil, nil, true, "", false, false)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-
-	cfg, err := hi.ClientSideTLSConfig(ctx, "")
+	hiPtr := new(atomic.Pointer[HandshakeInfo])
+	hiPtr.Store(hi)
+	cfg, _, done, err := ClientSideTLSConfig(ctx, hiPtr, "")
 	if err != nil {
-		t.Fatalf("hi.ClientSideTLSConfig() failed: %v", err)
+		t.Fatalf("GetClientSideTLSConfig() failed: %v", err)
 	}
+	defer done()
 
 	const wantErr = "no peer certificates presented"
 	if err := cfg.VerifyPeerCertificate(nil, nil); err == nil || !strings.Contains(err.Error(), wantErr) {

--- a/internal/credentials/xds/handshake_info_test.go
+++ b/internal/credentials/xds/handshake_info_test.go
@@ -344,19 +344,26 @@ func (hi *HandshakeInfo) Equal(other *HandshakeInfo) bool {
 	if hi == nil || other == nil {
 		return false
 	}
+
 	hi.mu.Lock()
 	r1, i1 := hi.rootProvider, hi.identityProvider
 	hi.mu.Unlock()
 	other.mu.Lock()
 	r2, i2 := other.rootProvider, other.identityProvider
 	other.mu.Unlock()
-	if r1 != r2 ||
-		i1 != i2 ||
-		hi.requireClientCert != other.requireClientCert ||
-		hi.sni != other.sni ||
-		hi.validateSANUsingSNI != other.validateSANUsingSNI ||
-		hi.useAutoHostSNI != other.useAutoHostSNI ||
-		len(hi.sanMatchers) != len(other.sanMatchers) {
+
+	switch {
+	case r1 != r2 || i1 != i2:
+		return false
+	case hi.requireClientCert != other.requireClientCert:
+		return false
+	case hi.sni != other.sni:
+		return false
+	case hi.validateSANUsingSNI != other.validateSANUsingSNI:
+		return false
+	case hi.useAutoHostSNI != other.useAutoHostSNI:
+		return false
+	case len(hi.sanMatchers) != len(other.sanMatchers):
 		return false
 	}
 	for i := range hi.sanMatchers {

--- a/internal/credentials/xds/handshake_info_test.go
+++ b/internal/credentials/xds/handshake_info_test.go
@@ -577,7 +577,6 @@ func loadCert(t *testing.T, certPath, keyPath string) [][]byte {
 }
 
 type testProviderWithRoots struct {
-	certprovider.Provider
 	roots *x509.CertPool
 }
 
@@ -586,6 +585,8 @@ func (m *testProviderWithRoots) KeyMaterial(context.Context) (*certprovider.KeyM
 		Roots: m.roots,
 	}, nil
 }
+
+func (m *testProviderWithRoots) Close() {}
 
 // Tests the scenario where the SNI provided by the xDS server is only present
 // in the URI SAN of the certificate presented by the server, and not in the DNS

--- a/internal/credentials/xds/handshake_info_test.go
+++ b/internal/credentials/xds/handshake_info_test.go
@@ -40,6 +40,7 @@ import (
 	"google.golang.org/grpc/credentials/tls/certprovider"
 	"google.golang.org/grpc/internal/credentials/spiffe"
 	"google.golang.org/grpc/internal/envconfig"
+	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/xds/matcher"
@@ -51,14 +52,6 @@ type s struct {
 
 func Test(t *testing.T) {
 	grpctest.RunSubTests(t, s{})
-}
-
-type testCertProvider struct {
-	certprovider.Provider
-}
-
-type testCertProviderWithKeyMaterial struct {
-	certprovider.Provider
 }
 
 func (s) TestDNSMatch(t *testing.T) {
@@ -224,9 +217,10 @@ func (s) TestMatchingSANExists_FailureCases(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			hi := NewHandshakeInfo(nil, nil, test.sanMatchers, false, "", false, false)
+			hi := NewHandshakeInfo(nil, nil, test.sanMatchers, "", false, false, false)
+			defer hi.Decrement()
 
-			if hi.MatchingSANExists(inputCert) {
+			if hi.Value().MatchingSANExists(inputCert) {
 				t.Fatalf("hi.MatchingSANExists(%+v) with SAN matchers +%v succeeded when expected to fail", inputCert, test.sanMatchers)
 			}
 		})
@@ -327,9 +321,10 @@ func (s) TestMatchingSANExists_Success(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			hi := NewHandshakeInfo(nil, nil, test.sanMatchers, false, "", false, false)
+			hi := NewHandshakeInfo(nil, nil, test.sanMatchers, "", false, false, false)
+			defer hi.Decrement()
 
-			if !hi.MatchingSANExists(inputCert) {
+			if !hi.Value().MatchingSANExists(inputCert) {
 				t.Fatalf("hi.MatchingSANExists(%+v) with SAN matchers +%v failed when expected to succeed", inputCert, test.sanMatchers)
 			}
 		})
@@ -345,12 +340,8 @@ func (hi *HandshakeInfo) Equal(other *HandshakeInfo) bool {
 		return false
 	}
 
-	hi.mu.Lock()
 	r1, i1 := hi.rootProvider, hi.identityProvider
-	hi.mu.Unlock()
-	other.mu.Lock()
 	r2, i2 := other.rootProvider, other.identityProvider
-	other.mu.Unlock()
 
 	switch {
 	case r1 != r2 || i1 != i2:
@@ -374,114 +365,126 @@ func (hi *HandshakeInfo) Equal(other *HandshakeInfo) bool {
 	return true
 }
 
+type testCertProvider struct {
+	certprovider.Provider
+}
+
 func (s) TestEqual(t *testing.T) {
 	tests := []struct {
 		desc      string
-		hi1       *HandshakeInfo
-		hi2       *HandshakeInfo
+		hi1       *grpcsync.RefCounted[HandshakeInfo]
+		hi2       *grpcsync.RefCounted[HandshakeInfo]
 		wantMatch bool
 	}{
 		{
-			desc:      "both HandshakeInfo are nil",
-			hi1:       nil,
-			hi2:       nil,
+			desc: "both HandshakeInfo are nil",
+			hi1: func() *grpcsync.RefCounted[HandshakeInfo] {
+				return grpcsync.NewRefCounted((*HandshakeInfo)(nil), func() {})
+			}(),
+			hi2: func() *grpcsync.RefCounted[HandshakeInfo] {
+				return grpcsync.NewRefCounted((*HandshakeInfo)(nil), func() {})
+			}(),
 			wantMatch: true,
 		},
 		{
-			desc:      "one HandshakeInfo is nil",
-			hi1:       nil,
-			hi2:       NewHandshakeInfo(&testCertProvider{}, nil, nil, false, "", false, false),
+			desc: "one HandshakeInfo is nil",
+			hi1: func() *grpcsync.RefCounted[HandshakeInfo] {
+				return grpcsync.NewRefCounted((*HandshakeInfo)(nil), func() {})
+			}(),
+			hi2:       NewHandshakeInfo(&testCertProvider{}, nil, nil, "", false, false, false),
 			wantMatch: false,
 		},
 		{
 			desc:      "different root providers",
-			hi1:       NewHandshakeInfo(&testCertProvider{}, nil, nil, false, "", false, false),
-			hi2:       NewHandshakeInfo(&testCertProvider{}, nil, nil, false, "", false, false),
+			hi1:       NewHandshakeInfo(&testCertProvider{}, nil, nil, "", false, false, false),
+			hi2:       NewHandshakeInfo(&testCertProvider{}, nil, nil, "", false, false, false),
 			wantMatch: false,
 		},
 		{
 			desc: "same providers, same SAN matchers",
 			hi1: NewHandshakeInfo(testCertProvider{}, testCertProvider{}, []matcher.StringMatcher{
 				matcher.NewExactStringMatcher("foo.com", false),
-			}, false, "", false, false),
+			}, "", false, false, false),
 			hi2: NewHandshakeInfo(testCertProvider{}, testCertProvider{}, []matcher.StringMatcher{
 				matcher.NewExactStringMatcher("foo.com", false),
-			}, false, "", false, false),
+			}, "", false, false, false),
 			wantMatch: true,
 		},
 		{
 			desc: "same providers, different SAN matchers",
 			hi1: NewHandshakeInfo(testCertProvider{}, testCertProvider{}, []matcher.StringMatcher{
 				matcher.NewExactStringMatcher("foo.com", false),
-			}, false, "", false, false),
+			}, "", false, false, false),
 			hi2: NewHandshakeInfo(testCertProvider{}, testCertProvider{}, []matcher.StringMatcher{
 				matcher.NewExactStringMatcher("bar.com", false),
-			}, false, "", false, false),
+			}, "", false, false, false),
 			wantMatch: false,
 		},
 		{
 			desc: "same SAN matchers with different content",
-			hi1: NewHandshakeInfo(&testCertProvider{}, &testCertProvider{}, []matcher.StringMatcher{
+			hi1: NewHandshakeInfo(testCertProvider{}, testCertProvider{}, []matcher.StringMatcher{
 				matcher.NewExactStringMatcher("foo.com", false),
-			}, false, "", false, false),
-			hi2: NewHandshakeInfo(&testCertProvider{}, &testCertProvider{}, []matcher.StringMatcher{
+			}, "", false, false, false),
+			hi2: NewHandshakeInfo(testCertProvider{}, testCertProvider{}, []matcher.StringMatcher{
 				matcher.NewExactStringMatcher("foo.com", false),
 				matcher.NewExactStringMatcher("bar.com", false),
-			}, false, "", false, false),
+			}, "", false, false, false),
 			wantMatch: false,
 		},
 		{
 			desc:      "different requireClientCert flags",
-			hi1:       NewHandshakeInfo(&testCertProvider{}, &testCertProvider{}, nil, true, "", false, false),
-			hi2:       NewHandshakeInfo(&testCertProvider{}, &testCertProvider{}, nil, false, "", false, false),
+			hi1:       NewHandshakeInfo(testCertProvider{}, testCertProvider{}, nil, "", true, false, false),
+			hi2:       NewHandshakeInfo(testCertProvider{}, testCertProvider{}, nil, "", false, false, false),
 			wantMatch: false,
 		},
 		{
 			desc:      "same identity provider, different root provider",
-			hi1:       NewHandshakeInfo(&testCertProvider{}, testCertProvider{}, nil, false, "", false, false),
-			hi2:       NewHandshakeInfo(&testCertProvider{}, testCertProvider{}, nil, false, "", false, false),
+			hi1:       NewHandshakeInfo(&testCertProvider{}, testCertProvider{}, nil, "", false, false, false),
+			hi2:       NewHandshakeInfo(&testCertProvider{}, testCertProvider{}, nil, "", false, false, false),
 			wantMatch: false,
 		},
 		{
 			desc:      "different identity provider, same root provider",
-			hi1:       NewHandshakeInfo(testCertProvider{}, &testCertProvider{}, nil, false, "", false, false),
-			hi2:       NewHandshakeInfo(testCertProvider{}, &testCertProvider{}, nil, false, "", false, false),
+			hi1:       NewHandshakeInfo(testCertProvider{}, &testCertProvider{}, nil, "", false, false, false),
+			hi2:       NewHandshakeInfo(testCertProvider{}, &testCertProvider{}, nil, "", false, false, false),
 			wantMatch: false,
 		},
 		{
 			desc:      "same sni and validateSANUsingSNI",
-			hi1:       NewHandshakeInfo(nil, nil, nil, false, "sni", true, false),
-			hi2:       NewHandshakeInfo(nil, nil, nil, false, "sni", true, false),
+			hi1:       NewHandshakeInfo(nil, nil, nil, "sni", false, true, false),
+			hi2:       NewHandshakeInfo(nil, nil, nil, "sni", false, true, false),
 			wantMatch: true,
 		},
 		{
 			desc:      "different sni",
-			hi1:       NewHandshakeInfo(nil, nil, nil, false, "sni1", false, false),
-			hi2:       NewHandshakeInfo(nil, nil, nil, false, "sni2", false, false),
+			hi1:       NewHandshakeInfo(nil, nil, nil, "sni1", false, false, false),
+			hi2:       NewHandshakeInfo(nil, nil, nil, "sni2", false, false, false),
 			wantMatch: false,
 		},
 		{
 			desc:      "same sni, different validateSANUsingSNI",
-			hi1:       NewHandshakeInfo(nil, nil, nil, false, "sni", false, false),
-			hi2:       NewHandshakeInfo(nil, nil, nil, false, "sni", true, false),
+			hi1:       NewHandshakeInfo(nil, nil, nil, "sni", false, false, false),
+			hi2:       NewHandshakeInfo(nil, nil, nil, "sni", false, true, false),
 			wantMatch: false,
 		},
 		{
 			desc:      "different autoHostSNI",
-			hi1:       NewHandshakeInfo(nil, nil, nil, false, "", false, true),
-			hi2:       NewHandshakeInfo(nil, nil, nil, false, "", false, false),
+			hi1:       NewHandshakeInfo(nil, nil, nil, "", false, false, true),
+			hi2:       NewHandshakeInfo(nil, nil, nil, "", false, false, false),
 			wantMatch: false,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			if gotMatch := test.hi1.Equal(test.hi2); gotMatch != test.wantMatch {
+			if gotMatch := test.hi1.Value().Equal(test.hi2.Value()); gotMatch != test.wantMatch {
 				t.Errorf("hi1.Equal(hi2) = %v; wantMatch %v", gotMatch, test.wantMatch)
 			}
 		})
 	}
 }
+
+type testCertProviderWithKeyMaterial struct{}
 
 func (p *testCertProviderWithKeyMaterial) KeyMaterial(_ context.Context) (*certprovider.KeyMaterial, error) {
 	km := &certprovider.KeyMaterial{}
@@ -520,6 +523,8 @@ func (p *testCertProviderWithKeyMaterial) KeyMaterial(_ context.Context) (*certp
 	return km, nil
 }
 
+func (p *testCertProviderWithKeyMaterial) Close() {}
+
 func (s) TestBuildVerifyFuncFailures(t *testing.T) {
 	tests := []struct {
 		desc          string
@@ -540,10 +545,12 @@ func (s) TestBuildVerifyFuncFailures(t *testing.T) {
 		},
 	}
 	testProvider := testCertProviderWithKeyMaterial{}
-	hi := NewHandshakeInfo(&testProvider, &testProvider, nil, true, "", false, false)
+	hi := NewHandshakeInfo(&testProvider, &testProvider, nil, "", true, false, false)
+	defer hi.Decrement()
+
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-	hiPtr := new(atomic.Pointer[HandshakeInfo])
+	hiPtr := new(atomic.Pointer[grpcsync.RefCounted[HandshakeInfo]])
 	hiPtr.Store(hi)
 	cfg, _, done, err := ClientSideTLSConfig(ctx, hiPtr, "")
 	if err != nil {
@@ -618,10 +625,10 @@ func (s) TestAutoHostSNI_DNS_SANValidation_Failures(t *testing.T) {
 	roots.AddCert(cert)
 
 	provider := &testProviderWithRoots{roots: roots}
-	hi := NewHandshakeInfo(provider, nil, nil, true, "wrong.sni.domain", true, false)
+	hi := NewHandshakeInfo(provider, nil, nil, "wrong.sni.domain", true, true, false)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-	hiPtr := new(atomic.Pointer[HandshakeInfo])
+	hiPtr := new(atomic.Pointer[grpcsync.RefCounted[HandshakeInfo]])
 	hiPtr.Store(hi)
 	cfg, _, done, err := ClientSideTLSConfig(ctx, hiPtr, "")
 	if err != nil {
@@ -640,10 +647,10 @@ func (s) TestAutoHostSNI_DNS_SANValidation_Failures(t *testing.T) {
 
 func (s) TestVerifyPeerCertificateZeroCerts(t *testing.T) {
 	provider := &testProviderWithRoots{roots: x509.NewCertPool()}
-	hi := NewHandshakeInfo(provider, nil, nil, true, "", false, false)
+	hi := NewHandshakeInfo(provider, nil, nil, "", true, false, false)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-	hiPtr := new(atomic.Pointer[HandshakeInfo])
+	hiPtr := new(atomic.Pointer[grpcsync.RefCounted[HandshakeInfo]])
 	hiPtr.Store(hi)
 	cfg, _, done, err := ClientSideTLSConfig(ctx, hiPtr, "")
 	if err != nil {

--- a/internal/credentials/xds/handshake_info_test.go
+++ b/internal/credentials/xds/handshake_info_test.go
@@ -626,6 +626,7 @@ func (s) TestAutoHostSNI_DNS_SANValidation_Failures(t *testing.T) {
 
 	provider := &testProviderWithRoots{roots: roots}
 	hi := NewHandshakeInfo(provider, nil, nil, "wrong.sni.domain", true, true, false)
+	defer hi.Decrement()
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 	hiPtr := new(atomic.Pointer[grpcsync.RefCounted[HandshakeInfo]])
@@ -648,6 +649,7 @@ func (s) TestAutoHostSNI_DNS_SANValidation_Failures(t *testing.T) {
 func (s) TestVerifyPeerCertificateZeroCerts(t *testing.T) {
 	provider := &testProviderWithRoots{roots: x509.NewCertPool()}
 	hi := NewHandshakeInfo(provider, nil, nil, "", true, false, false)
+	defer hi.Decrement()
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 	hiPtr := new(atomic.Pointer[grpcsync.RefCounted[HandshakeInfo]])

--- a/internal/grpcsync/refcounted.go
+++ b/internal/grpcsync/refcounted.go
@@ -19,7 +19,6 @@
 package grpcsync
 
 import (
-	"fmt"
 	"sync/atomic"
 
 	"google.golang.org/grpc/grpclog"
@@ -27,37 +26,36 @@ import (
 
 var logger = grpclog.Component("grpcsync")
 
-// RefCounted tracks how many consumers hold a value of type V and runs a
-// cleanup when the last reference is released.
-type RefCounted[V any] struct {
-	val      V
+// RefCounted is a reference counted pointer of type *T. It tracks the number of
+// active references and runs a cleanup when the last reference is released.
+type RefCounted[T any] struct {
+	val      *T
 	refCount atomic.Int32
 	onZero   func()
 }
 
-// NewRefCounted creates a new RefCounted instance wrapping the given value with
-// initial refcount of one. The provided onZero callback must not be nil, and is
-// executed exactly once when the reference count drops to zero.
+// NewRefCounted creates a new RefCounted instance wrapping the given pointer
+// with initial refcount of one.
 //
-// The value should typically be a pointer, interface, or handle rather than a
-// plain value type (such as a struct or primitive value).
+// The provided onZero callback must not be nil, and is executed exactly once
+// when the reference count drops to zero.  Panics if onZero is nil.
 //
 // WARNING: onZero runs synchronously inside Decrement; it must not acquire
 // locks held by Decrement callers.
-func NewRefCounted[V any](val V, onZero func()) (*RefCounted[V], error) {
+func NewRefCounted[T any](val *T, onZero func()) *RefCounted[T] {
 	if onZero == nil {
-		return nil, fmt.Errorf("grpcsync: onZero callback cannot be nil")
+		panic("grpcsync: onZero callback cannot be nil")
 	}
-	rc := &RefCounted[V]{
+	rc := &RefCounted[T]{
 		val:    val,
 		onZero: onZero,
 	}
 	rc.refCount.Store(1)
-	return rc, nil
+	return rc
 }
 
 // Value returns the encapsulated resource.
-func (rc *RefCounted[V]) Value() V {
+func (rc *RefCounted[T]) Value() *T {
 	return rc.val
 }
 
@@ -70,7 +68,7 @@ func (rc *RefCounted[V]) Value() V {
 // CompareAndSwap loop overhead. TryIncrement should be reserved for speculative
 // lookups (such as fetching from a cache or map) where the resource might be
 // dead.
-func (rc *RefCounted[V]) TryIncrement() bool {
+func (rc *RefCounted[T]) TryIncrement() bool {
 	// Utilize a CompareAndSwap loop to prevent race conditions where a concurrent
 	// decrement could drop the count to zero between the read and the increment
 	// operation, which would otherwise inadvertently resurrect a closed resource.
@@ -91,7 +89,7 @@ func (rc *RefCounted[V]) TryIncrement() bool {
 // reference is already present, ensuring the resource is not dead. If there is
 // a possibility that the resource is dead or its reference count might have
 // reached zero, call TryIncrement instead.
-func (rc *RefCounted[V]) Increment() {
+func (rc *RefCounted[T]) Increment() {
 	if rc.refCount.Add(1) <= 1 {
 		logger.Errorf("Resource already closed or dead")
 	}
@@ -99,7 +97,7 @@ func (rc *RefCounted[V]) Increment() {
 
 // Decrement decrements the reference count. If it drops to zero, the onZero
 // callback is executed synchronously before this method returns.
-func (rc *RefCounted[V]) Decrement() {
+func (rc *RefCounted[T]) Decrement() {
 	if v := rc.refCount.Add(-1); v < 0 {
 		logger.Errorf("Refcount cannot be negative")
 	} else if v == 0 {

--- a/internal/grpcsync/refcounted_test.go
+++ b/internal/grpcsync/refcounted_test.go
@@ -31,18 +31,11 @@ import (
 // correctly retrieved and that the onZero callback is invoked when the
 // reference count drops to zero.
 func (s) TestRefCounted(t *testing.T) {
-	const val = "test-value"
+	val := 666
 	var onZeroCalled atomic.Bool
-
-	rc, err := NewRefCounted(val, func() {
-		onZeroCalled.Store(true)
-	})
-	if err != nil {
-		t.Fatalf("NewRefCounted() failed: %v", err)
-	}
-
-	if got := rc.Value(); got != val {
-		t.Fatalf("Value() = %v, want %v", got, val)
+	rc := NewRefCounted(&val, func() { onZeroCalled.Store(true) })
+	if got := rc.Value(); *got != val {
+		t.Fatalf("Value() = %v, want %v", *got, val)
 	}
 
 	if got := onZeroCalled.Load(); got {
@@ -61,16 +54,9 @@ func (s) TestRefCounted(t *testing.T) {
 // onZero callback is only executed when the count drops to zero, and not
 // beforehand.
 func (s) TestRefCounted_IncrementDecrement(t *testing.T) {
-	const val = 42
+	val := 666
 	var onZeroCount atomic.Int32
-
-	rc, err := NewRefCounted(val, func() {
-		onZeroCount.Add(1)
-	})
-	if err != nil {
-		t.Fatalf("NewRefCounted() failed: %v", err)
-	}
-
+	rc := NewRefCounted(&val, func() { onZeroCount.Add(1) })
 	rc.Increment()
 	rc.Decrement()
 
@@ -90,14 +76,9 @@ func (s) TestRefCounted_IncrementDecrement(t *testing.T) {
 // resources but fails on resources whose reference count has already dropped to
 // zero.
 func (s) TestRefCounted_TryIncrement(t *testing.T) {
+	val := 666
 	var onZeroCount atomic.Int32
-	rc, err := NewRefCounted("val", func() {
-		onZeroCount.Add(1)
-	})
-	if err != nil {
-		t.Fatalf("NewRefCounted() failed: %v", err)
-	}
-
+	rc := NewRefCounted(&val, func() { onZeroCount.Add(1) })
 	if got := rc.TryIncrement(); !got {
 		t.Fatalf("TryIncrement() on active resource = %v, want true", got)
 	}
@@ -118,17 +99,12 @@ func (s) TestRefCounted_TryIncrement(t *testing.T) {
 // and decrement the reference count. It verifies that the reference counting is
 // thread-safe and the onZero callback is invoked exactly once.
 func (s) TestRefCounted_Concurrent(t *testing.T) {
-	const numGoroutines = 100
+	val := 666
 	var onZeroCount atomic.Int32
-
-	rc, err := NewRefCounted("concurrent-val", func() {
-		onZeroCount.Add(1)
-	})
-	if err != nil {
-		t.Fatalf("NewRefCounted() failed: %v", err)
-	}
+	rc := NewRefCounted(&val, func() { onZeroCount.Add(1) })
 
 	var wg sync.WaitGroup
+	const numGoroutines = 100
 	for i := 0; i < numGoroutines; i++ {
 		wg.Go(func() {
 			if rc.TryIncrement() {
@@ -145,11 +121,9 @@ func (s) TestRefCounted_Concurrent(t *testing.T) {
 
 // Test verifies that Decrementing a resource whose reference count has already
 // dropped to zero results in a negative refcount log error.
-func (s) TestRefCounted_DecrementNegative(t *testing.T) {
-	rc, err := NewRefCounted("val", func() {})
-	if err != nil {
-		t.Fatalf("NewRefCounted() failed: %v", err)
-	}
+func (s) TestRefCounted_DecrementNegative(_ *testing.T) {
+	val := 666
+	rc := NewRefCounted(&val, func() {})
 	rc.Decrement()
 
 	grpctest.ExpectError("Refcount cannot be negative")
@@ -158,11 +132,9 @@ func (s) TestRefCounted_DecrementNegative(t *testing.T) {
 
 // Test verifies that Incrementing a dead resource results in a closed resource
 // log error.
-func (s) TestRefCounted_IncrementDead(t *testing.T) {
-	rc, err := NewRefCounted("val", func() {})
-	if err != nil {
-		t.Fatalf("NewRefCounted() failed: %v", err)
-	}
+func (s) TestRefCounted_IncrementDead(_ *testing.T) {
+	val := 666
+	rc := NewRefCounted(&val, func() {})
 	rc.Decrement()
 
 	grpctest.ExpectError("Resource already closed or dead")
@@ -173,7 +145,11 @@ func (s) TestRefCounted_IncrementDead(t *testing.T) {
 // callback is nil.
 func (s) TestNilOnZero(t *testing.T) {
 	const wantErr = "grpcsync: onZero callback cannot be nil"
-	if _, err := NewRefCounted("val", nil); err == nil || err.Error() != wantErr {
-		t.Fatalf("NewRefCounted(_, nil) returned error: %v, want: %q", err, wantErr)
-	}
+	defer func() {
+		if r := recover(); r == nil || r != wantErr {
+			t.Fatalf("NewRefCounted(_, nil) panic = %v, want: %q", r, wantErr)
+		}
+	}()
+	val := 666
+	NewRefCounted(&val, nil)
 }

--- a/internal/xds/balancer/clusterimpl/clusterimpl.go
+++ b/internal/xds/balancer/clusterimpl/clusterimpl.go
@@ -41,6 +41,7 @@ import (
 	"google.golang.org/grpc/internal/balancer/gracefulswitch"
 	"google.golang.org/grpc/internal/credentials/xds"
 	"google.golang.org/grpc/internal/grpclog"
+	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/pretty"
 	xdsinternal "google.golang.org/grpc/internal/xds"
 
@@ -82,7 +83,7 @@ func (bb) Build(cc balancer.ClientConn, bOpts balancer.BuildOptions) balancer.Ba
 		loadWrapper:     loadstore.NewWrapper(),
 		requestCountMax: defaultRequestCountMax,
 	}
-	b.xdsHIPtr.Store(xds.NewHandshakeInfo(nil, nil, nil, false, "", false, false))
+	b.xdsHIPtr.Store(xds.NewHandshakeInfo(nil, nil, nil, "", false, false, false))
 	b.logger = prefixLogger(b)
 	b.child = gracefulswitch.NewBalancer(b, bOpts)
 	b.logger.Infof("Created")
@@ -127,7 +128,7 @@ type clusterImplBalancer struct {
 	lrsServer        *bootstrap.ServerConfig // Load reporting server configuration.
 	dropCategories   []DropConfig            // The categories for drops.
 	child            *gracefulswitch.Balancer
-	xdsHIPtr         atomic.Pointer[xds.HandshakeInfo] // Accessed atomically as it is shared between the balancer and the transport.
+	xdsHIPtr         atomic.Pointer[grpcsync.RefCounted[xds.HandshakeInfo]] // Accessed atomically as it is shared between the balancer and the transport.
 	xdsCredsInUse    bool
 
 	// The active security configuration received from the control plane.
@@ -368,9 +369,9 @@ func (b *clusterImplBalancer) handleSecurityConfig(config *xdsresource.SecurityC
 	// handles this by delegating to its fallback credentials.
 	if config == nil {
 		b.securityConfig = nil
-		oldHI := b.xdsHIPtr.Swap(xds.NewHandshakeInfo(nil, nil, nil, false, "", false, false))
+		oldHI := b.xdsHIPtr.Swap(xds.NewHandshakeInfo(nil, nil, nil, "", false, false, false))
 		if oldHI != nil {
-			oldHI.Close()
+			oldHI.Decrement()
 		}
 		return nil
 	}
@@ -380,11 +381,11 @@ func (b *clusterImplBalancer) handleSecurityConfig(config *xdsresource.SecurityC
 		return err
 	}
 
-	newHI := xds.NewHandshakeInfo(rootProvider, identityProvider, config.SubjectAltNameMatchers, false, config.SNI, config.AutoSNISANValidation, config.UseAutoHostSNI)
+	newHI := xds.NewHandshakeInfo(rootProvider, identityProvider, config.SubjectAltNameMatchers, config.SNI, false, config.AutoSNISANValidation, config.UseAutoHostSNI)
 	b.securityConfig = config
 	oldHI := b.xdsHIPtr.Swap(newHI)
 	if oldHI != nil {
-		oldHI.Close()
+		oldHI.Decrement()
 	}
 	return nil
 }
@@ -516,7 +517,7 @@ func (b *clusterImplBalancer) Close() {
 	}
 	oldHI := b.xdsHIPtr.Swap(nil)
 	if oldHI != nil {
-		oldHI.Close()
+		oldHI.Decrement()
 	}
 	b.securityConfig = nil
 	b.logger.Infof("Shutdown")

--- a/internal/xds/balancer/clusterimpl/clusterimpl.go
+++ b/internal/xds/balancer/clusterimpl/clusterimpl.go
@@ -130,10 +130,8 @@ type clusterImplBalancer struct {
 	xdsHIPtr         atomic.Pointer[xds.HandshakeInfo] // Accessed atomically as it is shared between the balancer and the transport.
 	xdsCredsInUse    bool
 
-	// The certificate providers are cached here to that they can be closed when
-	// a new provider is to be created.
-	cachedRoot     certprovider.Provider
-	cachedIdentity certprovider.Provider
+	// The active security configuration received from the control plane.
+	securityConfig *xdsresource.SecurityConfig
 
 	// The following fields are protected by mu, since they are accessed in
 	// balancer API methods and in methods called from the child policy.
@@ -326,6 +324,33 @@ func buildProviderFunc(configs map[string]*certprovider.BuildableConfig, instanc
 	return provider, nil
 }
 
+func (b *clusterImplBalancer) buildProviders(config *xdsresource.SecurityConfig) (certprovider.Provider, certprovider.Provider, error) {
+	cpc := b.xdsClient.BootstrapConfig().CertProviderConfigs()
+	var rootProvider certprovider.Provider
+	if config.UseSystemRootCerts {
+		rootProvider = systemRootCertsProvider{}
+	} else {
+		rp, err := buildProvider(cpc, config.RootInstanceName, config.RootCertName, false, true)
+		if err != nil {
+			return nil, nil, err
+		}
+		rootProvider = rp
+	}
+
+	var identityProvider certprovider.Provider
+	if name, cert := config.IdentityInstanceName, config.IdentityCertName; name != "" {
+		ip, err := buildProvider(cpc, name, cert, true, false)
+		if err != nil {
+			if rootProvider != nil {
+				rootProvider.Close()
+			}
+			return nil, nil, err
+		}
+		identityProvider = ip
+	}
+	return rootProvider, identityProvider, nil
+}
+
 // handleSecurityConfig processes the security configuration received from the
 // management server, creates appropriate certificate provider plugins, and
 // updates the HandshakeInfo which is added as an address attribute in
@@ -334,7 +359,7 @@ func (b *clusterImplBalancer) handleSecurityConfig(config *xdsresource.SecurityC
 	// If xdsCredentials are not in use, i.e, the user did not want to get
 	// security configuration from an xDS server, we should not be acting on the
 	// received security config here. Doing so poses a security threat.
-	if !b.xdsCredsInUse {
+	if !b.xdsCredsInUse || config.Equal(b.securityConfig) {
 		return nil
 	}
 
@@ -342,48 +367,25 @@ func (b *clusterImplBalancer) handleSecurityConfig(config *xdsresource.SecurityC
 	// not sent any security configuration. The xdsCredentials implementation
 	// handles this by delegating to its fallback credentials.
 	if config == nil {
-		// We need to explicitly set the fields to nil here since this might be
-		// a case of switching from a good security configuration to an empty
-		// one where fallback credentials are to be used.
-		b.xdsHIPtr.Store(xds.NewHandshakeInfo(nil, nil, nil, false, "", false, false))
+		b.securityConfig = nil
+		oldHI := b.xdsHIPtr.Swap(xds.NewHandshakeInfo(nil, nil, nil, false, "", false, false))
+		if oldHI != nil {
+			oldHI.Close()
+		}
 		return nil
-
 	}
 
-	// A root provider is required whether we are using TLS or mTLS.
-	cpc := b.xdsClient.BootstrapConfig().CertProviderConfigs()
-	var rootProvider certprovider.Provider
-	if config.UseSystemRootCerts {
-		rootProvider = systemRootCertsProvider{}
-	} else {
-		rp, err := buildProvider(cpc, config.RootInstanceName, config.RootCertName, false, true)
-		if err != nil {
-			return err
-		}
-		rootProvider = rp
+	rootProvider, identityProvider, err := b.buildProviders(config)
+	if err != nil {
+		return err
 	}
 
-	// The identity provider is only present when using mTLS.
-	var identityProvider certprovider.Provider
-	if name, cert := config.IdentityInstanceName, config.IdentityCertName; name != "" {
-		var err error
-		identityProvider, err = buildProvider(cpc, name, cert, true, false)
-		if err != nil {
-			return err
-		}
+	newHI := xds.NewHandshakeInfo(rootProvider, identityProvider, config.SubjectAltNameMatchers, false, config.SNI, config.AutoSNISANValidation, config.UseAutoHostSNI)
+	b.securityConfig = config
+	oldHI := b.xdsHIPtr.Swap(newHI)
+	if oldHI != nil {
+		oldHI.Close()
 	}
-
-	// Close the old providers and cache the new ones.
-	if b.cachedRoot != nil {
-		b.cachedRoot.Close()
-	}
-	if b.cachedIdentity != nil {
-		b.cachedIdentity.Close()
-	}
-	b.cachedRoot = rootProvider
-	b.cachedIdentity = identityProvider
-
-	b.xdsHIPtr.Store(xds.NewHandshakeInfo(rootProvider, identityProvider, config.SubjectAltNameMatchers, false, config.SNI, config.AutoSNISANValidation, config.UseAutoHostSNI))
 	return nil
 }
 
@@ -512,12 +514,11 @@ func (b *clusterImplBalancer) Close() {
 		b.cancelLoadReport(stopCtx)
 		b.cancelLoadReport = nil
 	}
-	if b.cachedRoot != nil {
-		b.cachedRoot.Close()
+	oldHI := b.xdsHIPtr.Swap(nil)
+	if oldHI != nil {
+		oldHI.Close()
 	}
-	if b.cachedIdentity != nil {
-		b.cachedIdentity.Close()
-	}
+	b.securityConfig = nil
 	b.logger.Infof("Shutdown")
 }
 

--- a/internal/xds/server/conn_wrapper.go
+++ b/internal/xds/server/conn_wrapper.go
@@ -49,8 +49,8 @@ type connWrapper struct {
 	// A reference to the listenerWrapper on which this connection was accepted.
 	parent *listenerWrapper
 
-	// The certificate providers created for this connection.
-	rootProvider, identityProvider certprovider.Provider
+	// The HandshakeInfo created for this connection.
+	hi *xdsinternal.HandshakeInfo
 
 	// The connection deadline as configured by the grpc.Server on the rawConn
 	// that is returned by a call to Accept(). This is set to the connection
@@ -113,13 +113,13 @@ func (c *connWrapper) XDSHandshakeInfo() (*xdsinternal.HandshakeInfo, error) {
 	if instance, cert := secCfg.RootInstanceName, secCfg.RootCertName; instance != "" {
 		rp, err = buildProviderFunc(cpc, instance, cert, false, true)
 		if err != nil {
+			ip.Close()
 			return nil, err
 		}
 	}
-	c.identityProvider = ip
-	c.rootProvider = rp
 
-	return xdsinternal.NewHandshakeInfo(c.rootProvider, c.identityProvider, nil, secCfg.RequireClientCert, "", false, false), nil
+	c.hi = xdsinternal.NewHandshakeInfo(rp, ip, nil, secCfg.RequireClientCert, "", false, false)
+	return c.hi, nil
 }
 
 // PassServerTransport drains the passed in ServerTransport if draining is set,
@@ -148,11 +148,8 @@ func (c *connWrapper) Drain() {
 
 // Close closes the providers and the underlying connection.
 func (c *connWrapper) Close() error {
-	if c.identityProvider != nil {
-		c.identityProvider.Close()
-	}
-	if c.rootProvider != nil {
-		c.rootProvider.Close()
+	if c.hi != nil {
+		c.hi.Close()
 	}
 	c.parent.removeConn(c)
 	return c.Conn.Close()

--- a/internal/xds/server/conn_wrapper.go
+++ b/internal/xds/server/conn_wrapper.go
@@ -95,9 +95,9 @@ func (c *connWrapper) XDSHandshakeInfo() (*grpcsync.RefCounted[xds.HandshakeInfo
 	if c.filterChain.securityCfg == nil {
 		// If the security config is empty, this means that the control plane
 		// did not provide any security configuration and therefore we should
-		// return an empty HandshakeInfo here so that the xdsCreds can use the
-		// configured fallback credentials.
-		return xds.NewHandshakeInfo(nil, nil, nil, "", false, false, false), nil
+		// return nil here so that the xdsCreds can use the configured fallback
+		// credentials.
+		return nil, nil
 	}
 
 	cpc := c.parent.xdsC.BootstrapConfig().CertProviderConfigs()

--- a/internal/xds/server/conn_wrapper.go
+++ b/internal/xds/server/conn_wrapper.go
@@ -161,12 +161,12 @@ func (c *connWrapper) Close() error {
 		return nil
 	}
 	c.closed = true
-	if c.hi != nil {
-		if hi := c.hi.Value(); hi != nil {
-			c.hi.Decrement()
-		}
-	}
+	hi := c.hi
 	c.mu.Unlock()
+
+	if hi != nil {
+		hi.Decrement()
+	}
 
 	c.parent.removeConn(c)
 	return c.Conn.Close()

--- a/internal/xds/server/conn_wrapper.go
+++ b/internal/xds/server/conn_wrapper.go
@@ -125,6 +125,13 @@ func (c *connWrapper) XDSHandshakeInfo() (*grpcsync.RefCounted[xds.HandshakeInfo
 	// The reference count will be decremented when the connection is closed.
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.closed {
+		if rp != nil {
+			rp.Close()
+		}
+		ip.Close()
+		return nil, fmt.Errorf("xds: connection closed")
+	}
 	c.hi = xds.NewHandshakeInfo(rp, ip, nil, "", secCfg.RequireClientCert, false, false)
 	return c.hi, nil
 }

--- a/internal/xds/server/conn_wrapper.go
+++ b/internal/xds/server/conn_wrapper.go
@@ -26,7 +26,8 @@ import (
 	"time"
 
 	"google.golang.org/grpc/credentials/tls/certprovider"
-	xdsinternal "google.golang.org/grpc/internal/credentials/xds"
+	"google.golang.org/grpc/internal/credentials/xds"
+	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/transport"
 )
 
@@ -49,9 +50,6 @@ type connWrapper struct {
 	// A reference to the listenerWrapper on which this connection was accepted.
 	parent *listenerWrapper
 
-	// The HandshakeInfo created for this connection.
-	hi *xdsinternal.HandshakeInfo
-
 	// The connection deadline as configured by the grpc.Server on the rawConn
 	// that is returned by a call to Accept(). This is set to the connection
 	// timeout value configured by the user (or to a default value) before
@@ -63,6 +61,8 @@ type connWrapper struct {
 	mu       sync.Mutex
 	st       transport.ServerTransport
 	draining bool
+	closed   bool
+	hi       *grpcsync.RefCounted[xds.HandshakeInfo]
 
 	// The virtual hosts with matchable routes and instantiated HTTP Filters per
 	// route, or an error.
@@ -91,13 +91,13 @@ func (c *connWrapper) GetDeadline() time.Time {
 // XDSHandshakeInfo returns a HandshakeInfo with appropriate security
 // configuration for this connection. This method is invoked by the
 // ServerHandshake() method of the XdsCredentials.
-func (c *connWrapper) XDSHandshakeInfo() (*xdsinternal.HandshakeInfo, error) {
+func (c *connWrapper) XDSHandshakeInfo() (*grpcsync.RefCounted[xds.HandshakeInfo], error) {
 	if c.filterChain.securityCfg == nil {
 		// If the security config is empty, this means that the control plane
 		// did not provide any security configuration and therefore we should
 		// return an empty HandshakeInfo here so that the xdsCreds can use the
 		// configured fallback credentials.
-		return xdsinternal.NewHandshakeInfo(nil, nil, nil, false, "", false, false), nil
+		return xds.NewHandshakeInfo(nil, nil, nil, "", false, false, false), nil
 	}
 
 	cpc := c.parent.xdsC.BootstrapConfig().CertProviderConfigs()
@@ -118,7 +118,14 @@ func (c *connWrapper) XDSHandshakeInfo() (*xdsinternal.HandshakeInfo, error) {
 		}
 	}
 
-	c.hi = xdsinternal.NewHandshakeInfo(rp, ip, nil, secCfg.RequireClientCert, "", false, false)
+	// Note that this method is invoked when a connection is accepted, and the
+	// xdsCredentials are doing a handshake on it. This can only ever be called
+	// once per connection. So, we do not need to worry about decrementing the
+	// reference count for the existing HandshakeInfo, which will always be nil.
+	// The reference count will be decremented when the connection is closed.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.hi = xds.NewHandshakeInfo(rp, ip, nil, "", secCfg.RequireClientCert, false, false)
 	return c.hi, nil
 }
 
@@ -148,9 +155,19 @@ func (c *connWrapper) Drain() {
 
 // Close closes the providers and the underlying connection.
 func (c *connWrapper) Close() error {
-	if c.hi != nil {
-		c.hi.Close()
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
 	}
+	c.closed = true
+	if c.hi != nil {
+		if hi := c.hi.Value(); hi != nil {
+			c.hi.Decrement()
+		}
+	}
+	c.mu.Unlock()
+
 	c.parent.removeConn(c)
 	return c.Conn.Close()
 }


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-go/issues/9015

Root cause for the race:
- As part of handling configuration updates, the `clusterimpl` LB policy calls `Close` on its cached certificate providers. The `type` of these certificate providers, as returned by the provider store, is `singleCloseWrappedProvider`, which contains a pointer to a reference counted provider of type `wrappedProvider`.
- `singleCloseWrappedProvider.Close()` mutates the internal pointer to an instance of `closedProvider` that always returns an error when asked for key material.
- Any concurrent transport creation for a subchannel that had loaded the previous `HandshakeInfo` snapshot and was executing a call to `KeyMaterial` as part of `ClientHandshake` would end up calling `closedProvider.KeyMaterial`, causing the TLS handshake to fail with: `provider instance is closed`.
- While `HandshakeInfo` was accessed via an `atomic.Pointer` inside `clusterimpl` and across the load balancer and transport boundaries, the fact that `clusterimpl` was retaining mutable references to state inside the `HandshakeInfo` allowed it to mutate internal in a way that lead to data races.
  
Changes made here:
- `HandshakeInfo` now owns the lifetime of the provider instances within it.
  - It provides APIs to retrieve the `tls.Config` and internally tracks the number of active handshakes
  - The certificate providers are only closed after the `HandshakeInfo` is closed and all active handshakes have completed.
- `clusterimpl` keeps track of the most recent security configuration and suppresses creation of new certificate providers if the config does not change

RELEASE NOTES:
- xds: Fixed a bug that caused transient handshake failures when TLS handshakes and xDS Cluster updates happened concurrently.