### PR TITLE
xds/rbac: avoid nil deref on unset CidrRange prefix_len

### DIFF
--- a/internal/xds/rbac/matchers.go
+++ b/internal/xds/rbac/matchers.go
@@ -365,7 +365,7 @@ type remoteIPMatcher struct {
 func newRemoteIPMatcher(cidrRange *v3corepb.CidrRange) (*remoteIPMatcher, error) {
 	// Convert configuration to a cidrRangeString, as Go standard library has
 	// methods that parse cidr string.
-	cidrRangeString := fmt.Sprintf("%s/%d", cidrRange.AddressPrefix, cidrRange.PrefixLen.Value)
+	cidrRangeString := fmt.Sprintf("%s/%d", cidrRange.GetAddressPrefix(), cidrRange.GetPrefixLen().GetValue())
 	ipNet, err := netip.ParsePrefix(cidrRangeString)
 	if err != nil {
 		return nil, err
@@ -391,7 +391,7 @@ type localIPMatcher struct {
 }
 
 func newLocalIPMatcher(cidrRange *v3corepb.CidrRange) (*localIPMatcher, error) {
-	cidrRangeString := fmt.Sprintf("%s/%d", cidrRange.AddressPrefix, cidrRange.PrefixLen.Value)
+	cidrRangeString := fmt.Sprintf("%s/%d", cidrRange.GetAddressPrefix(), cidrRange.GetPrefixLen().GetValue())
 	ipNet, err := netip.ParsePrefix(cidrRangeString)
 	if err != nil {
 		return nil, err

--- a/internal/xds/rbac/rbac_engine_test.go
+++ b/internal/xds/rbac/rbac_engine_test.go
@@ -301,6 +301,42 @@ func (s) TestNewChainEngine(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "RemoteIpMatcherUnsetPrefixLen",
+			policies: []*v3rbacpb.RBAC{
+				{
+					Action: v3rbacpb.RBAC_ALLOW,
+					Policies: map[string]*v3rbacpb.Policy{
+						"certain-source-ip": {
+							Permissions: []*v3rbacpb.Permission{
+								{Rule: &v3rbacpb.Permission_Any{Any: true}},
+							},
+							Principals: []*v3rbacpb.Principal{
+								{Identifier: &v3rbacpb.Principal_DirectRemoteIp{DirectRemoteIp: &v3corepb.CidrRange{AddressPrefix: "0.0.0.0"}}},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "DestinationIpMatcherUnsetPrefixLen",
+			policies: []*v3rbacpb.RBAC{
+				{
+					Action: v3rbacpb.RBAC_ALLOW,
+					Policies: map[string]*v3rbacpb.Policy{
+						"certain-destination-ip": {
+							Permissions: []*v3rbacpb.Permission{
+								{Rule: &v3rbacpb.Permission_DestinationIp{DestinationIp: &v3corepb.CidrRange{AddressPrefix: "0.0.0.0"}}},
+							},
+							Principals: []*v3rbacpb.Principal{
+								{Identifier: &v3rbacpb.Principal_Any{Any: true}},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "MatcherToNotPolicy",
 			policies: []*v3rbacpb.RBAC{
 				{


### PR DESCRIPTION
`newRemoteIPMatcher` and `newLocalIPMatcher` build the CIDR string from `cidrRange.PrefixLen.Value`, dereferencing the `PrefixLen` wrapper field directly. An RBAC policy from the control plane whose `destination_ip`/`direct_remote_ip`/`source_ip`/`remote_ip` CidrRange sets `address_prefix` but leaves `prefix_len` unset makes `PrefixLen == nil`, so `NewChainEngine` panics while the resource is parsed. Nothing recovers on the xdsclient decode path, so the process goes down.

RELEASE NOTES:
- xds/rbac: Fix a potential panic when parsing a CIDR range that does not contain a prefix length.