### PR TITLE
opentelemetry: initialize attemptInfo with fields set 

### DIFF
--- a/stats/opentelemetry/client_metrics.go
+++ b/stats/opentelemetry/client_metrics.go
@@ -160,27 +160,14 @@ func (h *clientMetricsHandler) HandleConn(context.Context, stats.ConnStats) {}
 
 // TagRPC implements per RPC attempt context management for metrics.
 func (h *clientMetricsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
-	ctx, ri := getOrCreateClientRPCInfo(ctx)
+	ctx, ri := getOrCreateClientRPCInfo(ctx, info)
 	ai := ri.ai
-	if ai.xdsLabels == nil {
-		ai.xdsLabels = map[string]string{
-			// The defaults for all the per call labels from a plugin that
-			// executes on the callpath that this OpenTelemetry component
-			// currently supports.
-			"grpc.lb.locality":        "",
-			"grpc.lb.backend_service": "",
-		}
-	}
-
 	// Numerous stats handlers can be used for the same channel. This callback
 	// ensures that all label updates are propagated to the rpc attempt info across
 	// derived contexts.
 	ctx = istats.RegisterTelemetryLabelCallback(ctx, func(labels map[string]string) {
 		maps.Copy(ai.xdsLabels, labels)
 	})
-
-	ai.startTime = time.Now()
-	ai.method = removeLeadingSlash(info.FullMethodName)
 
 	return ctx
 }

