### PR TITLE
randomsubsetting: ignore endpoints without addresses

### DIFF
--- a/balancer/randomsubsetting/randomsubsetting.go
+++ b/balancer/randomsubsetting/randomsubsetting.go
@@ -151,6 +151,15 @@ func (b *subsettingBalancer) calculateSubset(endpoints []resolver.Endpoint) []re
 		ep   resolver.Endpoint
 	}
 
+	// Empty endpoints cannot be hashed and are ignored by child policies.
+	// Remove them here so they do not count toward the requested subset size.
+	isEmpty := func(endpoint resolver.Endpoint) bool {
+		return len(endpoint.Addresses) == 0
+	}
+	if slices.ContainsFunc(endpoints, isEmpty) {
+		endpoints = slices.DeleteFunc(slices.Clone(endpoints), isEmpty)
+	}
+
 	subsetSize := b.cfg.SubsetSize
 	if len(endpoints) <= int(subsetSize) {
 		return endpoints

--- a/balancer/randomsubsetting/randomsubsetting_test.go
+++ b/balancer/randomsubsetting/randomsubsetting_test.go
@@ -167,6 +167,26 @@ func (s) TestCalculateSubset_Simple(t *testing.T) {
 	}
 }
 
+func (s) TestCalculateSubset_IgnoresEndpointsWithoutAddresses(t *testing.T) {
+	emptyEndpoint := resolver.Endpoint{Addresses: []resolver.Address{}}
+	endpoints := append([]resolver.Endpoint{emptyEndpoint}, makeEndpoints(3)...)
+	b := &subsettingBalancer{
+		cfg:        &lbConfig{SubsetSize: 2},
+		hashSeed:   0,
+		hashDigest: xxhash.New(),
+	}
+
+	got := b.calculateSubset(endpoints)
+	if len(got) != 2 {
+		t.Fatalf("calculateSubset() returned %d endpoints, want 2", len(got))
+	}
+	for _, endpoint := range got {
+		if len(endpoint.Addresses) == 0 {
+			t.Errorf("calculateSubset() returned an endpoint without addresses")
+		}
+	}
+}
+
 func (s) TestCalculateSubset_EndpointsRetainHashValues(t *testing.T) {
 	endpoints := makeEndpoints(10)
 	const subsetSize = 5


### PR DESCRIPTION
## Summary

The `random_subsetting` LB policy can receive a resolver update containing a mix of endpoints with and without addresses. This is valid resolver output as long as at least one endpoint has an address.

The policy currently assumes every endpoint has at least one address and reads `Addresses[0]` while hashing. If the update contains more endpoints than the configured subset size, an endpoint without an address can therefore trigger a panic.

## Fix

- Ignore endpoints that do not contain any addresses.
- Filter them before comparing the endpoint count with `subsetSize` and before hashing.
- Filter a cloned slice so the resolver-owned endpoint list is not modified.

RELEASE NOTES:
- randomsubsetting: Prevent a panic when resolver updates include endpoints without addresses.