### PR TITLE
credentials/alts: support max frame size negotiation via env var

### DIFF
--- a/credentials/alts/internal/conn/record.go
+++ b/credentials/alts/internal/conn/record.go
@@ -135,7 +135,13 @@ type conn struct {
 
 // NewConn creates a new secure channel instance given the other party role and
 // handshaking result.
-func NewConn(c net.Conn, side core.Side, recordProtocol string, key []byte, protected []byte, negotiatedMaxFrameSize int) (net.Conn, error) {
+func NewConn(c net.Conn, side core.Side, recordProtocol string, key []byte, protected []byte) (net.Conn, error) {
+	return NewConnWithMaxFrameSize(c, side, recordProtocol, key, protected, 0)
+}
+
+// NewConnWithMaxFrameSize creates a new secure channel instance given the
+// other party role, handshaking result, and negotiated maximum frame size.
+func NewConnWithMaxFrameSize(c net.Conn, side core.Side, recordProtocol string, key []byte, protected []byte, negotiatedMaxFrameSize int) (net.Conn, error) {
 	newCrypto := protocols[recordProtocol]
 	if newCrypto == nil {
 		return nil, fmt.Errorf("negotiated unknown next_protocol %q", recordProtocol)

--- a/credentials/alts/internal/conn/record.go
+++ b/credentials/alts/internal/conn/record.go
@@ -62,11 +62,10 @@ const (
 	// The bytes size limit for a ALTS record message.
 	altsRecordLengthLimit = 1024 * 1024 // 1 MiB
 	// The default bytes size of a ALTS record message.
-	altsRecordDefaultLength = 64 * 1024 // 64KiB
+	altsRecordDefaultLength = 4 * 1024 // 4KiB
 	// Message type value included in ALTS record framing.
 	altsRecordMsgType = uint32(0x06)
-	// The maximum write buffer size. This *must* be multiple of
-	// altsRecordDefaultLength.
+	// The maximum write buffer size, which can hold multiple ALTS frames.
 	altsWriteBufferMaxSize = 512 * 1024 // 512KiB
 	// The initial buffer used to read from the network.
 	// It includes an additional 512 Bytes to hold two 16KiB records plus
@@ -136,7 +135,7 @@ type conn struct {
 
 // NewConn creates a new secure channel instance given the other party role and
 // handshaking result.
-func NewConn(c net.Conn, side core.Side, recordProtocol string, key []byte, protected []byte, peerMaxFrameSize int) (net.Conn, error) {
+func NewConn(c net.Conn, side core.Side, recordProtocol string, key []byte, protected []byte, negotiatedMaxFrameSize int) (net.Conn, error) {
 	newCrypto := protocols[recordProtocol]
 	if newCrypto == nil {
 		return nil, fmt.Errorf("negotiated unknown next_protocol %q", recordProtocol)
@@ -147,19 +146,8 @@ func NewConn(c net.Conn, side core.Side, recordProtocol string, key []byte, prot
 	}
 	overhead := MsgLenFieldSize + msgTypeFieldSize + crypto.EncryptionOverhead()
 
-	// peerMaxFrameSize is the max_frame_size the peer advertised in the
-	// handshake result, or 0 if it did not advertise one. If it's smaller
-	// than altsRecordDefaultLength, honor it so that this side never writes
-	// frames larger than the peer said it can accept.
-	maxRecordLen := altsRecordDefaultLength
-	if peerMaxFrameSize > 0 {
-		if peerMaxFrameSize <= overhead {
-			return nil, fmt.Errorf("invalid peer max_frame_size %d: must be greater than frame overhead %d", peerMaxFrameSize, overhead)
-		}
-		if peerMaxFrameSize < maxRecordLen {
-			maxRecordLen = peerMaxFrameSize
-		}
-	}
+	// Clamp maxRecordLen to be at least altsRecordDefaultLength.
+	maxRecordLen := max(altsRecordDefaultLength, negotiatedMaxFrameSize)
 	payloadLengthLimit := maxRecordLen - overhead
 	// We pre-allocate protected to be of size 32KB during initialization.
 	// We increase the size of the buffer by the required amount if it can't

--- a/credentials/alts/internal/conn/record.go
+++ b/credentials/alts/internal/conn/record.go
@@ -62,7 +62,7 @@ const (
 	// The bytes size limit for a ALTS record message.
 	altsRecordLengthLimit = 1024 * 1024 // 1 MiB
 	// The default bytes size of a ALTS record message.
-	altsRecordDefaultLength = 4 * 1024 // 4KiB
+	altsRecordDefaultLength = 64 * 1024 // 64KiB
 	// Message type value included in ALTS record framing.
 	altsRecordMsgType = uint32(0x06)
 	// The maximum write buffer size. This *must* be multiple of
@@ -136,7 +136,7 @@ type conn struct {
 
 // NewConn creates a new secure channel instance given the other party role and
 // handshaking result.
-func NewConn(c net.Conn, side core.Side, recordProtocol string, key []byte, protected []byte) (net.Conn, error) {
+func NewConn(c net.Conn, side core.Side, recordProtocol string, key []byte, protected []byte, peerMaxFrameSize int) (net.Conn, error) {
 	newCrypto := protocols[recordProtocol]
 	if newCrypto == nil {
 		return nil, fmt.Errorf("negotiated unknown next_protocol %q", recordProtocol)
@@ -146,7 +146,21 @@ func NewConn(c net.Conn, side core.Side, recordProtocol string, key []byte, prot
 		return nil, fmt.Errorf("protocol %q: %v", recordProtocol, err)
 	}
 	overhead := MsgLenFieldSize + msgTypeFieldSize + crypto.EncryptionOverhead()
-	payloadLengthLimit := altsRecordDefaultLength - overhead
+
+	// peerMaxFrameSize is the max_frame_size the peer advertised in the
+	// handshake result, or 0 if it did not advertise one. If it's smaller
+	// than altsRecordDefaultLength, honor it so that this side never writes
+	// frames larger than the peer said it can accept.
+	maxRecordLen := altsRecordDefaultLength
+	if peerMaxFrameSize > 0 {
+		if peerMaxFrameSize <= overhead {
+			return nil, fmt.Errorf("invalid peer max_frame_size %d: must be greater than frame overhead %d", peerMaxFrameSize, overhead)
+		}
+		if peerMaxFrameSize < maxRecordLen {
+			maxRecordLen = peerMaxFrameSize
+		}
+	}
+	payloadLengthLimit := maxRecordLen - overhead
 	// We pre-allocate protected to be of size 32KB during initialization.
 	// We increase the size of the buffer by the required amount if it can't
 	// hold a complete encrypted record.
@@ -321,7 +335,8 @@ func (p *conn) Write(b []byte) (n int, err error) {
 	partialBSize := len(b)
 	if size > altsWriteBufferMaxSize {
 		size = altsWriteBufferMaxSize
-		const numOfFramesInMaxWriteBuf = altsWriteBufferMaxSize / altsRecordDefaultLength
+		frameLen := p.payloadLengthLimit + p.overhead
+		numOfFramesInMaxWriteBuf := altsWriteBufferMaxSize / frameLen
 		partialBSize = numOfFramesInMaxWriteBuf * p.payloadLengthLimit
 	}
 	// Get a writeBuf of the required length.
@@ -363,7 +378,7 @@ func (p *conn) Write(b []byte) (n int, err error) {
 			// written. This means we need to remove header,
 			// encryption overheads, and any partially-written
 			// frame data.
-			numOfWrittenFrames := int(math.Floor(float64(nn) / float64(altsRecordDefaultLength)))
+			numOfWrittenFrames := int(math.Floor(float64(nn) / float64(p.payloadLengthLimit+p.overhead)))
 			return partialBStart + numOfWrittenFrames*p.payloadLengthLimit, err
 		}
 	}

--- a/credentials/alts/internal/conn/record_test.go
+++ b/credentials/alts/internal/conn/record_test.go
@@ -459,29 +459,26 @@ func countALTSFrames(data []byte) int {
 	return count
 }
 
-func (s) TestNewConnPeerMaxFrameSize(t *testing.T) {
+func (s) TestNewConnNegotiatedMaxFrameSize(t *testing.T) {
 	key := make([]byte, 32)
+
 	for _, tc := range []struct {
-		name             string
-		peerMaxFrameSize int
-		wantMaxRecordLen int
-		wantErr          bool
+		name                   string
+		negotiatedMaxFrameSize int
+		wantMaxRecordLen       int
 	}{
-		{"not advertised", 0, altsRecordDefaultLength, false},
-		{"larger than our default", altsRecordDefaultLength + 1024, altsRecordDefaultLength, false},
-		{"equal to our default", altsRecordDefaultLength, altsRecordDefaultLength, false},
-		{"smaller than our default", 16 * 1024, 16 * 1024, false},
-		{"invalid smaller than overhead", 10, 0, true},
-		{"invalid equal to overhead", 24, 0, true},
+		{"not negotiated (0)", 0, altsRecordDefaultLength},
+		{"smaller than default (10)", 10, altsRecordDefaultLength},
+		{"smaller than default (1024)", 1024, altsRecordDefaultLength},
+		{"negotiated 4KB", 4 * 1024, 4 * 1024},
+		{"negotiated 16KB", 16 * 1024, 16 * 1024},
+		{"negotiated 64KB", 64 * 1024, 64 * 1024},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			tcConn := testConn{}
-			c, err := NewConn(&tcConn, core.ClientSide, rekeyRecordProtocol, key, nil, tc.peerMaxFrameSize)
-			if (err != nil) != tc.wantErr {
-				t.Fatalf("NewConn() err = %v, wantErr %v", err, tc.wantErr)
-			}
-			if tc.wantErr {
-				return
+			c, err := NewConn(&tcConn, core.ClientSide, rekeyRecordProtocol, key, nil, tc.negotiatedMaxFrameSize)
+			if err != nil {
+				t.Fatalf("NewConn() err = %v, want nil", err)
 			}
 			altsC := c.(*conn)
 			wantPayloadLimit := tc.wantMaxRecordLen - altsC.overhead
@@ -492,22 +489,21 @@ func (s) TestNewConnPeerMaxFrameSize(t *testing.T) {
 	}
 }
 
-// TestWriteHonorsPeerMaxFrameSize verifies that Write clamps its frame size to a
-// peer-advertised max_frame_size smaller than altsRecordDefaultLength, so we never
-// send a frame the peer said it can't accept.
-func (s) TestWriteHonorsPeerMaxFrameSize(t *testing.T) {
+// TestWriteHonorsNegotiatedMaxFrameSize verifies that Write uses the negotiated
+// max_frame_size so we never send a frame larger than negotiated.
+func (s) TestWriteHonorsNegotiatedMaxFrameSize(t *testing.T) {
 	key := make([]byte, 16)
-	const peerMaxFrameSize = 16 * 1024
+	const negotiatedMaxFrameSize = 16 * 1024
 	out := new(bytes.Buffer)
-	c, err := NewConn(&testConn{in: new(bytes.Buffer), out: out}, core.ClientSide, rekeyRecordProtocol, key, nil, peerMaxFrameSize)
+	c, err := NewConn(&testConn{in: new(bytes.Buffer), out: out}, core.ClientSide, rekeyRecordProtocol, key, nil, negotiatedMaxFrameSize)
 	if err != nil {
 		t.Fatalf("NewConn failed: %v", err)
 	}
 	altsC := c.(*conn)
-	if got, want := altsC.payloadLengthLimit+altsC.overhead, peerMaxFrameSize; got != want {
+	if got, want := altsC.payloadLengthLimit+altsC.overhead, negotiatedMaxFrameSize; got != want {
 		t.Fatalf("frame size = %v, want %v", got, want)
 	}
-	// Two peerMaxFrameSize-worth of plaintext should split into exactly two frames.
+	// Two negotiatedMaxFrameSize-worth of plaintext should split into exactly two frames.
 	payload := make([]byte, 2*altsC.payloadLengthLimit)
 	if _, err := c.Write(payload); err != nil {
 		t.Fatalf("Write failed: %v", err)
@@ -533,20 +529,20 @@ func (c *partialWriteTestConn) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
-// TestWritePartialWriteErrorWithPeerMaxFrameSize verifies that when a partial Write error occurs,
-// the number of written bytes returned correctly accounts for the negotiated peerMaxFrameSize.
-func (s) TestWritePartialWriteErrorWithPeerMaxFrameSize(t *testing.T) {
+// TestWritePartialWriteErrorWithNegotiatedMaxFrameSize verifies that when a partial Write error occurs,
+// the number of written bytes returned correctly accounts for the negotiated max_frame_size.
+func (s) TestWritePartialWriteErrorWithNegotiatedMaxFrameSize(t *testing.T) {
 	key := make([]byte, 16)
-	const peerMaxFrameSize = 16 * 1024
+	const negotiatedMaxFrameSize = 16 * 1024
 
 	// Allow writing 1.5 frames (16384 + 8192 = 24576 bytes) before returning io.ErrUnexpectedEOF.
-	writeLimit := peerMaxFrameSize + peerMaxFrameSize/2
+	writeLimit := negotiatedMaxFrameSize + negotiatedMaxFrameSize/2
 	errConn := &partialWriteTestConn{
 		maxWriteBytes: writeLimit,
 		err:           io.ErrUnexpectedEOF,
 	}
 
-	c, err := NewConn(errConn, core.ClientSide, rekeyRecordProtocol, key, nil, peerMaxFrameSize)
+	c, err := NewConn(errConn, core.ClientSide, rekeyRecordProtocol, key, nil, negotiatedMaxFrameSize)
 	if err != nil {
 		t.Fatalf("NewConn failed: %v", err)
 	}

--- a/credentials/alts/internal/conn/record_test.go
+++ b/credentials/alts/internal/conn/record_test.go
@@ -90,7 +90,7 @@ func newTestALTSRecordConn(in, out *bytes.Buffer, side core.Side, rp string, pro
 		in:  in,
 		out: out,
 	}
-	c, err := NewConn(&tc, side, rp, key, protected, 0)
+	c, err := NewConn(&tc, side, rp, key, protected)
 	if err != nil {
 		panic(fmt.Sprintf("Unexpected error creating test ALTS record connection: %v", err))
 	}
@@ -381,7 +381,7 @@ func BenchmarkWriteMemoryUsage(b *testing.B) {
 	conn := &noopConn{}
 
 	for b.Loop() {
-		c, err := NewConn(conn, core.ClientSide, rekeyRecordProtocol, key, nil, 0)
+		c, err := NewConn(conn, core.ClientSide, rekeyRecordProtocol, key, nil)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -433,7 +433,7 @@ func (s) TestParseFramedMsgVulnerability(t *testing.T) {
 	// bytes happen to start with `0x06` (altsRecordMsgType), the vulnerable
 	// code will try to slice `msg[4:]` which panics because len(msg) is 0.
 	malformedProtected := []byte{0x00, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00}
-	c, err := NewConn(&tc, core.ServerSide, rekeyRecordProtocol, key, malformedProtected, 0)
+	c, err := NewConn(&tc, core.ServerSide, rekeyRecordProtocol, key, malformedProtected)
 	if err != nil {
 		t.Fatalf("NewConn failed: %v", err)
 	}
@@ -476,7 +476,7 @@ func (s) TestNewConnNegotiatedMaxFrameSize(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			tcConn := testConn{}
-			c, err := NewConn(&tcConn, core.ClientSide, rekeyRecordProtocol, key, nil, tc.negotiatedMaxFrameSize)
+			c, err := NewConnWithMaxFrameSize(&tcConn, core.ClientSide, rekeyRecordProtocol, key, nil, tc.negotiatedMaxFrameSize)
 			if err != nil {
 				t.Fatalf("NewConn() err = %v, want nil", err)
 			}
@@ -495,7 +495,7 @@ func (s) TestWriteHonorsNegotiatedMaxFrameSize(t *testing.T) {
 	key := make([]byte, 16)
 	const negotiatedMaxFrameSize = 16 * 1024
 	out := new(bytes.Buffer)
-	c, err := NewConn(&testConn{in: new(bytes.Buffer), out: out}, core.ClientSide, rekeyRecordProtocol, key, nil, negotiatedMaxFrameSize)
+	c, err := NewConnWithMaxFrameSize(&testConn{in: new(bytes.Buffer), out: out}, core.ClientSide, rekeyRecordProtocol, key, nil, negotiatedMaxFrameSize)
 	if err != nil {
 		t.Fatalf("NewConn failed: %v", err)
 	}
@@ -542,7 +542,7 @@ func (s) TestWritePartialWriteErrorWithNegotiatedMaxFrameSize(t *testing.T) {
 		err:           io.ErrUnexpectedEOF,
 	}
 
-	c, err := NewConn(errConn, core.ClientSide, rekeyRecordProtocol, key, nil, negotiatedMaxFrameSize)
+	c, err := NewConnWithMaxFrameSize(errConn, core.ClientSide, rekeyRecordProtocol, key, nil, negotiatedMaxFrameSize)
 	if err != nil {
 		t.Fatalf("NewConn failed: %v", err)
 	}

--- a/credentials/alts/internal/conn/record_test.go
+++ b/credentials/alts/internal/conn/record_test.go
@@ -467,12 +467,12 @@ func (s) TestNewConnNegotiatedMaxFrameSize(t *testing.T) {
 		negotiatedMaxFrameSize int
 		wantMaxRecordLen       int
 	}{
-		{"not negotiated (0)", 0, altsRecordDefaultLength},
-		{"smaller than default (10)", 10, altsRecordDefaultLength},
-		{"smaller than default (1024)", 1024, altsRecordDefaultLength},
-		{"negotiated 4KB", 4 * 1024, 4 * 1024},
-		{"negotiated 16KB", 16 * 1024, 16 * 1024},
-		{"negotiated 64KB", 64 * 1024, 64 * 1024},
+		{"NotNegotiated", 0, altsRecordDefaultLength},
+		{"SmallerThanDefault_10B", 10, altsRecordDefaultLength},
+		{"SmallerThanDefault_1024B", 1024, altsRecordDefaultLength},
+		{"Negotiated_4KB", 4 * 1024, 4 * 1024},
+		{"Negotiated_16KB", 16 * 1024, 16 * 1024},
+		{"Negotiated_64KB", 64 * 1024, 64 * 1024},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			tcConn := testConn{}

--- a/credentials/alts/internal/conn/record_test.go
+++ b/credentials/alts/internal/conn/record_test.go
@@ -90,7 +90,7 @@ func newTestALTSRecordConn(in, out *bytes.Buffer, side core.Side, rp string, pro
 		in:  in,
 		out: out,
 	}
-	c, err := NewConn(&tc, side, rp, key, protected)
+	c, err := NewConn(&tc, side, rp, key, protected, 0)
 	if err != nil {
 		panic(fmt.Sprintf("Unexpected error creating test ALTS record connection: %v", err))
 	}
@@ -381,7 +381,7 @@ func BenchmarkWriteMemoryUsage(b *testing.B) {
 	conn := &noopConn{}
 
 	for b.Loop() {
-		c, err := NewConn(conn, core.ClientSide, rekeyRecordProtocol, key, nil)
+		c, err := NewConn(conn, core.ClientSide, rekeyRecordProtocol, key, nil, 0)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -433,7 +433,7 @@ func (s) TestParseFramedMsgVulnerability(t *testing.T) {
 	// bytes happen to start with `0x06` (altsRecordMsgType), the vulnerable
 	// code will try to slice `msg[4:]` which panics because len(msg) is 0.
 	malformedProtected := []byte{0x00, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00}
-	c, err := NewConn(&tc, core.ServerSide, rekeyRecordProtocol, key, malformedProtected)
+	c, err := NewConn(&tc, core.ServerSide, rekeyRecordProtocol, key, malformedProtected, 0)
 	if err != nil {
 		t.Fatalf("NewConn failed: %v", err)
 	}
@@ -441,5 +441,127 @@ func (s) TestParseFramedMsgVulnerability(t *testing.T) {
 	const wantErr = "shorter than message type field size"
 	if _, err := c.Read(buf); err == nil || !strings.Contains(err.Error(), wantErr) {
 		t.Fatalf("c.Read(buf) returned error: %v, want error containing %q", err, wantErr)
+	}
+}
+
+// countALTSFrames parses raw ALTS wire bytes and returns the number of complete frames.
+func countALTSFrames(data []byte) int {
+	count := 0
+	for len(data) >= MsgLenFieldSize {
+		frameLen := int(binary.LittleEndian.Uint32(data[:MsgLenFieldSize]))
+		total := MsgLenFieldSize + frameLen
+		if total > len(data) {
+			break
+		}
+		data = data[total:]
+		count++
+	}
+	return count
+}
+
+func (s) TestNewConnPeerMaxFrameSize(t *testing.T) {
+	key := make([]byte, 32)
+	for _, tc := range []struct {
+		name             string
+		peerMaxFrameSize int
+		wantMaxRecordLen int
+		wantErr          bool
+	}{
+		{"not advertised", 0, altsRecordDefaultLength, false},
+		{"larger than our default", altsRecordDefaultLength + 1024, altsRecordDefaultLength, false},
+		{"equal to our default", altsRecordDefaultLength, altsRecordDefaultLength, false},
+		{"smaller than our default", 16 * 1024, 16 * 1024, false},
+		{"invalid smaller than overhead", 10, 0, true},
+		{"invalid equal to overhead", 24, 0, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tcConn := testConn{}
+			c, err := NewConn(&tcConn, core.ClientSide, rekeyRecordProtocol, key, nil, tc.peerMaxFrameSize)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("NewConn() err = %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			altsC := c.(*conn)
+			wantPayloadLimit := tc.wantMaxRecordLen - altsC.overhead
+			if altsC.payloadLengthLimit != wantPayloadLimit {
+				t.Errorf("payloadLengthLimit = %v, want %v", altsC.payloadLengthLimit, wantPayloadLimit)
+			}
+		})
+	}
+}
+
+// TestWriteHonorsPeerMaxFrameSize verifies that Write clamps its frame size to a
+// peer-advertised max_frame_size smaller than altsRecordDefaultLength, so we never
+// send a frame the peer said it can't accept.
+func (s) TestWriteHonorsPeerMaxFrameSize(t *testing.T) {
+	key := make([]byte, 16)
+	const peerMaxFrameSize = 16 * 1024
+	out := new(bytes.Buffer)
+	c, err := NewConn(&testConn{in: new(bytes.Buffer), out: out}, core.ClientSide, rekeyRecordProtocol, key, nil, peerMaxFrameSize)
+	if err != nil {
+		t.Fatalf("NewConn failed: %v", err)
+	}
+	altsC := c.(*conn)
+	if got, want := altsC.payloadLengthLimit+altsC.overhead, peerMaxFrameSize; got != want {
+		t.Fatalf("frame size = %v, want %v", got, want)
+	}
+	// Two peerMaxFrameSize-worth of plaintext should split into exactly two frames.
+	payload := make([]byte, 2*altsC.payloadLengthLimit)
+	if _, err := c.Write(payload); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	if got, want := countALTSFrames(out.Bytes()), 2; got != want {
+		t.Errorf("Write produced %d frames, want %d", got, want)
+	}
+}
+
+type partialWriteTestConn struct {
+	net.Conn
+	maxWriteBytes int
+	err           error
+	out           bytes.Buffer
+}
+
+func (c *partialWriteTestConn) Write(b []byte) (int, error) {
+	if len(b) > c.maxWriteBytes {
+		c.out.Write(b[:c.maxWriteBytes])
+		return c.maxWriteBytes, c.err
+	}
+	c.out.Write(b)
+	return len(b), nil
+}
+
+// TestWritePartialWriteErrorWithPeerMaxFrameSize verifies that when a partial Write error occurs,
+// the number of written bytes returned correctly accounts for the negotiated peerMaxFrameSize.
+func (s) TestWritePartialWriteErrorWithPeerMaxFrameSize(t *testing.T) {
+	key := make([]byte, 16)
+	const peerMaxFrameSize = 16 * 1024
+
+	// Allow writing 1.5 frames (16384 + 8192 = 24576 bytes) before returning io.ErrUnexpectedEOF.
+	writeLimit := peerMaxFrameSize + peerMaxFrameSize/2
+	errConn := &partialWriteTestConn{
+		maxWriteBytes: writeLimit,
+		err:           io.ErrUnexpectedEOF,
+	}
+
+	c, err := NewConn(errConn, core.ClientSide, rekeyRecordProtocol, key, nil, peerMaxFrameSize)
+	if err != nil {
+		t.Fatalf("NewConn failed: %v", err)
+	}
+	altsC := c.(*conn)
+
+	// Send 3 frames worth of payload
+	payload := make([]byte, 3*altsC.payloadLengthLimit)
+	n, writeErr := c.Write(payload)
+	if writeErr != io.ErrUnexpectedEOF {
+		t.Fatalf("Write err = %v, want %v", writeErr, io.ErrUnexpectedEOF)
+	}
+
+	// Exactly 1 complete frame was written before the partial write error.
+	wantWrittenBytes := altsC.payloadLengthLimit
+	if n != wantWrittenBytes {
+		t.Errorf("Write() returned n = %d, want %d", n, wantWrittenBytes)
 	}
 }

--- a/credentials/alts/internal/handshaker/handshaker.go
+++ b/credentials/alts/internal/handshaker/handshaker.go
@@ -289,7 +289,11 @@ func (h *altsHandshaker) doHandshake(req *altspb.HandshakerReq) (net.Conn, *alts
 	if !ok {
 		return nil, nil, fmt.Errorf("unknown resulted record protocol %v", result.RecordProtocol)
 	}
-	sc, err := conn.NewConn(h.conn, h.side, result.GetRecordProtocol(), result.KeyData[:keyLen], extra, int(result.GetMaxFrameSize()))
+	maxFrameSize := int(envconfig.ALTSMaxFrameSize)
+	if peerMax := int(result.GetMaxFrameSize()); peerMax > 0 {
+		maxFrameSize = min(peerMax, maxFrameSize)
+	}
+	sc, err := conn.NewConn(h.conn, h.side, result.GetRecordProtocol(), result.KeyData[:keyLen], extra, maxFrameSize)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/credentials/alts/internal/handshaker/handshaker.go
+++ b/credentials/alts/internal/handshaker/handshaker.go
@@ -293,7 +293,7 @@ func (h *altsHandshaker) doHandshake(req *altspb.HandshakerReq) (net.Conn, *alts
 	if peerMax := int(result.GetMaxFrameSize()); peerMax > 0 {
 		maxFrameSize = min(peerMax, maxFrameSize)
 	}
-	sc, err := conn.NewConn(h.conn, h.side, result.GetRecordProtocol(), result.KeyData[:keyLen], extra, maxFrameSize)
+	sc, err := conn.NewConnWithMaxFrameSize(h.conn, h.side, result.GetRecordProtocol(), result.KeyData[:keyLen], extra, maxFrameSize)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/credentials/alts/internal/handshaker/handshaker.go
+++ b/credentials/alts/internal/handshaker/handshaker.go
@@ -289,7 +289,7 @@ func (h *altsHandshaker) doHandshake(req *altspb.HandshakerReq) (net.Conn, *alts
 	if !ok {
 		return nil, nil, fmt.Errorf("unknown resulted record protocol %v", result.RecordProtocol)
 	}
-	sc, err := conn.NewConn(h.conn, h.side, result.GetRecordProtocol(), result.KeyData[:keyLen], extra)
+	sc, err := conn.NewConn(h.conn, h.side, result.GetRecordProtocol(), result.KeyData[:keyLen], extra, int(result.GetMaxFrameSize()))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/credentials/alts/internal/handshaker/handshaker_test.go
+++ b/credentials/alts/internal/handshaker/handshaker_test.go
@@ -412,7 +412,7 @@ func (s) TestHandshakeMaxFrameSizeNegotiation(t *testing.T) {
 		t.Fatalf("ClientHandshake() failed: %v", err)
 	}
 	if sc == nil {
-		t.Fatalf("expected non-nil secure conn")
+		t.Fatal("ClientHandshake() returned nil conn, want non-nil")
 	}
 
 	// Clear any handshake frames written to out during ClientHandshake.
@@ -421,17 +421,17 @@ func (s) TestHandshakeMaxFrameSizeNegotiation(t *testing.T) {
 	// Write a payload large enough to produce a full ALTS frame.
 	payload := make([]byte, 128*1024)
 	if _, err := sc.Write(payload); err != nil {
-		t.Fatalf("sc.Write() failed: %v", err)
+		t.Fatalf("Secure conn Write() failed: %v", err)
 	}
 	// In ALTS wire format, the first 4 bytes of a frame contain the little-endian
 	// frame length (frameLen). Writing a large payload splits it into frames of
 	// the maximum calculated size. We verify the connection's max frame size by
 	// asserting that the total wire frame length (4 + frameLen) equals 64 * 1024.
 	if len(out.Bytes()) < 4 {
-		t.Fatalf("output buffer too small: %d bytes", len(out.Bytes()))
+		t.Fatalf("Output buffer too small: %d bytes", len(out.Bytes()))
 	}
 	frameLen := int(binary.LittleEndian.Uint32(out.Bytes()[:4]))
 	if got, want := 4+frameLen, 64*1024; got != want {
-		t.Errorf("wire frame size = %v, want %v", got, want)
+		t.Errorf("Wire frame size = %v, want %v", got, want)
 	}
 }

--- a/credentials/alts/internal/handshaker/handshaker_test.go
+++ b/credentials/alts/internal/handshaker/handshaker_test.go
@@ -21,6 +21,7 @@ package handshaker
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"testing"
@@ -377,13 +378,17 @@ func (s) TestNewServerHandshaker(t *testing.T) {
 }
 
 func (s) TestHandshakeMaxFrameSizeNegotiation(t *testing.T) {
+	old := envconfig.ALTSMaxFrameSize
+	envconfig.ALTSMaxFrameSize = 64 * 1024
+	defer func() { envconfig.ALTSMaxFrameSize = old }()
+
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
 	stream := &testRPCStream{
 		t:                t,
 		isClient:         true,
-		peerMaxFrameSize: 16 * 1024,
+		peerMaxFrameSize: 1024 * 1024,
 	}
 	f1 := testutil.MakeFrame("ServerInit")
 	f2 := testutil.MakeFrame("ServerFinished")
@@ -408,5 +413,25 @@ func (s) TestHandshakeMaxFrameSizeNegotiation(t *testing.T) {
 	}
 	if sc == nil {
 		t.Fatalf("expected non-nil secure conn")
+	}
+
+	// Clear any handshake frames written to out during ClientHandshake.
+	out.Reset()
+
+	// Write a payload large enough to produce a full ALTS frame.
+	payload := make([]byte, 128*1024)
+	if _, err := sc.Write(payload); err != nil {
+		t.Fatalf("sc.Write() failed: %v", err)
+	}
+	// In ALTS wire format, the first 4 bytes of a frame contain the little-endian
+	// frame length (frameLen). Writing a large payload splits it into frames of
+	// the maximum calculated size. We verify the connection's max frame size by
+	// asserting that the total wire frame length (4 + frameLen) equals 64 * 1024.
+	if len(out.Bytes()) < 4 {
+		t.Fatalf("output buffer too small: %d bytes", len(out.Bytes()))
+	}
+	frameLen := int(binary.LittleEndian.Uint32(out.Bytes()[:4]))
+	if got, want := 4+frameLen, 64*1024; got != want {
+		t.Errorf("wire frame size = %v, want %v", got, want)
 	}
 }

--- a/credentials/alts/internal/handshaker/handshaker_test.go
+++ b/credentials/alts/internal/handshaker/handshaker_test.go
@@ -78,6 +78,8 @@ type testRPCStream struct {
 	// The minimum expected value of the network_latency_ms field in a
 	// NextHandshakeMessageReq.
 	minExpectedNetworkLatency time.Duration
+	// peerMaxFrameSize is the max_frame_size in the HandshakerResult.
+	peerMaxFrameSize uint32
 }
 
 func (t *testRPCStream) Recv() (*altspb.HandshakerResp, error) {
@@ -127,6 +129,7 @@ func (t *testRPCStream) Send(req *altspb.HandshakerReq) error {
 		result := &altspb.HandshakerResult{
 			RecordProtocol: testRecordProtocol,
 			KeyData:        testKey,
+			MaxFrameSize:   t.peerMaxFrameSize,
 		}
 		resp = &altspb.HandshakerResp{
 			Result: result,
@@ -371,4 +374,39 @@ func (s) TestNewServerHandshaker(t *testing.T) {
 		t.Errorf("NewServerHandshaker() returned handshaker with unexpected clientConn")
 	}
 	hs.Close()
+}
+
+func (s) TestHandshakeMaxFrameSizeNegotiation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	stream := &testRPCStream{
+		t:                t,
+		isClient:         true,
+		peerMaxFrameSize: 16 * 1024,
+	}
+	f1 := testutil.MakeFrame("ServerInit")
+	f2 := testutil.MakeFrame("ServerFinished")
+	in := bytes.NewBuffer(f1)
+	in.Write(f2)
+	out := new(bytes.Buffer)
+	tc := testutil.NewTestConn(in, out)
+	chs := &altsHandshaker{
+		stream: stream,
+		conn:   tc,
+		clientOpts: &ClientHandshakerOptions{
+			TargetServiceAccounts: testTargetServiceAccounts,
+			ClientIdentity:        testClientIdentity,
+		},
+		side: core.ClientSide,
+	}
+	defer chs.Close()
+
+	sc, _, err := chs.ClientHandshake(ctx)
+	if err != nil {
+		t.Fatalf("ClientHandshake() failed: %v", err)
+	}
+	if sc == nil {
+		t.Fatalf("expected non-nil secure conn")
+	}
 }

--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -155,10 +155,10 @@ var (
 
 	// ALTSMaxFrameSize is the maximum frame size for ALTS in bytes.
 	// This can be overridden by setting the environment variable
-	// "GRPC_ALTS_MAX_FRAME_SIZE" (min: 4096, max: 512*1024, capped at
+	// "GRPC_GO_EXPERIMENTAL_ALTS_MAX_FRAME_SIZE" (min: 4096, max: 512*1024, capped at
 	// 512KiB to match altsWriteBufferMaxSize in
 	// credentials/alts/internal/conn/record.go).
-	ALTSMaxFrameSize = uint64FromEnv("GRPC_ALTS_MAX_FRAME_SIZE", 4096, 4096, 512*1024)
+	ALTSMaxFrameSize = uint64FromEnv("GRPC_GO_EXPERIMENTAL_ALTS_MAX_FRAME_SIZE", 4096, 4096, 512*1024)
 )
 
 func boolFromEnv(envVar string, def bool) bool {

--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -152,6 +152,13 @@ var (
 	//
 	// TODO: Remove this env var once v1.83.0 is release.
 	ControlBufferThrottleLimit = uint64FromEnv("GRPC_GO_EXPERIMENTAL_CONTROL_BUFFER_THROTTLE_LIMIT", 100, 1, 10000)
+
+	// ALTSMaxFrameSize is the maximum frame size for ALTS in bytes.
+	// This can be overridden by setting the environment variable
+	// "GRPC_ALTS_MAX_FRAME_SIZE" (min: 4096, max: 512*1024, capped at
+	// 512KiB to match altsWriteBufferMaxSize in
+	// credentials/alts/internal/conn/record.go).
+	ALTSMaxFrameSize = uint64FromEnv("GRPC_ALTS_MAX_FRAME_SIZE", 4096, 4096, 512*1024)
 )
 
 func boolFromEnv(envVar string, def bool) bool {


### PR DESCRIPTION
Because grpc-go currently does not dynamically negotiate the max frame size, the connection silently falls back to a default frame size of 4KiB. Moving the default gRPC write-buffer chunk (32KiB) through ALTS at 4KiB forces 9 small encryption calls per chunk. Raising the frame size to 64KiB lets that 32KiB chunk fit in a single frame, cutting per-chunk encrypt calls roughly 8x.

To roll this out safely and allow GCS testing before changing the default behavior, this PR:

-  Adds GRPC_GO_EXPERIMENTAL_ALTS_MAX_FRAME_SIZE environment variable: Allows configuring the maximum ALTS record frame size (default: 4096 bytes / 4KiB, max: 512KiB). Once GCS validates 64KiB in testing, a follow-up PR will flip the default value to 65536 (64KiB).

- Adds frame size negotiation in handshaker.go: After handshake completion, we negotiate the frame size by clamping GRPC_GO_EXPERIMENTAL_ALTS_MAX_FRAME_SIZE against any peer-advertised max_frame_size from the handshake result (min(peerMax, ourMax)), so we never write frames larger than a peer can accept.

- Aligns clamping with C++ and Java gRPC: Uses max(4KiB, negotiatedMaxFrameSize) so NewConn never returns an error when talking to peers with small or unset max frame sizes.

Benchmark/Profiling: 
see attached files [consolidated_benchmark_report.md](https://github.com/user-attachments/files/30359695/consolidated_benchmark_report.md) [consolidated_profiling_report.md](https://github.com/user-attachments/files/30359696/consolidated_profiling_report.md) 
The performance gains are more consistent under concurrent workloads (8 and 16 workers), where 64KB shows a stable 2% to 3% average latency reduction and 3% to 6% P99 reduction.

RELEASE NOTES:
* `credentials/alts`: add `GRPC_GO_EXPERIMENTAL_ALTS_MAX_FRAME_SIZE` environment variable (default 4KiB, max 512KiB) to control ALTS record frame size and honor peer-advertised `max_frame_size` from the ALTS handshake result.
