### PR TITLE
extproc: retrieve correct error status when Send fails with io.EOF

### DIFF
--- a/internal/xds/httpfilter/extproc/ext_proc.go
+++ b/internal/xds/httpfilter/extproc/ext_proc.go
@@ -313,6 +313,9 @@ func (i *clientInterceptor) NewStream(ctx context.Context, ri resolver.RPCInfo, 
 			},
 		}
 		if err = cs.procStream.Send(headerReq); err != nil {
+			if err == io.EOF {
+				_, err = cs.procStream.Recv()
+			}
 			return cs.handleProcStreamInitError(fmt.Errorf("failed to send client headers to external processor server: %v", err), newStream, opts)
 		}
 	} else {


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/9269

When the proc server fails abruptly , if it fails before the Send for request header is called , we will get an io.EOF error which needs to be retrived using Recv. 
If the proc server fails after the Send for request header, i.e. the Send returns nil, the correct error will automatically be retrieved by Recv run in the background loop in `recvFromProcServer`.
So , because of this race between the proc server failing and Send being called for request header , the test was flaking.
We need to get the correct error when Send for header req fails with io.EOF.

#ext-proc-a93

RELEASE NOTES: None