--- a/stats/opentelemetry/client_metrics.go
+++ b/stats/opentelemetry/client_metrics.go
@@ -161,12 +161,11 @@ func (h *clientMetricsHandler) HandleConn(context.Context, stats.ConnStats) {}
 // TagRPC implements per RPC attempt context management for metrics.
 func (h *clientMetricsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
 	ctx, ri := getOrCreateClientRPCInfo(ctx, info)
-	ai := ri.ai
 	// Numerous stats handlers can be used for the same channel. This callback
 	// ensures that all label updates are propagated to the rpc attempt info across
 	// derived contexts.
 	ctx = istats.RegisterTelemetryLabelCallback(ctx, func(labels map[string]string) {
-		maps.Copy(ai.xdsLabels, labels)
+		maps.Copy(ri.ai.xdsLabels, labels)
 	})
 
 	return ctx

--- a/stats/opentelemetry/client_tracing.go
+++ b/stats/opentelemetry/client_tracing.go
@@ -124,7 +124,7 @@ func (h *clientTracingHandler) HandleConn(context.Context, stats.ConnStats) {}
 
 // TagRPC implements per RPC attempt context management for traces.
 func (h *clientTracingHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
-	ctx, ri := getOrCreateClientRPCInfo(ctx)
+	ctx, ri := getOrCreateClientRPCInfo(ctx, info)
 	ci := getCallInfo(ctx)
 	if ci == nil {
 		logger.Error("context passed into client side stats handler (TagRPC) has no call info")

--- a/stats/opentelemetry/e2e_test.go
+++ b/stats/opentelemetry/e2e_test.go
@@ -991,6 +991,85 @@ func (s) TestMetricsAndTracesOptionEnabled(t *testing.T) {
 	validateTraces(t, spans, wantSpanInfos)
 }
 
+// TestTracingOnlyOptionEnabled verifies that tracing works correctly when only
+// tracing is enabled (metrics are disabled). It ensures that the method name
+// is correctly populated in both client and server spans.
+func (s) TestTracingOnlyOptionEnabled(t *testing.T) {
+	opts, exporter := defaultTraceOptions(t)
+
+	ss := setupStubServer(t, nil, opts)
+	defer ss.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	if _, err := ss.Client.UnaryCall(ctx, &testpb.SimpleRequest{Payload: &testpb.Payload{
+		Body: make([]byte, 100),
+	}}); err != nil {
+		t.Fatalf("Unexpected error from UnaryCall: %v", err)
+	}
+
+	wantSpanInfos := []traceSpanInfo{
+		{
+			name:     "Recv.grpc.testing.TestService.UnaryCall",
+			spanKind: oteltrace.SpanKindServer.String(),
+			status:   otelcodes.Ok,
+			events: []trace.Event{
+				{
+					Name: "Inbound message",
+					Attributes: []attribute.KeyValue{
+						{Key: "sequence-number", Value: attribute.IntValue(0)},
+						{Key: "message-size", Value: attribute.IntValue(104)},
+					},
+				},
+				{
+					Name: "Outbound message",
+					Attributes: []attribute.KeyValue{
+						{Key: "sequence-number", Value: attribute.IntValue(0)},
+						{Key: "message-size", Value: attribute.IntValue(104)},
+					},
+				},
+			},
+		},
+		{
+			name:     "Attempt.grpc.testing.TestService.UnaryCall",
+			spanKind: oteltrace.SpanKindInternal.String(),
+			status:   otelcodes.Ok,
+			attributes: []attribute.KeyValue{
+				{Key: "previous-rpc-attempts", Value: attribute.IntValue(0)},
+				{Key: "transparent-retry", Value: attribute.BoolValue(false)},
+			},
+			events: []trace.Event{
+				{
+					Name: "Outbound message",
+					Attributes: []attribute.KeyValue{
+						{Key: "sequence-number", Value: attribute.IntValue(0)},
+						{Key: "message-size", Value: attribute.IntValue(104)},
+					},
+				},
+				{
+					Name: "Inbound message",
+					Attributes: []attribute.KeyValue{
+						{Key: "sequence-number", Value: attribute.IntValue(0)},
+						{Key: "message-size", Value: attribute.IntValue(104)},
+					},
+				},
+			},
+		},
+		{
+			name:     "Sent.grpc.testing.TestService.UnaryCall",
+			spanKind: oteltrace.SpanKindClient.String(),
+			status:   otelcodes.Ok,
+		},
+	}
+
+	spans, err := waitForTraceSpans(ctx, exporter, wantSpanInfos)
+	if err != nil {
+		t.Fatal(err)
+	}
+	validateTraces(t, spans, wantSpanInfos)
+}
+
 // TestSpan verifies that the gRPC Trace Binary propagator correctly
 // propagates span context between a client and server using the grpc-
 // trace-bin header. It sets up a stub server with OpenTelemetry tracing
@@ -2444,7 +2523,7 @@ func (s) TestRelayContextCollisionTracing(t *testing.T) {
 	_, _ = relayServer.Client.UnaryCall(ctx, &testpb.SimpleRequest{})
 
 	wantSpans := []traceSpanInfo{
-		{name: "Recv.", spanKind: "server"},
+		{name: "Recv.grpc.testing.TestService.UnaryCall", spanKind: "server"},
 		{name: "Sent.grpc.testing.TestService.EmptyCall", spanKind: "client"},
 	}
 	spans, err := waitForTraceSpans(ctx, relayTraceExporter, wantSpans)
@@ -2454,7 +2533,7 @@ func (s) TestRelayContextCollisionTracing(t *testing.T) {
 
 	var srvTraceID, cliTraceID oteltrace.TraceID
 	for _, span := range spans {
-		if span.Name == "Recv." && span.SpanKind == oteltrace.SpanKindServer {
+		if span.Name == "Recv.grpc.testing.TestService.UnaryCall" && span.SpanKind == oteltrace.SpanKindServer {
 			srvTraceID = span.SpanContext.TraceID()
 		}
 		if span.Name == "Sent.grpc.testing.TestService.EmptyCall" && span.SpanKind == oteltrace.SpanKindClient {

--- a/stats/opentelemetry/opentelemetry.go
+++ b/stats/opentelemetry/opentelemetry.go
@@ -216,21 +216,55 @@ func serverRPCInfo(ctx context.Context) *rpcInfo {
 	return ri
 }
 
-func getOrCreateClientRPCInfo(ctx context.Context) (context.Context, *rpcInfo) {
+func getOrCreateClientRPCInfo(ctx context.Context, info *stats.RPCTagInfo) (context.Context, *rpcInfo) {
 	ri := clientRPCInfo(ctx)
 	if ri != nil {
 		return ctx, ri
 	}
-	ri = &rpcInfo{ai: &attemptInfo{}}
+	ri = &rpcInfo{
+		ai: &attemptInfo{
+			startTime: time.Now(),
+			method:    removeLeadingSlash(info.FullMethodName),
+			xdsLabels: map[string]string{
+				// The defaults for all the per call labels from a plugin that
+				// executes on the callpath that this OpenTelemetry component
+				// currently supports.
+				"grpc.lb.locality":        "",
+				"grpc.lb.backend_service": "",
+			},
+		},
+	}
 	return context.WithValue(ctx, clientRPCInfoKey{}, ri), ri
 }
 
-func getOrCreateServerRPCInfo(ctx context.Context) (context.Context, *rpcInfo) {
+func getOrCreateServerRPCInfo(ctx context.Context, info *stats.RPCTagInfo, options MetricsOptions) (context.Context, *rpcInfo) {
 	ri := serverRPCInfo(ctx)
 	if ri != nil {
 		return ctx, ri
 	}
-	ri = &rpcInfo{ai: &attemptInfo{}}
+	method := info.FullMethodName
+	if options.MethodAttributeFilter != nil {
+		if !options.MethodAttributeFilter(method) {
+			method = "other"
+		}
+	}
+	server := internal.ServerFromContext.(func(context.Context) *grpc.Server)(ctx)
+	if server == nil { // Shouldn't happen, defensive programming.
+		logger.Error("ctx passed into server side stats handler has no grpc server ref")
+		method = "other"
+	} else {
+		isRegisteredMethod := internal.IsRegisteredMethod.(func(*grpc.Server, string) bool)
+		if !isRegisteredMethod(server, method) {
+			method = "other"
+		}
+	}
+
+	ri = &rpcInfo{
+		ai: &attemptInfo{
+			startTime: time.Now(),
+			method:    removeLeadingSlash(method),
+		},
+	}
 	return context.WithValue(ctx, serverRPCInfoKey{}, ri), ri
 }
 

--- a/stats/opentelemetry/server_metrics.go
+++ b/stats/opentelemetry/server_metrics.go
@@ -26,7 +26,6 @@ import (
 
 	"google.golang.org/grpc"
 	estats "google.golang.org/grpc/experimental/stats"
-	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
@@ -180,27 +179,7 @@ func (h *serverMetricsHandler) HandleConn(context.Context, stats.ConnStats) {}
 
 // TagRPC implements per RPC context management for metrics.
 func (h *serverMetricsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
-	method := info.FullMethodName
-	if h.options.MetricsOptions.MethodAttributeFilter != nil {
-		if !h.options.MetricsOptions.MethodAttributeFilter(method) {
-			method = "other"
-		}
-	}
-	server := internal.ServerFromContext.(func(context.Context) *grpc.Server)(ctx)
-	if server == nil { // Shouldn't happen, defensive programming.
-		logger.Error("ctx passed into server side stats handler has no grpc server ref")
-		method = "other"
-	} else {
-		isRegisteredMethod := internal.IsRegisteredMethod.(func(*grpc.Server, string) bool)
-		if !isRegisteredMethod(server, method) {
-			method = "other"
-		}
-	}
-	ctx, ri := getOrCreateServerRPCInfo(ctx)
-	ai := ri.ai
-	ai.startTime = time.Now()
-	ai.method = removeLeadingSlash(method)
-
+	ctx, _ = getOrCreateServerRPCInfo(ctx, info, h.options.MetricsOptions)
 	return ctx
 }
 

--- a/stats/opentelemetry/server_tracing.go
+++ b/stats/opentelemetry/server_tracing.go
@@ -39,8 +39,8 @@ func (h *serverTracingHandler) initializeTraces() {
 }
 
 // TagRPC implements per RPC attempt context management for traces.
-func (h *serverTracingHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
-	ctx, ri := getOrCreateServerRPCInfo(ctx)
+func (h *serverTracingHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
+	ctx, ri := getOrCreateServerRPCInfo(ctx, info, h.options.MetricsOptions)
 	ctx, _ = h.traceTagRPC(ctx, ri.ai)
 	return ctx
 }


### PR DESCRIPTION
Fixes: #9097

Previously, if only tracing was enabled, the server-side span name would not be correctly populated (falling back to "Recv.") because the method name population logic was only present in the metrics handler's TagRPC method.

This change fixes this by:
* Moving the common client RPC info initialization (including start time and method name) to `getOrCreateClientRPCInfo`.
* Moving the common server RPC info initialization (including start time, method name, and method filtering/validation logic) to `getOrCreateServerRPCInfo`.
* Updating both client and server metrics and tracing handlers to use these shared helper functions. This ensures that
  the RPC info is correctly initialized by whichever handler executes first.

RELEASE NOTES:
* opentelemetry: ensure method names are correctly set in trace spans when metrics are disabled.