### PR TITLE
xds: implement Child Channel Options (gRFC A110)

### DIFF
--- a/balancer/grpclb/grpclb_remote_balancer.go
+++ b/balancer/grpclb/grpclb_remote_balancer.go
@@ -37,7 +37,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/timestamppb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 
 	lbpb "google.golang.org/grpc/balancer/grpclb/grpc_lb_v1"
 )

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -96,6 +96,7 @@ type dialOptions struct {
 	maxCallAttempts             int
 	enableLocalDNSResolution    bool // Specifies if target hostnames should be resolved when proxying is enabled.
 	useProxy                    bool // Specifies if a server should be connected via proxy.
+	childDialOpts               []DialOption
 }
 
 // DialOption configures how we set up the connection.
@@ -808,5 +809,18 @@ func WithMaxCallAttempts(n int) DialOption {
 func withBufferPool(bufferPool mem.BufferPool) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.copts.BufferPool = bufferPool
+	})
+}
+
+// WithChildDialOptions returns a DialOption that specifies the dial options
+// to be applied to any child channels created by components on this channel.
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func WithChildDialOptions(opts ...DialOption) DialOption {
+	return newFuncDialOption(func(o *dialOptions) {
+		o.childDialOpts = append(o.childDialOpts, opts...)
 	})
 }

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -64,6 +64,9 @@ var (
 	// gRPC server. An xDS-enabled server needs to know what type of credentials
 	// is configured on the underlying gRPC server. This is set by server.go.
 	GetServerCredentials any // func (*grpc.Server) credentials.TransportCredentials
+	// GetServerChildDialOptions returns the child dial options configured on a
+	// gRPC server. This is set by server.go.
+	GetServerChildDialOptions any // func(*grpc.Server) []any
 	// MetricsRecorderForServer returns the MetricsRecorderList derived from a
 	// server's stats handlers.
 	MetricsRecorderForServer any // func (*grpc.Server) estats.MetricsRecorder

--- a/internal/xds/httpfilter/extproc/config_test.go
+++ b/internal/xds/httpfilter/extproc/config_test.go
@@ -600,7 +600,7 @@ func (s) TestParseFilterConfigOverride_Errors(t *testing.T) {
 
 func (s) TestBuildClientInterceptor_Success(t *testing.T) {
 	origCreateExtProcChannel := createExtProcChannel
-	createExtProcChannel = func(cfg xdsresource.GRPCServiceConfig) (grpc.ClientConnInterface, func() error, error) {
+	createExtProcChannel = func(cfg xdsresource.GRPCServiceConfig, opts ...grpc.DialOption) (grpc.ClientConnInterface, func() error, error) {
 		conn, _ := grpc.NewClient(cfg.TargetURI, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		return conn, conn.Close, nil
 	}
@@ -829,7 +829,7 @@ func (s) TestBuildClientInterceptor_Success(t *testing.T) {
 
 func (s) TestBuildClientInterceptor_Failure(t *testing.T) {
 	origCreateExtProcChannel := createExtProcChannel
-	createExtProcChannel = func(cfg xdsresource.GRPCServiceConfig) (grpc.ClientConnInterface, func() error, error) {
+	createExtProcChannel = func(cfg xdsresource.GRPCServiceConfig, opts ...grpc.DialOption) (grpc.ClientConnInterface, func() error, error) {
 		if cfg.TargetURI == "error-uri" {
 			return nil, nil, fmt.Errorf("dial error")
 		}

--- a/internal/xds/httpfilter/extproc/ext_proc.go
+++ b/internal/xds/httpfilter/extproc/ext_proc.go
@@ -52,7 +52,7 @@ var (
 	parseGRPCServiceConfig = func(*v3corepb.GrpcService) (xdsresource.GRPCServiceConfig, error) {
 		return xdsresource.GRPCServiceConfig{}, fmt.Errorf("parseGRPCServiceConfig not implemented")
 	}
-	createExtProcChannel = func(xdsresource.GRPCServiceConfig) (grpc.ClientConnInterface, func() error, error) {
+	createExtProcChannel = func(xdsresource.GRPCServiceConfig, ...grpc.DialOption) (grpc.ClientConnInterface, func() error, error) {
 		return nil, nil, fmt.Errorf("dialing external processing server not implemented")
 	}
 )
@@ -194,17 +194,19 @@ func (builder) IsTerminal() bool {
 	return false
 }
 
-func (builder) BuildClientFilter(httpfilter.ClientFilterOptions) httpfilter.ClientFilter {
-	return clientFilter{}
+func (builder) BuildClientFilter(opts httpfilter.ClientFilterOptions) httpfilter.ClientFilter {
+	return clientFilter{childDialOpts: opts.ChildDialOpts}
 }
 
 var _ httpfilter.ClientFilterBuilder = builder{}
 
-type clientFilter struct{}
+type clientFilter struct {
+	childDialOpts []grpc.DialOption
+}
 
 func (clientFilter) Close() {}
 
-func (clientFilter) BuildClientInterceptor(base, override httpfilter.FilterConfig) (httpfilter.ClientInterceptor, error) {
+func (cf clientFilter) BuildClientInterceptor(base, override httpfilter.FilterConfig) (httpfilter.ClientInterceptor, error) {
 	b, ok := base.(baseConfig)
 	if !ok {
 		return nil, fmt.Errorf("extproc: incorrect config type provided (%T): %v", base, base)
@@ -221,7 +223,12 @@ func (clientFilter) BuildClientInterceptor(base, override httpfilter.FilterConfi
 	config := newInterceptorConfig(b, ov)
 
 	// Create a channel to the external processing server.
-	cc, cancel, err := createExtProcChannel(config.server)
+	combinedOpts := make([]grpc.DialOption, 0, len(cf.childDialOpts)*2)
+	combinedOpts = append(combinedOpts, cf.childDialOpts...)
+	if len(cf.childDialOpts) > 0 {
+		combinedOpts = append(combinedOpts, grpc.WithChildDialOptions(cf.childDialOpts...))
+	}
+	cc, cancel, err := createExtProcChannel(config.server, combinedOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("extproc: failed to create client: %v", err)
 	}

--- a/internal/xds/httpfilter/httpfilter.go
+++ b/internal/xds/httpfilter/httpfilter.go
@@ -90,6 +90,9 @@ type ClientInterceptor interface {
 // ClientFilterOptions contains options for building a client filter.
 type ClientFilterOptions struct {
 	FilterName string // FilterName is the filter name from the xDS configuration.
+	// ChildDialOpts specifies the dial options to be applied to any child
+	// channels created by components on this channel.
+	ChildDialOpts []grpc.DialOption
 }
 
 // ClientFilterBuilder is an optional interface that a Builder can implement to

--- a/internal/xds/resolver/internal/internal.go
+++ b/internal/xds/resolver/internal/internal.go
@@ -26,5 +26,5 @@ var (
 	NewWRR any // func() wrr.WRR
 
 	// NewXDSClient is the function used to create a new xDS client.
-	NewXDSClient any // func(string, estats.MetricsRecorder) (xdsclient.XDSClient, func(), error)
+	NewXDSClient any // func(string, estats.MetricsRecorder, ...grpc.DialOption) (xdsclient.XDSClient, func(), error)
 )

--- a/internal/xds/resolver/xds_resolver.go
+++ b/internal/xds/resolver/xds_resolver.go
@@ -55,7 +55,7 @@ const Scheme = "xds"
 // the provided config and a new xDS client in that pool.
 func newBuilderWithConfigForTesting(config []byte) (resolver.Builder, error) {
 	return &xdsResolverBuilder{
-		newXDSClient: func(name string, mr estats.MetricsRecorder) (xdsclient.XDSClient, func(), error) {
+		newXDSClient: func(name string, mr estats.MetricsRecorder, opts ...grpc.DialOption) (xdsclient.XDSClient, func(), error) {
 			config, err := bootstrap.NewConfigFromContents(config)
 			if err != nil {
 				return nil, nil, err
@@ -64,6 +64,7 @@ func newBuilderWithConfigForTesting(config []byte) (resolver.Builder, error) {
 			return pool.NewClientForTesting(xdsclient.OptionsForTesting{
 				Name:            name,
 				MetricsRecorder: mr,
+				DialOpts:        opts,
 			})
 		},
 	}, nil
@@ -74,10 +75,11 @@ func newBuilderWithConfigForTesting(config []byte) (resolver.Builder, error) {
 // specific xds client pool being used.
 func newBuilderWithPoolForTesting(pool *xdsclient.Pool) (resolver.Builder, error) {
 	return &xdsResolverBuilder{
-		newXDSClient: func(name string, mr estats.MetricsRecorder) (xdsclient.XDSClient, func(), error) {
+		newXDSClient: func(name string, mr estats.MetricsRecorder, opts ...grpc.DialOption) (xdsclient.XDSClient, func(), error) {
 			return pool.NewClientForTesting(xdsclient.OptionsForTesting{
 				Name:            name,
 				MetricsRecorder: mr,
+				DialOpts:        opts,
 			})
 		},
 	}, nil
@@ -88,7 +90,7 @@ func newBuilderWithPoolForTesting(pool *xdsclient.Pool) (resolver.Builder, error
 // specific xDS client being used.
 func newBuilderWithClientForTesting(client xdsclient.XDSClient) (resolver.Builder, error) {
 	return &xdsResolverBuilder{
-		newXDSClient: func(string, estats.MetricsRecorder) (xdsclient.XDSClient, func(), error) {
+		newXDSClient: func(string, estats.MetricsRecorder, ...grpc.DialOption) (xdsclient.XDSClient, func(), error) {
 			// Returning an empty close func here means that the responsibility
 			// of closing the client lies with the caller.
 			return client, func() {}, nil
@@ -107,7 +109,7 @@ func init() {
 }
 
 type xdsResolverBuilder struct {
-	newXDSClient func(string, estats.MetricsRecorder) (xdsclient.XDSClient, func(), error)
+	newXDSClient func(string, estats.MetricsRecorder, ...grpc.DialOption) (xdsclient.XDSClient, func(), error)
 }
 
 // Build helps implement the resolver.Builder interface.
@@ -115,12 +117,20 @@ type xdsResolverBuilder struct {
 // The xds bootstrap process is performed (and a new xDS client is built) every
 // time an xds resolver is built.
 func (b *xdsResolverBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (_ resolver.Resolver, retErr error) {
+	var childDialOpts []grpc.DialOption
+	if len(opts.ChildDialOpts) > 0 {
+		childDialOpts = make([]grpc.DialOption, len(opts.ChildDialOpts))
+		for i, opt := range opts.ChildDialOpts {
+			childDialOpts[i] = opt.(grpc.DialOption)
+		}
+	}
+
 	// Initialize the xDS client.
-	newXDSClient := rinternal.NewXDSClient.(func(string, estats.MetricsRecorder) (xdsclient.XDSClient, func(), error))
+	newXDSClient := rinternal.NewXDSClient.(func(string, estats.MetricsRecorder, ...grpc.DialOption) (xdsclient.XDSClient, func(), error))
 	if b.newXDSClient != nil {
 		newXDSClient = b.newXDSClient
 	}
-	client, xdsClientClose, err := newXDSClient(target.String(), opts.MetricsRecorder)
+	client, xdsClientClose, err := newXDSClient(target.String(), opts.MetricsRecorder, childDialOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("xds: failed to create xds-client: %v", err)
 	}
@@ -142,6 +152,7 @@ func (b *xdsResolverBuilder) Build(target resolver.Target, cc resolver.ClientCon
 		httpFilters:     make(map[clientFilterKey]httpfilter.ClientFilter),
 		channelID:       rand.Uint64(),
 		ldsResourceName: ldsResourceName,
+		childDialOpts:   childDialOpts,
 
 		// serializer used to synchronize the following:
 		// - updates from the dependency manager. This could lead to generation
@@ -264,7 +275,8 @@ type xdsResolver struct {
 	// lives here so that the resolver can reuse filter instances across config
 	// updates when the same filter is specified, and to be able to clean up
 	// filter instances that are no longer used.
-	httpFilters map[clientFilterKey]httpfilter.ClientFilter
+	httpFilters   map[clientFilterKey]httpfilter.ClientFilter
+	childDialOpts []grpc.DialOption
 }
 
 // ResolveNow calls RequestDNSReresolution on the dependency manager.
@@ -685,7 +697,10 @@ func (r *xdsResolver) getOrCreateClientFilter(builder httpfilter.ClientFilterBui
 		return clientFilter
 	}
 
-	cf := builder.BuildClientFilter(httpfilter.ClientFilterOptions{FilterName: key.name})
+	cf := builder.BuildClientFilter(httpfilter.ClientFilterOptions{
+		FilterName:    key.name,
+		ChildDialOpts: r.childDialOpts,
+	})
 	r.httpFilters[key] = cf
 	return cf
 }

--- a/internal/xds/resolver/xds_resolver_test.go
+++ b/internal/xds/resolver/xds_resolver_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	estats "google.golang.org/grpc/experimental/stats"
 	"google.golang.org/grpc/internal"
@@ -257,7 +258,7 @@ func (s) TestResolverCloseClosesXDSClient(t *testing.T) {
 	// client is closed.
 	origNewClient := rinternal.NewXDSClient
 	closeCh := make(chan struct{})
-	rinternal.NewXDSClient = func(string, estats.MetricsRecorder) (xdsclient.XDSClient, func(), error) {
+	rinternal.NewXDSClient = func(string, estats.MetricsRecorder, ...grpc.DialOption) (xdsclient.XDSClient, func(), error) {
 		bc := e2e.DefaultBootstrapContents(t, uuid.New().String(), "dummy-management-server-address")
 		config, err := bootstrap.NewConfigFromContents(bc)
 		if err != nil {

--- a/internal/xds/xdsclient/clientimpl.go
+++ b/internal/xds/xdsclient/clientimpl.go
@@ -134,8 +134,8 @@ func (mr *metricsReporter) ReportMetric(metric any) {
 	}
 }
 
-func newClientImpl(config *bootstrap.Config, metricsRecorder estats.MetricsRecorder, target string, watchExpiryTimeout time.Duration) (*clientImpl, error) {
-	gConfig, err := BuildXDSClientConfig(config, metricsRecorder, target, watchExpiryTimeout)
+func newClientImpl(config *bootstrap.Config, metricsRecorder estats.MetricsRecorder, target string, watchExpiryTimeout time.Duration, opts ...grpc.DialOption) (*clientImpl, error) {
+	gConfig, err := BuildXDSClientConfig(config, metricsRecorder, target, watchExpiryTimeout, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -176,10 +176,10 @@ func (c *clientImpl) decrRef() int32 {
 	return atomic.AddInt32(&c.refCount, -1)
 }
 
-func buildServerConfigs(bootstrapSC []*bootstrap.ServerConfig, grpcTransportConfigs map[string]grpctransport.Config, gServerCfgMap map[xdsclient.ServerConfig]*bootstrap.ServerConfig) ([]xdsclient.ServerConfig, error) {
+func buildServerConfigs(bootstrapSC []*bootstrap.ServerConfig, grpcTransportConfigs map[string]grpctransport.Config, gServerCfgMap map[xdsclient.ServerConfig]*bootstrap.ServerConfig, childDialOpts ...grpc.DialOption) ([]xdsclient.ServerConfig, error) {
 	var gServerCfg []xdsclient.ServerConfig
 	for _, sc := range bootstrapSC {
-		if err := populateGRPCTransportConfigsFromServerConfig(sc, grpcTransportConfigs); err != nil {
+		if err := populateGRPCTransportConfigsFromServerConfig(sc, grpcTransportConfigs, childDialOpts...); err != nil {
 			return nil, err
 		}
 		var serverFeatures xdsclient.ServerFeature
@@ -205,7 +205,7 @@ func buildServerConfigs(bootstrapSC []*bootstrap.ServerConfig, grpcTransportConf
 // BuildXDSClientConfig builds the xdsclient.Config from the bootstrap.Config.
 //
 // This function is exported for fuzz testing purposes only.
-func BuildXDSClientConfig(config *bootstrap.Config, metricsRecorder estats.MetricsRecorder, target string, watchExpiryTimeout time.Duration) (xdsclient.Config, error) {
+func BuildXDSClientConfig(config *bootstrap.Config, metricsRecorder estats.MetricsRecorder, target string, watchExpiryTimeout time.Duration, childDialOpts ...grpc.DialOption) (xdsclient.Config, error) {
 	grpcTransportConfigs := make(map[string]grpctransport.Config)
 	gServerCfgMap := make(map[xdsclient.ServerConfig]*bootstrap.ServerConfig)
 
@@ -217,14 +217,14 @@ func BuildXDSClientConfig(config *bootstrap.Config, metricsRecorder estats.Metri
 		if len(cfg.XDSServers) >= 1 {
 			serverCfg = cfg.XDSServers
 		}
-		gsc, err := buildServerConfigs(serverCfg, grpcTransportConfigs, gServerCfgMap)
+		gsc, err := buildServerConfigs(serverCfg, grpcTransportConfigs, gServerCfgMap, childDialOpts...)
 		if err != nil {
 			return xdsclient.Config{}, err
 		}
 		gAuthorities[name] = xdsclient.Authority{XDSServers: gsc}
 	}
 
-	gServerCfgs, err := buildServerConfigs(config.XDSServers(), grpcTransportConfigs, gServerCfgMap)
+	gServerCfgs, err := buildServerConfigs(config.XDSServers(), grpcTransportConfigs, gServerCfgMap, childDialOpts...)
 	if err != nil {
 		return xdsclient.Config{}, err
 	}
@@ -259,7 +259,7 @@ func BuildXDSClientConfig(config *bootstrap.Config, metricsRecorder estats.Metri
 // populateGRPCTransportConfigsFromServerConfig iterates through the channel
 // credentials of the provided server configuration, builds credential bundles,
 // and populates the grpctransport.Config map.
-func populateGRPCTransportConfigsFromServerConfig(sc *bootstrap.ServerConfig, grpcTransportConfigs map[string]grpctransport.Config) error {
+func populateGRPCTransportConfigsFromServerConfig(sc *bootstrap.ServerConfig, grpcTransportConfigs map[string]grpctransport.Config, childDialOpts ...grpc.DialOption) error {
 	for _, cc := range sc.ChannelCreds() {
 		c := xdsbootstrap.GetChannelCredentials(cc.Type)
 		if c == nil {
@@ -272,8 +272,14 @@ func populateGRPCTransportConfigsFromServerConfig(sc *bootstrap.ServerConfig, gr
 		grpcTransportConfigs[cc.Type] = grpctransport.Config{
 			Credentials: bundle,
 			GRPCNewClient: func(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-				opts = append(opts, sc.DialOptions()...)
-				return grpc.NewClient(target, opts...)
+				combinedOpts := make([]grpc.DialOption, 0, len(childDialOpts)+len(opts)+len(sc.DialOptions())+1)
+				combinedOpts = append(combinedOpts, childDialOpts...)
+				combinedOpts = append(combinedOpts, opts...)
+				combinedOpts = append(combinedOpts, sc.DialOptions()...)
+				if len(childDialOpts) > 0 {
+					combinedOpts = append(combinedOpts, grpc.WithChildDialOptions(childDialOpts...))
+				}
+				return grpc.NewClient(target, combinedOpts...)
 			},
 		}
 	}

--- a/internal/xds/xdsclient/pool.go
+++ b/internal/xds/xdsclient/pool.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	v3statuspb "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
+	"google.golang.org/grpc"
 	estats "google.golang.org/grpc/experimental/stats"
 	"google.golang.org/grpc/internal/envconfig"
 	istats "google.golang.org/grpc/internal/stats"
@@ -78,6 +79,8 @@ type OptionsForTesting struct {
 	// the client. If unset, the client will use the config provided by env
 	// variables.
 	Config *bootstrap.Config
+	// DialOpts specifies dial options for testing.
+	DialOpts []grpc.DialOption
 }
 
 // NewPool creates a new xDS client pool with the given bootstrap config.
@@ -103,8 +106,8 @@ func NewPool(config *bootstrap.Config) *Pool {
 // The second return value represents a close function which the caller is
 // expected to invoke once they are done using the client.  It is safe for the
 // caller to invoke this close function multiple times.
-func (p *Pool) NewClientWithConfig(name string, metricsRecorder estats.MetricsRecorder, config *bootstrap.Config) (XDSClient, func(), error) {
-	return p.newRefCounted(name, metricsRecorder, defaultWatchExpiryTimeout, config)
+func (p *Pool) NewClientWithConfig(name string, metricsRecorder estats.MetricsRecorder, config *bootstrap.Config, opts ...grpc.DialOption) (XDSClient, func(), error) {
+	return p.newRefCounted(name, metricsRecorder, defaultWatchExpiryTimeout, config, opts...)
 }
 
 // NewClient returns an xDS client with the given name from the pool. If the
@@ -114,8 +117,8 @@ func (p *Pool) NewClientWithConfig(name string, metricsRecorder estats.MetricsRe
 // The second return value represents a close function which the caller is
 // expected to invoke once they are done using the client.  It is safe for the
 // caller to invoke this close function multiple times.
-func (p *Pool) NewClient(name string, metricsRecorder estats.MetricsRecorder) (XDSClient, func(), error) {
-	return p.newRefCounted(name, metricsRecorder, defaultWatchExpiryTimeout, nil)
+func (p *Pool) NewClient(name string, metricsRecorder estats.MetricsRecorder, opts ...grpc.DialOption) (XDSClient, func(), error) {
+	return p.newRefCounted(name, metricsRecorder, defaultWatchExpiryTimeout, nil, opts...)
 }
 
 // NewClientForTesting returns an xDS client configured with the provided
@@ -142,7 +145,7 @@ func (p *Pool) NewClientForTesting(opts OptionsForTesting) (XDSClient, func(), e
 	if opts.MetricsRecorder == nil {
 		opts.MetricsRecorder = istats.NewMetricsRecorderList(nil)
 	}
-	c, cancel, err := p.newRefCounted(opts.Name, opts.MetricsRecorder, opts.WatchExpiryTimeout, opts.Config)
+	c, cancel, err := p.newRefCounted(opts.Name, opts.MetricsRecorder, opts.WatchExpiryTimeout, opts.Config, opts.DialOpts...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -268,7 +271,7 @@ func (p *Pool) clientRefCountedClose(name string) {
 // newRefCounted creates a new reference counted xDS client implementation for
 // name, if one does not exist already. If an xDS client for the given name
 // exists, it gets a reference to it and returns it.
-func (p *Pool) newRefCounted(name string, metricsRecorder estats.MetricsRecorder, watchExpiryTimeout time.Duration, bConfig *bootstrap.Config) (*clientImpl, func(), error) {
+func (p *Pool) newRefCounted(name string, metricsRecorder estats.MetricsRecorder, watchExpiryTimeout time.Duration, bConfig *bootstrap.Config, opts ...grpc.DialOption) (*clientImpl, func(), error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -296,7 +299,7 @@ func (p *Pool) newRefCounted(name string, metricsRecorder estats.MetricsRecorder
 		return nil, nil, fmt.Errorf("failed to read xDS bootstrap config from env vars: bootstrap environment variables (%q or %q) not defined and fallback config not set", envconfig.XDSBootstrapFileNameEnv, envconfig.XDSBootstrapFileContentEnv)
 	}
 
-	c, err := newClientImpl(config, metricsRecorder, name, watchExpiryTimeout)
+	c, err := newClientImpl(config, metricsRecorder, name, watchExpiryTimeout, opts...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -178,6 +178,10 @@ type BuildOptions struct {
 	Authority string
 	// MetricsRecorder is the metrics recorder to do recording.
 	MetricsRecorder stats.MetricsRecorder
+	// ChildDialOpts specifies the dial options to be applied to any child
+	// channels created by components on this channel. These are passed as
+	// []any (unexported/empty interfaces) to avoid circular imports.
+	ChildDialOpts []any
 }
 
 // An Endpoint is one network endpoint, or server, which may have multiple

--- a/resolver_wrapper.go
+++ b/resolver_wrapper.go
@@ -72,6 +72,13 @@ func (ccr *ccResolverWrapper) start() error {
 			errCh <- ctx.Err()
 			return
 		}
+		var childDialOpts []any
+		if len(ccr.cc.dopts.childDialOpts) > 0 {
+			childDialOpts = make([]any, len(ccr.cc.dopts.childDialOpts))
+			for i, opt := range ccr.cc.dopts.childDialOpts {
+				childDialOpts[i] = opt
+			}
+		}
 		opts := resolver.BuildOptions{
 			DisableServiceConfig: ccr.cc.dopts.disableServiceConfig,
 			DialCreds:            ccr.cc.dopts.copts.TransportCredentials,
@@ -79,6 +86,7 @@ func (ccr *ccResolverWrapper) start() error {
 			Dialer:               ccr.cc.dopts.copts.Dialer,
 			Authority:            ccr.cc.authority,
 			MetricsRecorder:      ccr.cc.metricsRecorderList,
+			ChildDialOpts:        childDialOpts,
 		}
 		var err error
 		// The delegating resolver is used unless:

--- a/server.go
+++ b/server.go
@@ -89,6 +89,16 @@ func init() {
 	internal.MetricsRecorderForServer = func(srv *Server) estats.MetricsRecorder {
 		return istats.NewMetricsRecorderList(srv.opts.statsHandlers)
 	}
+	internal.GetServerChildDialOptions = func(srv *Server) []any {
+		if len(srv.opts.childDialOpts) == 0 {
+			return nil
+		}
+		opts := make([]any, len(srv.opts.childDialOpts))
+		for i, opt := range srv.opts.childDialOpts {
+			opts[i] = opt
+		}
+		return opts
+	}
 }
 
 var statusOK = status.New(codes.OK, "")
@@ -183,6 +193,7 @@ type serverOptions struct {
 	bufferPool            mem.BufferPool
 	waitForHandlers       bool
 	staticWindowSize      bool
+	childDialOpts         []DialOption
 }
 
 var defaultServerOptions = serverOptions{
@@ -660,6 +671,19 @@ func WaitForHandlers(w bool) ServerOption {
 func bufferPool(bufferPool mem.BufferPool) ServerOption {
 	return newFuncServerOption(func(o *serverOptions) {
 		o.bufferPool = bufferPool
+	})
+}
+
+// ChildDialOptions returns a ServerOption that specifies the dial options
+// to be applied to any child channels created by components on this server.
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func ChildDialOptions(opts ...DialOption) ServerOption {
+	return newFuncServerOption(func(o *serverOptions) {
+		o.childDialOpts = append(o.childDialOpts, opts...)
 	})
 }
 

--- a/version.go
+++ b/version.go
@@ -19,4 +19,4 @@
 package grpc
 
 // Version is the current grpc version.
-const Version = "1.83.0-dev"
+const Version = "1.84.0-dev"

--- a/xds/server.go
+++ b/xds/server.go
@@ -86,8 +86,17 @@ func NewGRPCServer(opts ...grpc.ServerOption) (*GRPCServer, error) {
 
 	var mrl estats.MetricsRecorder
 	mrl = istats.NewMetricsRecorderList(nil)
+	var childDialOpts []grpc.DialOption
 	if srv, ok := s.gs.(*grpc.Server); ok { // Will hit in prod but not for testing.
 		mrl = internal.MetricsRecorderForServer.(func(*grpc.Server) estats.MetricsRecorder)(srv)
+		if internal.GetServerChildDialOptions != nil {
+			if rawOpts := internal.GetServerChildDialOptions.(func(*grpc.Server) []any)(srv); len(rawOpts) > 0 {
+				childDialOpts = make([]grpc.DialOption, len(rawOpts))
+				for i, opt := range rawOpts {
+					childDialOpts[i] = opt.(grpc.DialOption)
+				}
+			}
+		}
 	}
 
 	// Initializing the xDS client upfront (instead of at serving time)
@@ -97,7 +106,7 @@ func NewGRPCServer(opts ...grpc.ServerOption) (*GRPCServer, error) {
 	if s.opts.clientPoolForTesting != nil {
 		pool = s.opts.clientPoolForTesting
 	}
-	xdsClient, xdsClientClose, err := pool.NewClient(xdsclient.NameForServer, mrl)
+	xdsClient, xdsClientClose, err := pool.NewClient(xdsclient.NameForServer, mrl, childDialOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("xDS client creation failed: %v", err)
 	}

--- a/xds/test/child_channel_options_test.go
+++ b/xds/test/child_channel_options_test.go
@@ -1,0 +1,350 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package xds_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal"
+	"google.golang.org/grpc/internal/testutils/xds/e2e"
+	"google.golang.org/grpc/internal/xds/bootstrap"
+	"google.golang.org/grpc/internal/xds/xdsclient"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/xds"
+	xdsbootstrap "google.golang.org/grpc/xds/bootstrap"
+)
+
+// TestChildChannelOptions_Client verifies that user-specified child dial options
+// propagate correctly to client-side channels established with the control plane.
+func (s) TestChildChannelOptions_Client(t *testing.T) {
+	userAgentCh := make(chan string, 10)
+	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{
+		OnStreamOpen: func(ctx context.Context, id int64, typeURL string) error {
+			md, ok := metadata.FromIncomingContext(ctx)
+			t.Logf("OnStreamOpen: md=%v, ok=%v", md, ok)
+			if ok {
+				if ua := md.Get("user-agent"); len(ua) > 0 {
+					select {
+					case userAgentCh <- ua[0]:
+					default:
+					}
+				}
+			}
+			return nil
+		},
+	})
+
+	nodeID := uuid.New().String()
+	bc := e2e.DefaultBootstrapContents(t, nodeID, mgmtServer.Address)
+	config, err := bootstrap.NewConfigFromContents(bc)
+	if err != nil {
+		t.Fatalf("Failed to parse bootstrap contents: %v", err)
+	}
+
+	pool := xdsclient.NewPool(config)
+
+	resolverBuilder, err := internal.NewXDSResolverWithPoolForTesting.(func(*xdsclient.Pool) (resolver.Builder, error))(pool)
+	if err != nil {
+		t.Fatalf("Failed to create xds resolver builder: %v", err)
+	}
+
+	cc, err := grpc.NewClient(
+		"xds:///my-service",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithChildDialOptions(grpc.WithUserAgent("child-agent-client")),
+		grpc.WithResolvers(resolverBuilder),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	defer cc.Close()
+
+	// Trigger resolver build and xDS client connection to management server
+	cc.Connect()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	var gotUA string
+	select {
+	case gotUA = <-userAgentCh:
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for OnStreamOpen to be called on management server")
+	}
+
+	if !strings.Contains(gotUA, "child-agent-client") {
+		t.Errorf("Received user-agent = %q, want it to contain %q", gotUA, "child-agent-client")
+	}
+}
+
+// TestChildChannelOptions_Server verifies that user-specified child dial options
+// propagate correctly to server-side channels established with the control plane.
+func (s) TestChildChannelOptions_Server(t *testing.T) {
+	userAgentCh := make(chan string, 10)
+	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{
+		OnStreamOpen: func(ctx context.Context, id int64, typeURL string) error {
+			md, ok := metadata.FromIncomingContext(ctx)
+			t.Logf("OnStreamOpen: md=%v, ok=%v", md, ok)
+			if ok {
+				if ua := md.Get("user-agent"); len(ua) > 0 {
+					select {
+					case userAgentCh <- ua[0]:
+					default:
+					}
+				}
+			}
+			return nil
+		},
+	})
+
+	nodeID := uuid.New().String()
+	bc := e2e.DefaultBootstrapContents(t, nodeID, mgmtServer.Address)
+	config, err := bootstrap.NewConfigFromContents(bc)
+	if err != nil {
+		t.Fatalf("Failed to parse bootstrap contents: %v", err)
+	}
+
+	pool := xdsclient.NewPool(config)
+
+	xs, err := xds.NewGRPCServer(
+		grpc.ChildDialOptions(grpc.WithUserAgent("child-agent-server")),
+		xds.ClientPoolForTesting(pool),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create xds server: %v", err)
+	}
+	defer xs.Stop()
+
+	// Trigger connection to management server by calling Serve on a listener.
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("Failed to listen: %v", err)
+	}
+	defer lis.Close()
+
+	go xs.Serve(lis)
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	var gotUA string
+	select {
+	case gotUA = <-userAgentCh:
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for OnStreamOpen to be called on management server")
+	}
+
+	if !strings.Contains(gotUA, "child-agent-server") {
+		t.Errorf("Received user-agent = %q, want it to contain %q", gotUA, "child-agent-server")
+	}
+}
+
+type precedenceCredsBuilder struct{}
+
+func (precedenceCredsBuilder) Build(config json.RawMessage) (credentials.Bundle, func(), error) {
+	return precedenceBundle{Bundle: insecure.NewBundle()}, func() {}, nil
+}
+
+func (precedenceCredsBuilder) Name() string {
+	return "precedence-creds"
+}
+
+type precedenceBundle struct {
+	credentials.Bundle
+}
+
+func (precedenceBundle) DialOptions() []grpc.DialOption {
+	return []grpc.DialOption{grpc.WithUserAgent("bootstrap-agent")}
+}
+
+// TestChildChannelOptions_Precedence verifies that options configured in the
+// bootstrap configuration take precedence over child dial options.
+func (s) TestChildChannelOptions_Precedence(t *testing.T) {
+	xdsbootstrap.RegisterChannelCredentials(precedenceCredsBuilder{})
+
+	userAgentCh := make(chan string, 10)
+	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{
+		OnStreamOpen: func(ctx context.Context, id int64, typeURL string) error {
+			md, ok := metadata.FromIncomingContext(ctx)
+			t.Logf("OnStreamOpen: md=%v, ok=%v", md, ok)
+			if ok {
+				if ua := md.Get("user-agent"); len(ua) > 0 {
+					select {
+					case userAgentCh <- ua[0]:
+					default:
+					}
+				}
+			}
+			return nil
+		},
+	})
+
+	nodeID := uuid.New().String()
+	serversJSON := fmt.Sprintf(`[{
+		"server_uri": "passthrough:///%s",
+		"channel_creds": [{"type": "precedence-creds"}]
+	}]`, mgmtServer.Address)
+
+	bc, err := bootstrap.NewContentsForTesting(bootstrap.ConfigOptionsForTesting{
+		Servers: []byte(serversJSON),
+		Node:    []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
+	})
+	if err != nil {
+		t.Fatalf("Failed to create bootstrap configuration: %v", err)
+	}
+
+	config, err := bootstrap.NewConfigFromContents(bc)
+	if err != nil {
+		t.Fatalf("Failed to parse bootstrap contents: %v", err)
+	}
+
+	pool := xdsclient.NewPool(config)
+
+	resolverBuilder, err := internal.NewXDSResolverWithPoolForTesting.(func(*xdsclient.Pool) (resolver.Builder, error))(pool)
+	if err != nil {
+		t.Fatalf("Failed to create xds resolver builder: %v", err)
+	}
+
+	cc, err := grpc.NewClient(
+		"xds:///my-service",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithChildDialOptions(grpc.WithUserAgent("child-agent")),
+		grpc.WithResolvers(resolverBuilder),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	defer cc.Close()
+
+	// Trigger connection
+	cc.Connect()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	var gotUA string
+	select {
+	case gotUA = <-userAgentCh:
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for OnStreamOpen to be called on management server")
+	}
+
+	if !strings.Contains(gotUA, "bootstrap-agent") {
+		t.Errorf("Received user-agent = %q, want it to contain %q", gotUA, "bootstrap-agent")
+	}
+	if strings.Contains(gotUA, "child-agent") {
+		t.Errorf("Received user-agent = %q, want it NOT to contain %q", gotUA, "child-agent")
+	}
+}
+
+// TestChildChannelOptions_SharedResourceIgnoresSubsequent verifies that when
+// an xDS client is shared, subsequent dials with different options do not recreate
+// or modify the connection, and are ignored.
+func (s) TestChildChannelOptions_SharedResourceIgnoresSubsequent(t *testing.T) {
+	userAgentCh := make(chan string, 10)
+	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{
+		OnStreamOpen: func(ctx context.Context, id int64, typeURL string) error {
+			md, ok := metadata.FromIncomingContext(ctx)
+			t.Logf("OnStreamOpen: md=%v, ok=%v", md, ok)
+			if ok {
+				if ua := md.Get("user-agent"); len(ua) > 0 {
+					select {
+					case userAgentCh <- ua[0]:
+					default:
+					}
+				}
+			}
+			return nil
+		},
+	})
+
+	nodeID := uuid.New().String()
+	bc := e2e.DefaultBootstrapContents(t, nodeID, mgmtServer.Address)
+	config, err := bootstrap.NewConfigFromContents(bc)
+	if err != nil {
+		t.Fatalf("Failed to parse bootstrap contents: %v", err)
+	}
+
+	pool := xdsclient.NewPool(config)
+
+	resolverBuilder, err := internal.NewXDSResolverWithPoolForTesting.(func(*xdsclient.Pool) (resolver.Builder, error))(pool)
+	if err != nil {
+		t.Fatalf("Failed to create xds resolver builder: %v", err)
+	}
+
+	cc1, err := grpc.NewClient(
+		"xds:///service-1",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithChildDialOptions(grpc.WithUserAgent("agent-1")),
+		grpc.WithResolvers(resolverBuilder),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create client 1: %v", err)
+	}
+	defer cc1.Close()
+
+	// Trigger connection for cc1
+	cc1.Connect()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	var gotUA1 string
+	select {
+	case gotUA1 = <-userAgentCh:
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for first client connection")
+	}
+
+	if !strings.Contains(gotUA1, "agent-1") {
+		t.Errorf("First connection user-agent = %q, want it to contain %q", gotUA1, "agent-1")
+	}
+
+	cc2, err := grpc.NewClient(
+		"xds:///service-1", // Use the same target name to ensure connection sharing
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithChildDialOptions(grpc.WithUserAgent("agent-2")),
+		grpc.WithResolvers(resolverBuilder),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create client 2: %v", err)
+	}
+	defer cc2.Close()
+
+	// Trigger connection for cc2
+	cc2.Connect()
+
+	select {
+	case gotUA2 := <-userAgentCh:
+		t.Fatalf("A new stream was opened to the management server with user-agent = %q; expected connection sharing", gotUA2)
+	case <-time.After(500 * time.Millisecond):
+		// Success: no new stream was opened, meaning cc2 reused the cached connection/client.
+	}
+}


### PR DESCRIPTION
PR that has been implemented by AI Agent: gRPC Go To Spec Translator
This is for implementation of gRFC A110 (Implement Child Channel Options) in Go language.