### PR TITLE
resolver: log resolver state updates at verbosity 2

### DIFF
--- a/resolver_wrapper.go
+++ b/resolver_wrapper.go
@@ -188,7 +188,7 @@ func (ccr *ccResolverWrapper) ParseServiceConfig(scJSON string) *serviceconfig.P
 // addChannelzTraceEvent adds a channelz trace event containing the new
 // state received from resolver implementations.
 func (ccr *ccResolverWrapper) addChannelzTraceEvent(s resolver.State) {
-	if !logger.V(0) && !channelz.IsOn() {
+	if !logger.V(2) && !channelz.IsOn() {
 		return
 	}
 	var updates []string


### PR DESCRIPTION
Fixes #9210

addChannelzTraceEvent logs the full resolver.State (via pretty.ToJSON) on every UpdateState/NewAddress. The #7437 guard `!logger.V(0) && !channelz.IsOn()` does not fire at the default verbosity (logger.V(0) is true), so with channelz off the whole state is marshalled on every update only to be discarded by the default ERROR-level logger. See #9210 for benchmarks and analysis.

V(2) is the verbosity used for detailed logs throughout the tree (this was the only V(0) gate). channelz, when enabled, still records the event.

Behavior change: at the default verbosity the "Resolver state updated" message no longer logs; it now requires -v 2.

RELEASE NOTES:
* resolver: only log resolver state updates at verbosity 2 or higher, avoiding a full marshal of the resolver state on every update when channelz is off and verbose logging is disabled