### PR TITLE
test: tolerate OutPayload/InTrailer reorder in RetryStats

### DIFF
--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -726,8 +726,11 @@ func (s) TestRetryStats(t *testing.T) {
 		handler.s[pIdx], handler.s[tIdx] = handler.s[tIdx], handler.s[pIdx]
 	}
 
-	// The same race can reorder the OutPayload and InTrailer of the
-	// transparent retry attempt (positions 6 and 7).
+	// The transparent retry attempt has a similar race, but between sending
+	// the payload and receiving the trailer.  OutPayload is reported once the
+	// data frame is queued on the transport, not once it is written, so the
+	// server can respond and the trailer can be reported first.  Adjust the
+	// received stats accordingly if necessary.
 	const tIdx2, pIdx2 = 6, 7
 	_, okT2 := handler.s[tIdx2].(*stats.InTrailer)
 	_, okP2 := handler.s[pIdx2].(*stats.OutPayload)

--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -726,6 +726,15 @@ func (s) TestRetryStats(t *testing.T) {
 		handler.s[pIdx], handler.s[tIdx] = handler.s[tIdx], handler.s[pIdx]
 	}
 
+	// The same race can reorder the OutPayload and InTrailer of the
+	// transparent retry attempt (positions 6 and 7).
+	const tIdx2, pIdx2 = 6, 7
+	_, okT2 := handler.s[tIdx2].(*stats.InTrailer)
+	_, okP2 := handler.s[pIdx2].(*stats.OutPayload)
+	if okT2 && okP2 {
+		handler.s[pIdx2], handler.s[tIdx2] = handler.s[tIdx2], handler.s[pIdx2]
+	}
+
 	for i := range handler.s {
 		w, s := want[i], handler.s[i]
 


### PR DESCRIPTION
Fixes #5881

`Test/RetryStats` flakes about 1 in 10k runs. The test already tolerates a payload/trailer race for the final attempt (positions 13 and 14), where the InPayload and InTrailer stats can arrive out of order. The same race applies to the transparent retry attempt: its OutPayload and InTrailer stats (positions 6 and 7) can also be recorded out of order, which the test does not yet tolerate. The reported failure is `at position 6: got *stats.InTrailer; want *stats.OutPayload`.

This extends the existing tolerance to the retry attempt's OutPayload/InTrailer pair, using the same swap technique already applied at positions 13 and 14.

RELEASE NOTES: N/A
