### PR TITLE
server: fix client disconnect race when using compression

### DIFF
--- a/internal/transport/server_stream.go
+++ b/internal/transport/server_stream.go
@@ -30,6 +30,10 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// ErrSetSendCompressOnDoneStream indicates that the send compressor cannot be
+// changed because the stream has finished.
+var ErrSetSendCompressOnDoneStream = errors.New("transport: set send compressor called after stream done")
+
 // ServerStream implements streaming functionality for a gRPC server.
 type ServerStream struct {
 	Stream // Embed for common stream functionality.
@@ -110,8 +114,11 @@ func (s *ServerStream) ContentSubtype() string {
 
 // SetSendCompress sets the compression algorithm to the stream.
 func (s *ServerStream) SetSendCompress(name string) error {
-	if s.isHeaderSent() || s.getState() == streamDone {
-		return errors.New("transport: set send compressor called after headers sent or stream done")
+	if s.isHeaderSent() {
+		return errors.New("transport: set send compressor called after headers sent")
+	}
+	if s.getState() == streamDone {
+		return ErrSetSendCompressOnDoneStream
 	}
 
 	s.sendCompress = name

--- a/server.go
+++ b/server.go
@@ -1386,7 +1386,16 @@ func (s *Server) processUnaryRPC(ctx context.Context, stream *transport.ServerSt
 
 	if sendCompressorName != "" {
 		if err := stream.SetSendCompress(sendCompressorName); err != nil {
-			return status.Errorf(codes.Internal, "grpc: failed to set send compressor: %v", err)
+			// If conn closed, return DeadlineExceeded instead of Internal. This
+			// prevents a client disconnect race from reporting spurious internal errors.
+			if ctx.Err() != nil {
+				return status.FromContextError(ctx.Err()).Err()
+			}
+			return status.Errorf(
+				codes.Internal,
+				"grpc: failed to set send compressor: %v",
+				err,
+			)
 		}
 	}
 

--- a/server.go
+++ b/server.go
@@ -1386,16 +1386,10 @@ func (s *Server) processUnaryRPC(ctx context.Context, stream *transport.ServerSt
 
 	if sendCompressorName != "" {
 		if err := stream.SetSendCompress(sendCompressorName); err != nil {
-			// If conn closed, return DeadlineExceeded instead of Internal. This
-			// prevents a client disconnect race from reporting spurious internal errors.
-			if ctx.Err() != nil {
+			if errors.Is(err, transport.ErrSetSendCompressOnDoneStream) && ctx.Err() != nil {
 				return status.FromContextError(ctx.Err()).Err()
 			}
-			return status.Errorf(
-				codes.Internal,
-				"grpc: failed to set send compressor: %v",
-				err,
-			)
+			return status.Errorf(codes.Internal, "grpc: failed to set send compressor: %v", err)
 		}
 	}
 
@@ -1720,6 +1714,9 @@ func (s *Server) processStreamingRPC(ctx context.Context, stream *transport.Serv
 
 	if ss.sendCompressorName != "" {
 		if err := stream.SetSendCompress(ss.sendCompressorName); err != nil {
+			if errors.Is(err, transport.ErrSetSendCompressOnDoneStream) && ctx.Err() != nil {
+				return status.FromContextError(ctx.Err()).Err()
+			}
 			return status.Errorf(codes.Internal, "grpc: failed to set send compressor: %v", err)
 		}
 	}

--- a/test/compressor_test.go
+++ b/test/compressor_test.go
@@ -433,7 +433,7 @@ func (s) TestUnarySetSendCompressorAfterHeaderSendFailure(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
-	wantErr := status.Error(codes.Unknown, "transport: set send compressor called after headers sent or stream done")
+	wantErr := status.Error(codes.Unknown, "transport: set send compressor called after headers sent")
 	if _, err := ss.Client.EmptyCall(ctx, &testpb.Empty{}); !equalError(err, wantErr) {
 		t.Fatalf("Unexpected unary call error, got: %v, want: %v", err, wantErr)
 	}
@@ -459,7 +459,7 @@ func (s) TestStreamSetSendCompressorAfterHeaderSendFailure(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
-	wantErr := status.Error(codes.Unknown, "transport: set send compressor called after headers sent or stream done")
+	wantErr := status.Error(codes.Unknown, "transport: set send compressor called after headers sent")
 	s, err := ss.Client.FullDuplexCall(ctx)
 	if err != nil {
 		t.Fatalf("Unexpected full duplex call error, got: %v, want: nil", err)

--- a/test/context_canceled_test.go
+++ b/test/context_canceled_test.go
@@ -28,11 +28,47 @@ import (
 	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/internal/stubserver"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 
 	testgrpc "google.golang.org/grpc/interop/grpc_testing"
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
+
+type cancelBeforeHandlerStatsHandler struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+	err    error
+	method string
+}
+
+func (h *cancelBeforeHandlerStatsHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+	return ctx
+}
+
+func (h *cancelBeforeHandlerStatsHandler) HandleRPC(ctx context.Context, stat stats.RPCStats) {
+	switch stat := stat.(type) {
+	case *stats.InHeader:
+		if stat.FullMethod != h.method {
+			return
+		}
+		h.cancel()
+		<-ctx.Done()
+		// Stream cancellation marks the stream done immediately after canceling
+		// the context. Wait for that state transition before allowing request
+		// processing to continue.
+		time.Sleep(10 * time.Millisecond)
+	case *stats.End:
+		h.err = stat.Error
+		close(h.done)
+	}
+}
+
+func (*cancelBeforeHandlerStatsHandler) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+func (*cancelBeforeHandlerStatsHandler) HandleConn(context.Context, stats.ConnStats) {}
 
 func (s) TestContextCanceled(t *testing.T) {
 	ss := &stubserver.StubServer{
@@ -160,5 +196,80 @@ func (s) TestCancelWhileRecvingWithCompression(t *testing.T) {
 	}
 	if err := ss.CC.Close(); err != nil {
 		t.Fatalf("Close failed with %v, want nil", err)
+	}
+}
+
+func (s) TestCancelBeforeHandlerWithCompression(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		method    string
+		streaming bool
+	}{
+		{
+			name:   "unary",
+			method: testgrpc.TestService_UnaryCall_FullMethodName,
+		},
+		{
+			name:      "streaming",
+			method:    testgrpc.TestService_FullDuplexCall_FullMethodName,
+			streaming: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			testCtx, testCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+			defer testCancel()
+			callCtx, callCancel := context.WithCancel(testCtx)
+			defer callCancel()
+
+			statsHandler := &cancelBeforeHandlerStatsHandler{
+				cancel: callCancel,
+				done:   make(chan struct{}),
+				method: test.method,
+			}
+			handlerCalled := false
+			ss := &stubserver.StubServer{
+				UnaryCallF: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+					handlerCalled = true
+					return &testpb.SimpleResponse{}, nil
+				},
+				FullDuplexCallF: func(testgrpc.TestService_FullDuplexCallServer) error {
+					handlerCalled = true
+					return nil
+				},
+			}
+			if err := ss.Start([]grpc.ServerOption{grpc.StatsHandler(statsHandler)}); err != nil {
+				t.Fatalf("Error starting endpoint server: %v", err)
+			}
+			defer ss.Stop()
+
+			var err error
+			if test.streaming {
+				stream, streamErr := ss.Client.FullDuplexCall(callCtx, grpc.UseCompressor(gzip.Name))
+				if streamErr == nil {
+					_, streamErr = stream.Recv()
+				}
+				err = streamErr
+			} else {
+				_, err = ss.Client.UnaryCall(callCtx, &testpb.SimpleRequest{
+					Payload: &testpb.Payload{Body: []byte("payload")},
+				}, grpc.UseCompressor(gzip.Name))
+			}
+			if got, want := status.Code(err), codes.Canceled; got != want {
+				t.Fatalf("RPC returned code %v, want %v", got, want)
+			}
+
+			select {
+			case <-statsHandler.done:
+				if got, want := status.Code(statsHandler.err), codes.Canceled; got != want {
+					t.Fatalf("stats.End error code = %v, want %v; error: %v", got, want, statsHandler.err)
+				}
+			case <-testCtx.Done():
+				t.Fatal("Timeout waiting for server stats.End")
+			}
+
+			if handlerCalled {
+				t.Error("RPC handler unexpectedly called")
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes a bug where a client disconnects prior to decoding, causing the server to attempt to SetCompress on a done context. 

This isn't a client facing issue because they disconnect / cancel and don't see the errors. But server metrics report transient Internal errors when clients act poorly. This was problematic because this behavior is client controlled and occurs before handler/middleware is invoked. 

RELEASE NOTES: fixed a bug where clients using compression could cause spurious internal errors on the server during disconnect