### PR TITLE
serviceconfig: accept ProtoJSON integer strings

### DIFF
--- a/service_config.go
+++ b/service_config.go
@@ -23,6 +23,8 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
+	"strings"
 	"time"
 
 	"google.golang.org/grpc/balancer"
@@ -35,6 +37,143 @@ import (
 )
 
 const maxInt = int(^uint(0) >> 1)
+
+// jsonUint32 decodes service-config fields whose protobuf schema type is
+// uint32. ProtoJSON accepts JSON numbers, quoted numbers (including integral
+// decimal and exponent forms), and null for these fields.
+//
+// protojson cannot decode a scalar directly; it requires a protobuf message.
+// Using wrapperspb.UInt32Value would add wrapperspb to the root grpc package's
+// dependency graph, while borrowing an unrelated generated message would
+// introduce an undesirable package coupling. Keep this local decoder so
+// service-config parsing preserves ProtoJSON uint32 semantics without changing
+// the root grpc package dependency graph.
+//
+// normalizeJSONUint32 also preserves ProtoJSON edge cases such as negative zero
+// and zero with an exponent too large to fit in an integer. A big.Float-based
+// parser was avoided because it rejects the latter even though ProtoJSON accepts
+// it as zero. Malformed strings, non-integral values, negative nonzero values,
+// and values outside the uint32 range are rejected.
+type jsonUint32 uint32
+
+func (j *jsonUint32) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*j = 0
+		return nil
+	}
+
+	var number json.Number
+	if err := json.Unmarshal(data, &number); err != nil {
+		return err
+	}
+
+	value, err := parseJSONUint32(number.String())
+	if err != nil {
+		return err
+	}
+	*j = jsonUint32(value)
+	return nil
+}
+
+func parseJSONUint32(s string) (uint32, error) {
+	value, ok := normalizeJSONUint32(s)
+	if !ok {
+		return 0, fmt.Errorf("invalid uint32 value %q", s)
+	}
+	return value, nil
+}
+
+func normalizeJSONUint32(number string) (uint32, bool) {
+	if number == "" {
+		return 0, false
+	}
+
+	negative := number[0] == '-'
+	if negative {
+		number = number[1:]
+		if number == "" {
+			return 0, false
+		}
+	}
+
+	exponentText := ""
+	if i := strings.IndexAny(number, "eE"); i >= 0 {
+		exponentText = number[i+1:]
+		number = number[:i]
+	}
+
+	integerPart := number
+	fractionalPart := ""
+	if i := strings.IndexByte(number, '.'); i >= 0 {
+		integerPart = number[:i]
+		fractionalPart = strings.TrimRight(number[i+1:], "0")
+	}
+
+	// Match ProtoJSON handling of zero, including negative zero and zero with
+	// an exponent that is too large to fit in an integer.
+	if integerPart == "0" {
+		integerPart = ""
+	}
+	if integerPart == "" && fractionalPart == "" {
+		return 0, true
+	}
+
+	// Only zero may carry a negative sign for an unsigned ProtoJSON value.
+	// The zero case was handled above, so all remaining negative values fail.
+	if negative {
+		return 0, false
+	}
+
+	exponent := 0
+	if exponentText != "" {
+		parsed, err := strconv.ParseInt(exponentText, 10, 32)
+		if err != nil {
+			return 0, false
+		}
+		exponent = int(parsed)
+	}
+
+	var digits string
+	if exponent >= 0 {
+		// Match ProtoJSON's bounded normalization before applying the final
+		// uint32 range check.
+		const maxDigits = 20
+		if len(fractionalPart) > exponent ||
+			len(integerPart) > maxDigits ||
+			exponent > maxDigits-len(integerPart) {
+			return 0, false
+		}
+
+		digits = integerPart + fractionalPart +
+			strings.Repeat("0", exponent-len(fractionalPart))
+	} else {
+		if len(fractionalPart) > 0 {
+			return 0, false
+		}
+
+		decimalPoint := len(integerPart) + exponent
+		if decimalPoint < 0 {
+			return 0, false
+		}
+
+		for _, digit := range integerPart[decimalPoint:] {
+			if digit != '0' {
+				return 0, false
+			}
+		}
+		digits = integerPart[:decimalPoint]
+	}
+
+	if digits == "" {
+		return 0, true
+	}
+
+	value, err := strconv.ParseUint(digits, 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return uint32(value), true
+}
 
 // MethodConfig defines the configuration recommended by the service providers for a
 // particular method.
@@ -96,7 +235,7 @@ type healthCheckConfig struct {
 }
 
 type jsonRetryPolicy struct {
-	MaxAttempts          int
+	MaxAttempts          jsonUint32
 	InitialBackoff       internalserviceconfig.Duration
 	MaxBackoff           internalserviceconfig.Duration
 	BackoffMultiplier    float64
@@ -149,8 +288,8 @@ type jsonMC struct {
 	Name                    *[]jsonName
 	WaitForReady            *bool
 	Timeout                 *internalserviceconfig.Duration
-	MaxRequestMessageBytes  *int64
-	MaxResponseMessageBytes *int64
+	MaxRequestMessageBytes  *jsonUint32
+	MaxResponseMessageBytes *jsonUint32
 	RetryPolicy             *jsonRetryPolicy
 }
 
@@ -227,14 +366,14 @@ func parseServiceConfig(js string, maxAttempts int) *serviceconfig.ParseResult {
 			return &serviceconfig.ParseResult{Err: err}
 		}
 		if m.MaxRequestMessageBytes != nil {
-			if *m.MaxRequestMessageBytes > int64(maxInt) {
+			if uint64(*m.MaxRequestMessageBytes) > uint64(maxInt) {
 				mc.MaxReqSize = newInt(maxInt)
 			} else {
 				mc.MaxReqSize = newInt(int(*m.MaxRequestMessageBytes))
 			}
 		}
 		if m.MaxResponseMessageBytes != nil {
-			if *m.MaxResponseMessageBytes > int64(maxInt) {
+			if uint64(*m.MaxResponseMessageBytes) > uint64(maxInt) {
 				mc.MaxRespSize = newInt(maxInt)
 			} else {
 				mc.MaxRespSize = newInt(int(*m.MaxResponseMessageBytes))
@@ -285,8 +424,8 @@ func convertRetryPolicy(jrp *jsonRetryPolicy, maxAttempts int) (p *internalservi
 		return nil, fmt.Errorf("invalid retry policy (%+v): ", jrp)
 	}
 
-	if jrp.MaxAttempts < maxAttempts {
-		maxAttempts = jrp.MaxAttempts
+	if int64(jrp.MaxAttempts) < int64(maxAttempts) {
+		maxAttempts = int(jrp.MaxAttempts)
 	}
 	rp := &internalserviceconfig.RetryPolicy{
 		MaxAttempts:          maxAttempts,

--- a/service_config.go
+++ b/service_config.go
@@ -23,6 +23,8 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
+	"strings"
 	"time"
 
 	"google.golang.org/grpc/balancer"
@@ -35,6 +37,115 @@ import (
 )
 
 const maxInt = int(^uint(0) >> 1)
+
+// jsonUint32 accepts numeric, string, and null forms allowed by ProtoJSON.
+type jsonUint32 uint32
+
+func (j *jsonUint32) UnmarshalJSON(data []byte) error {
+	if strings.TrimSpace(string(data)) == "null" {
+		*j = 0
+		return nil
+	}
+
+	var number json.Number
+	if err := json.Unmarshal(data, &number); err != nil {
+		return err
+	}
+
+	value, err := parseJSONUint32(number.String())
+	if err != nil {
+		return err
+	}
+	*j = jsonUint32(value)
+	return nil
+}
+
+func parseJSONUint32(number string) (uint32, error) {
+	raw := number
+	if number == "" {
+		return 0, fmt.Errorf("invalid uint32 value %q", raw)
+	}
+
+	negative := number[0] == '-'
+	if negative {
+		number = number[1:]
+	}
+
+	exponentText := ""
+	if i := strings.IndexAny(number, "eE"); i >= 0 {
+		exponentText = number[i+1:]
+		number = number[:i]
+	}
+
+	integerPart := number
+	fractionalPart := ""
+	if i := strings.IndexByte(number, '.'); i >= 0 {
+		integerPart = number[:i]
+		fractionalPart = strings.TrimRight(number[i+1:], "0")
+	}
+
+	// Match ProtoJSON handling of zero, including negative zero and zero with
+	// an exponent that is too large to fit in an integer.
+	if integerPart == "0" {
+		integerPart = ""
+	}
+	if integerPart == "" && fractionalPart == "" {
+		return 0, nil
+	}
+
+	exponent := 0
+	if exponentText != "" {
+		parsed, err := strconv.ParseInt(exponentText, 10, 32)
+		if err != nil {
+			return 0, fmt.Errorf("invalid uint32 value %q", raw)
+		}
+		exponent = int(parsed)
+	}
+
+	var digits string
+	if exponent >= 0 {
+		// Match ProtoJSON's bounded normalization before applying the final
+		// uint32 range check.
+		const maxDigits = 20
+		if len(fractionalPart) > exponent ||
+			len(integerPart) > maxDigits ||
+			exponent > maxDigits-len(integerPart) {
+			return 0, fmt.Errorf("invalid uint32 value %q", raw)
+		}
+
+		digits = integerPart + fractionalPart +
+			strings.Repeat("0", exponent-len(fractionalPart))
+	} else {
+		if len(fractionalPart) > 0 {
+			return 0, fmt.Errorf("invalid uint32 value %q", raw)
+		}
+
+		decimalPoint := len(integerPart) + exponent
+		if decimalPoint < 0 {
+			return 0, fmt.Errorf("invalid uint32 value %q", raw)
+		}
+
+		for _, digit := range integerPart[decimalPoint:] {
+			if digit != '0' {
+				return 0, fmt.Errorf("invalid uint32 value %q", raw)
+			}
+		}
+		digits = integerPart[:decimalPoint]
+	}
+
+	if digits == "" {
+		return 0, nil
+	}
+	if negative {
+		return 0, fmt.Errorf("invalid uint32 value %q", raw)
+	}
+
+	value, err := strconv.ParseUint(digits, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid uint32 value %q", raw)
+	}
+	return uint32(value), nil
+}
 
 // MethodConfig defines the configuration recommended by the service providers for a
 // particular method.
@@ -96,7 +207,7 @@ type healthCheckConfig struct {
 }
 
 type jsonRetryPolicy struct {
-	MaxAttempts          int
+	MaxAttempts          jsonUint32
 	InitialBackoff       internalserviceconfig.Duration
 	MaxBackoff           internalserviceconfig.Duration
 	BackoffMultiplier    float64
@@ -149,8 +260,8 @@ type jsonMC struct {
 	Name                    *[]jsonName
 	WaitForReady            *bool
 	Timeout                 *internalserviceconfig.Duration
-	MaxRequestMessageBytes  *int64
-	MaxResponseMessageBytes *int64
+	MaxRequestMessageBytes  *jsonUint32
+	MaxResponseMessageBytes *jsonUint32
 	RetryPolicy             *jsonRetryPolicy
 }
 
@@ -227,14 +338,14 @@ func parseServiceConfig(js string, maxAttempts int) *serviceconfig.ParseResult {
 			return &serviceconfig.ParseResult{Err: err}
 		}
 		if m.MaxRequestMessageBytes != nil {
-			if *m.MaxRequestMessageBytes > int64(maxInt) {
+			if uint64(*m.MaxRequestMessageBytes) > uint64(maxInt) {
 				mc.MaxReqSize = newInt(maxInt)
 			} else {
 				mc.MaxReqSize = newInt(int(*m.MaxRequestMessageBytes))
 			}
 		}
 		if m.MaxResponseMessageBytes != nil {
-			if *m.MaxResponseMessageBytes > int64(maxInt) {
+			if uint64(*m.MaxResponseMessageBytes) > uint64(maxInt) {
 				mc.MaxRespSize = newInt(maxInt)
 			} else {
 				mc.MaxRespSize = newInt(int(*m.MaxResponseMessageBytes))
@@ -285,8 +396,8 @@ func convertRetryPolicy(jrp *jsonRetryPolicy, maxAttempts int) (p *internalservi
 		return nil, fmt.Errorf("invalid retry policy (%+v): ", jrp)
 	}
 
-	if jrp.MaxAttempts < maxAttempts {
-		maxAttempts = jrp.MaxAttempts
+	if int64(jrp.MaxAttempts) < int64(maxAttempts) {
+		maxAttempts = int(jrp.MaxAttempts)
 	}
 	rp := &internalserviceconfig.RetryPolicy{
 		MaxAttempts:          maxAttempts,

--- a/service_config_test.go
+++ b/service_config_test.go
@@ -339,9 +339,113 @@ func (s) TestParseTimeOut(t *testing.T) {
 	runParseTests(t, testcases)
 }
 
+func (s) TestJSONUint32(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    jsonUint32
+		wantErr bool
+	}{
+		{
+			name:  "number",
+			input: `42`,
+			want:  42,
+		},
+		{
+			name:  "string",
+			input: `"42"`,
+			want:  42,
+		},
+		{
+			name:  "uint32 maximum",
+			input: `"4294967295"`,
+			want:  4294967295,
+		},
+		{
+			name:  "null",
+			input: `null`,
+			want:  0,
+		},
+		{
+			name:  "fractional leading zeros with exponent",
+			input: `"0.00000000001e11"`,
+			want:  1,
+		},
+		{
+			name:  "negative zero",
+			input: `"-0"`,
+			want:  0,
+		},
+		{
+			name:  "zero with oversized exponent",
+			input: `"0e999999999999999999999"`,
+			want:  0,
+		},
+		{
+			name:    "oversized exponent",
+			input:   `"1e999999999999999999999"`,
+			wantErr: true,
+		},
+		{
+			name:  "quoted exponent",
+			input: `"1e2"`,
+			want:  100,
+		},
+		{
+			name:  "quoted decimal exponent",
+			input: `"1.024e3"`,
+			want:  1024,
+		},
+		{
+			name:    "quoted comma-separated value",
+			input:   `"1,000"`,
+			wantErr: true,
+		},
+		{
+			name:  "quoted zero fraction",
+			input: `"1.0"`,
+			want:  1,
+		},
+		{
+			name:    "negative",
+			input:   `"-1"`,
+			wantErr: true,
+		},
+		{
+			name:    "uint32 overflow",
+			input:   `"4294967296"`,
+			wantErr: true,
+		},
+		{
+			name:    "nonzero fraction",
+			input:   `"1.5"`,
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			input:   `""`,
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var got jsonUint32
+			err := json.Unmarshal([]byte(test.input), &got)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("json.Unmarshal(%q) error = %v, wantErr %v", test.input, err, test.wantErr)
+			}
+			if err == nil && got != test.want {
+				t.Fatalf("json.Unmarshal(%q) = %d, want %d", test.input, got, test.want)
+			}
+		})
+	}
+}
+
 func (s) TestParseMsgSize(t *testing.T) {
 	testcases := []parseTestCase{
 		{
+			name: "numeric integers",
 			scjs: `{
     "methodConfig": [
         {
@@ -367,6 +471,7 @@ func (s) TestParseMsgSize(t *testing.T) {
 			},
 		},
 		{
+			name: "stringified integers",
 			scjs: `{
     "methodConfig": [
         {
@@ -378,7 +483,23 @@ func (s) TestParseMsgSize(t *testing.T) {
             ],
             "maxRequestMessageBytes": "1024",
             "maxResponseMessageBytes": "2048"
-        },
+        }
+    ]
+}`,
+			wantSC: &ServiceConfig{
+				Methods: map[string]MethodConfig{
+					"/foo/Bar": {
+						MaxReqSize:  newInt(1024),
+						MaxRespSize: newInt(2048),
+					},
+				},
+				lbConfig: lbConfigFor(t, "", nil),
+			},
+		},
+		{
+			name: "stringified exponent",
+			scjs: `{
+    "methodConfig": [
         {
             "name": [
                 {
@@ -386,8 +507,33 @@ func (s) TestParseMsgSize(t *testing.T) {
                     "method": "Bar"
                 }
             ],
-            "maxRequestMessageBytes": 1024,
-            "maxResponseMessageBytes": 2048
+            "maxRequestMessageBytes": "1.024e3",
+            "maxResponseMessageBytes": "2.048e3"
+        }
+    ]
+}`,
+			wantSC: &ServiceConfig{
+				Methods: map[string]MethodConfig{
+					"/foo/Bar": {
+						MaxReqSize:  newInt(1024),
+						MaxRespSize: newInt(2048),
+					},
+				},
+				lbConfig: lbConfigFor(t, "", nil),
+			},
+		},
+		{
+			name: "invalid stringified integer",
+			scjs: `{
+    "methodConfig": [
+        {
+            "name": [
+                {
+                    "service": "foo",
+                    "method": "Bar"
+                }
+            ],
+            "maxRequestMessageBytes": "1024.5"
         }
     ]
 }`,
@@ -397,6 +543,109 @@ func (s) TestParseMsgSize(t *testing.T) {
 
 	runParseTests(t, testcases)
 }
+
+func (s) TestParseRetryMaxAttempts(t *testing.T) {
+	retryPolicy := func() *internalserviceconfig.RetryPolicy {
+		return &internalserviceconfig.RetryPolicy{
+			MaxAttempts:       4,
+			InitialBackoff:    time.Second,
+			MaxBackoff:        2 * time.Second,
+			BackoffMultiplier: 2,
+			RetryableStatusCodes: map[codes.Code]bool{
+				codes.Unavailable: true,
+			},
+		}
+	}
+
+	testcases := []parseTestCase{
+		{
+			name: "numeric integer",
+			scjs: `{
+    "methodConfig": [
+        {
+            "name": [
+                {
+                    "service": "foo",
+                    "method": "Bar"
+                }
+            ],
+            "retryPolicy": {
+                "maxAttempts": 4,
+                "initialBackoff": "1s",
+                "maxBackoff": "2s",
+                "backoffMultiplier": 2,
+                "retryableStatusCodes": ["UNAVAILABLE"]
+            }
+        }
+    ]
+}`,
+			wantSC: &ServiceConfig{
+				Methods: map[string]MethodConfig{
+					"/foo/Bar": {
+						RetryPolicy: retryPolicy(),
+					},
+				},
+				lbConfig: lbConfigFor(t, "", nil),
+			},
+		},
+		{
+			name: "stringified integer",
+			scjs: `{
+    "methodConfig": [
+        {
+            "name": [
+                {
+                    "service": "foo",
+                    "method": "Bar"
+                }
+            ],
+            "retryPolicy": {
+                "maxAttempts": "4",
+                "initialBackoff": "1s",
+                "maxBackoff": "2s",
+                "backoffMultiplier": 2,
+                "retryableStatusCodes": ["UNAVAILABLE"]
+            }
+        }
+    ]
+}`,
+			wantSC: &ServiceConfig{
+				Methods: map[string]MethodConfig{
+					"/foo/Bar": {
+						RetryPolicy: retryPolicy(),
+					},
+				},
+				lbConfig: lbConfigFor(t, "", nil),
+			},
+		},
+		{
+			name: "invalid stringified integer",
+			scjs: `{
+    "methodConfig": [
+        {
+            "name": [
+                {
+                    "service": "foo",
+                    "method": "Bar"
+                }
+            ],
+            "retryPolicy": {
+                "maxAttempts": "4.5",
+                "initialBackoff": "1s",
+                "maxBackoff": "2s",
+                "backoffMultiplier": 2,
+                "retryableStatusCodes": ["UNAVAILABLE"]
+            }
+        }
+    ]
+}`,
+			wantErr: true,
+		},
+	}
+
+	runParseTests(t, testcases)
+}
+
 func (s) TestParseDefaultMethodConfig(t *testing.T) {
 	dc := &ServiceConfig{
 		Methods: map[string]MethodConfig{

--- a/service_config_test.go
+++ b/service_config_test.go
@@ -339,9 +339,103 @@ func (s) TestParseTimeOut(t *testing.T) {
 	runParseTests(t, testcases)
 }
 
+func (s) TestJSONUint32(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    jsonUint32
+		wantErr bool
+	}{
+		{
+			name:  "number",
+			input: `42`,
+			want:  42,
+		},
+		{
+			name:  "string",
+			input: `"42"`,
+			want:  42,
+		},
+		{
+			name:  "uint32 maximum",
+			input: `"4294967295"`,
+			want:  4294967295,
+		},
+		{
+			name:  "null",
+			input: `null`,
+			want:  0,
+		},
+		{
+			name:  "fractional leading zeros with exponent",
+			input: `"0.00000000001e11"`,
+			want:  1,
+		},
+		{
+			name:  "negative zero",
+			input: `"-0"`,
+			want:  0,
+		},
+		{
+			name:  "zero with oversized exponent",
+			input: `"0e999999999999999999999"`,
+			want:  0,
+		},
+		{
+			name:    "oversized exponent",
+			input:   `"1e999999999999999999999"`,
+			wantErr: true,
+		},
+		{
+			name:  "quoted exponent",
+			input: `"1e2"`,
+			want:  100,
+		},
+		{
+			name:  "quoted zero fraction",
+			input: `"1.0"`,
+			want:  1,
+		},
+		{
+			name:    "negative",
+			input:   `"-1"`,
+			wantErr: true,
+		},
+		{
+			name:    "uint32 overflow",
+			input:   `"4294967296"`,
+			wantErr: true,
+		},
+		{
+			name:    "nonzero fraction",
+			input:   `"1.5"`,
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			input:   `""`,
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var got jsonUint32
+			err := json.Unmarshal([]byte(test.input), &got)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("json.Unmarshal(%q) error = %v, wantErr %v", test.input, err, test.wantErr)
+			}
+			if err == nil && got != test.want {
+				t.Fatalf("json.Unmarshal(%q) = %d, want %d", test.input, got, test.want)
+			}
+		})
+	}
+}
+
 func (s) TestParseMsgSize(t *testing.T) {
 	testcases := []parseTestCase{
 		{
+			name: "numeric integers",
 			scjs: `{
     "methodConfig": [
         {
@@ -367,6 +461,7 @@ func (s) TestParseMsgSize(t *testing.T) {
 			},
 		},
 		{
+			name: "stringified integers",
 			scjs: `{
     "methodConfig": [
         {
@@ -378,7 +473,23 @@ func (s) TestParseMsgSize(t *testing.T) {
             ],
             "maxRequestMessageBytes": "1024",
             "maxResponseMessageBytes": "2048"
-        },
+        }
+    ]
+}`,
+			wantSC: &ServiceConfig{
+				Methods: map[string]MethodConfig{
+					"/foo/Bar": {
+						MaxReqSize:  newInt(1024),
+						MaxRespSize: newInt(2048),
+					},
+				},
+				lbConfig: lbConfigFor(t, "", nil),
+			},
+		},
+		{
+			name: "invalid stringified integer",
+			scjs: `{
+    "methodConfig": [
         {
             "name": [
                 {
@@ -386,8 +497,7 @@ func (s) TestParseMsgSize(t *testing.T) {
                     "method": "Bar"
                 }
             ],
-            "maxRequestMessageBytes": 1024,
-            "maxResponseMessageBytes": 2048
+            "maxRequestMessageBytes": "1024.5"
         }
     ]
 }`,
@@ -397,6 +507,109 @@ func (s) TestParseMsgSize(t *testing.T) {
 
 	runParseTests(t, testcases)
 }
+
+func (s) TestParseRetryMaxAttempts(t *testing.T) {
+	retryPolicy := func() *internalserviceconfig.RetryPolicy {
+		return &internalserviceconfig.RetryPolicy{
+			MaxAttempts:       4,
+			InitialBackoff:    time.Second,
+			MaxBackoff:        2 * time.Second,
+			BackoffMultiplier: 2,
+			RetryableStatusCodes: map[codes.Code]bool{
+				codes.Unavailable: true,
+			},
+		}
+	}
+
+	testcases := []parseTestCase{
+		{
+			name: "numeric integer",
+			scjs: `{
+    "methodConfig": [
+        {
+            "name": [
+                {
+                    "service": "foo",
+                    "method": "Bar"
+                }
+            ],
+            "retryPolicy": {
+                "maxAttempts": 4,
+                "initialBackoff": "1s",
+                "maxBackoff": "2s",
+                "backoffMultiplier": 2,
+                "retryableStatusCodes": ["UNAVAILABLE"]
+            }
+        }
+    ]
+}`,
+			wantSC: &ServiceConfig{
+				Methods: map[string]MethodConfig{
+					"/foo/Bar": {
+						RetryPolicy: retryPolicy(),
+					},
+				},
+				lbConfig: lbConfigFor(t, "", nil),
+			},
+		},
+		{
+			name: "stringified integer",
+			scjs: `{
+    "methodConfig": [
+        {
+            "name": [
+                {
+                    "service": "foo",
+                    "method": "Bar"
+                }
+            ],
+            "retryPolicy": {
+                "maxAttempts": "4",
+                "initialBackoff": "1s",
+                "maxBackoff": "2s",
+                "backoffMultiplier": 2,
+                "retryableStatusCodes": ["UNAVAILABLE"]
+            }
+        }
+    ]
+}`,
+			wantSC: &ServiceConfig{
+				Methods: map[string]MethodConfig{
+					"/foo/Bar": {
+						RetryPolicy: retryPolicy(),
+					},
+				},
+				lbConfig: lbConfigFor(t, "", nil),
+			},
+		},
+		{
+			name: "invalid stringified integer",
+			scjs: `{
+    "methodConfig": [
+        {
+            "name": [
+                {
+                    "service": "foo",
+                    "method": "Bar"
+                }
+            ],
+            "retryPolicy": {
+                "maxAttempts": "4.5",
+                "initialBackoff": "1s",
+                "maxBackoff": "2s",
+                "backoffMultiplier": 2,
+                "retryableStatusCodes": ["UNAVAILABLE"]
+            }
+        }
+    ]
+}`,
+			wantErr: true,
+		},
+	}
+
+	runParseTests(t, testcases)
+}
+
 func (s) TestParseDefaultMethodConfig(t *testing.T) {
 	dc := &ServiceConfig{
 		Methods: map[string]MethodConfig{


### PR DESCRIPTION
Fixes #9260

Service config is defined as the JSON representation of its protobuf
schema, but the parser used standard `encoding/json` integer decoding.
This caused valid ProtoJSON string representations of integer fields to
be rejected.

Add a dependency-neutral `jsonUint32` decoder that accepts the numeric,
string, and null forms allowed for ProtoJSON unsigned integer fields.

The decoder supports integral decimal and exponent forms, while rejecting
negative values, overflow, non-integral values, and malformed strings.

Use it for:

- retry policy `maxAttempts`
- `maxRequestMessageBytes`
- `maxResponseMessageBytes`

Existing numeric JSON values continue to work, and the public `grpc`
package dependency graph remains unchanged.

Testing:

- focused service-config parsing tests on amd64
- focused service-config parsing tests with `GOARCH=386`
- `go test . -count=1`
- `go vet .`
- `./scripts/vet.sh`
- dependency comparison against `upstream/master`

RELEASE NOTES:
* serviceconfig: Accept ProtoJSON string representations for integer-valued service configuration fields. These fields now enforce their protobuf `uint32` range, so values above `4294967295` that were previously accepted by the wider Go JSON integer types are rejected.

