### PR TITLE
metadata: Add ValueFromOutgoingContext

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -400,9 +400,11 @@ func ValueFromOutgoingContext(ctx context.Context, key string) []string {
 			panic(fmt.Sprintf("metadata: ValueFromOutgoingContext got an odd number of input pairs for metadata: %d", len(added)))
 		}
 
-		// Case insensitive, like FromOutgoingContext: added isn't guaranteed lowercase.
+		// Case insensitive, like FromOutgoingContext: added isn't guaranteed
+		// lowercase, though AppendToOutgoingContext already lowercases it in
+		// practice, so try the cheap exact match first.
 		for i := 0; i < len(added); i += 2 {
-			if strings.EqualFold(added[i], key) {
+			if added[i] == key || strings.EqualFold(added[i], key) {
 				if vals == nil {
 					vals = make([]string, 0, len(matchedMD)+1)
 					vals = append(vals, matchedMD...)

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -376,21 +376,25 @@ func ValueFromOutgoingContext(ctx context.Context, key string) []string {
 	// checked: raw.added still needs to be walked and accumulated regardless.
 	// The else below prevents that from overwriting an exact match with an
 	// unrelated case-insensitive one.
-	var vals []string
+	var matchedMD []string
 	if v, ok := raw.md[key]; ok {
-		vals = copyOf(v)
+		matchedMD = v
 	} else {
 		for k, v := range raw.md {
 			// Case insensitive comparison: MD is a map, and there's no
 			// guarantee that the MD attached to the context is created using
 			// our helper functions.
 			if strings.EqualFold(k, key) {
-				vals = copyOf(v)
+				matchedMD = v
 				break
 			}
 		}
 	}
 
+	// Defer allocating vals until raw.added actually has a match, so a match
+	// found only in raw.md doesn't pay for both a copyOf and a growing
+	// append.
+	var vals []string
 	for _, added := range raw.added {
 		if len(added)%2 == 1 {
 			panic(fmt.Sprintf("metadata: ValueFromOutgoingContext got an odd number of input pairs for metadata: %d", len(added)))
@@ -399,11 +403,18 @@ func ValueFromOutgoingContext(ctx context.Context, key string) []string {
 		// Case insensitive, like FromOutgoingContext: added isn't guaranteed lowercase.
 		for i := 0; i < len(added); i += 2 {
 			if strings.EqualFold(added[i], key) {
+				if vals == nil {
+					vals = make([]string, 0, len(matchedMD)+1)
+					vals = append(vals, matchedMD...)
+				}
 				vals = append(vals, added[i+1])
 			}
 		}
 	}
 
+	if vals == nil && matchedMD != nil {
+		return copyOf(matchedMD)
+	}
 	return vals
 }
 

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -360,6 +360,49 @@ func FromOutgoingContext(ctx context.Context) (MD, bool) {
 	return out, ok
 }
 
+// ValueFromOutgoingContext returns the metadata value corresponding to the
+// metadata key from the outgoing metadata if it exists. Keys are matched in a
+// case-insensitive manner.
+//
+// Unlike FromOutgoingContext, this does not copy the entire outgoing metadata.
+func ValueFromOutgoingContext(ctx context.Context, key string) []string {
+	raw, ok := ctx.Value(mdOutgoingKey{}).(rawMD)
+	if !ok {
+		return nil
+	}
+
+	key = strings.ToLower(key)
+	var vals []string
+	if v, ok := raw.md[key]; ok {
+		vals = copyOf(v)
+	} else {
+		for k, v := range raw.md {
+			// Case insensitive comparison: MD is a map, and there's no
+			// guarantee that the MD attached to the context is created using
+			// our helper functions.
+			if strings.EqualFold(k, key) {
+				vals = copyOf(v)
+				break
+			}
+		}
+	}
+
+	for _, added := range raw.added {
+		if len(added)%2 == 1 {
+			panic(fmt.Sprintf("metadata: ValueFromOutgoingContext got an odd number of input pairs for metadata: %d", len(added)))
+		}
+
+		// Case insensitive, like FromOutgoingContext: added isn't guaranteed lowercase.
+		for i := 0; i < len(added); i += 2 {
+			if strings.EqualFold(added[i], key) {
+				vals = append(vals, added[i+1])
+			}
+		}
+	}
+
+	return vals
+}
+
 type rawMD struct {
 	md    MD
 	added [][]string

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -372,6 +372,10 @@ func ValueFromOutgoingContext(ctx context.Context, key string) []string {
 	}
 
 	key = strings.ToLower(key)
+	// Unlike ValueFromIncomingContext, this can't return as soon as raw.md is
+	// checked: raw.added still needs to be walked and accumulated regardless.
+	// The else below prevents that from overwriting an exact match with an
+	// unrelated case-insensitive one.
 	var vals []string
 	if v, ok := raw.md[key]; ok {
 		vals = copyOf(v)

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -20,6 +20,7 @@ package metadata
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strconv"
 	"testing"
@@ -342,6 +343,93 @@ func (s) TestAppendToOutgoingContext_FromKVSlice(t *testing.T) {
 	}
 }
 
+func (s) TestValueFromOutgoingContext(t *testing.T) {
+	tCtx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	md := Pairs(
+		"X-My-Header-1", "42",
+		"x-my-header-3", "44",
+	)
+	// Verify that we match case-insensitively even if callers directly
+	// modify md.
+	md["X-INCORRECT-UPPERCASE"] = []string{"foo"}
+	ctx := NewOutgoingContext(tCtx, md)
+	ctx = AppendToOutgoingContext(ctx, "x-my-header-2", "43-1")
+	ctx = AppendToOutgoingContext(ctx, "X-My-Header-2", "43-2")
+
+	for _, test := range []struct {
+		key  string
+		want []string
+	}{
+		{
+			key:  "x-my-header-1",
+			want: []string{"42"},
+		},
+		{
+			// Split across raw.md (none here) and two AppendToOutgoingContext
+			// calls (raw.added) — must accumulate across all of them, in
+			// call order, same as FromOutgoingContext.
+			key:  "x-my-header-2",
+			want: []string{"43-1", "43-2"},
+		},
+		{
+			key:  "x-my-header-3",
+			want: []string{"44"},
+		},
+		{
+			key:  "x-unknown",
+			want: nil,
+		},
+		{
+			key:  "x-incorrect-uppercase",
+			want: []string{"foo"},
+		},
+	} {
+		v := ValueFromOutgoingContext(ctx, test.key)
+		if !reflect.DeepEqual(v, test.want) {
+			t.Errorf("ValueFromOutgoingContext(ctx, %q) = %v, want %v", test.key, v, test.want)
+		}
+	}
+
+	// Accumulate raw.md with later appends, in order.
+	mergeCtx := NewOutgoingContext(tCtx, Pairs("k1", "v1", "k2", "v2"))
+	mergeCtx = AppendToOutgoingContext(mergeCtx, "k1", "v3")
+	mergeCtx = AppendToOutgoingContext(mergeCtx, "k1", "v4")
+	if v, want := ValueFromOutgoingContext(mergeCtx, "k1"), []string{"v1", "v3", "v4"}; !reflect.DeepEqual(v, want) {
+		t.Errorf("ValueFromOutgoingContext(ctx, \"k1\") = %v, want %v", v, want)
+	}
+
+	// No outgoing metadata at all.
+	if v := ValueFromOutgoingContext(tCtx, "x-my-header-1"); v != nil {
+		t.Errorf("ValueFromOutgoingContext on context with no outgoing metadata = %v, want nil", v)
+	}
+}
+
+func (s) TestValueFromOutgoingContext_AddedCaseInsensitive(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	ctx = context.WithValue(ctx, mdOutgoingKey{}, rawMD{added: [][]string{{"X-My-Header", "42"}}})
+
+	if v, want := ValueFromOutgoingContext(ctx, "x-my-header"), []string{"42"}; !reflect.DeepEqual(v, want) {
+		t.Errorf("ValueFromOutgoingContext(ctx, \"x-my-header\") = %v, want %v", v, want)
+	}
+}
+
+func (s) TestValueFromOutgoingContext_PanicsOnOddPairs(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("ValueFromOutgoingContext did not panic on an odd number of pairs in added")
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	ctx = context.WithValue(ctx, mdOutgoingKey{}, rawMD{added: [][]string{{"key-without-a-value"}}})
+
+	ValueFromOutgoingContext(ctx, "key-without-a-value")
+}
+
 // Old/slow approach to adding metadata to context
 func Benchmark_AddingMetadata_ContextManipulationApproach(b *testing.B) {
 	// TODO: Add in N=1-100 tests once Go1.6 support is removed.
@@ -379,6 +467,38 @@ func BenchmarkFromOutgoingContext(b *testing.B) {
 	}
 }
 
+// Reading one key out of many staged headers
+func BenchmarkValueFromOutgoingContextVsFromOutgoingContext(b *testing.B) {
+	for _, numHeaders := range []int{1, 10, 50} {
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+		defer cancel()
+		md := MD{}
+		for i := 0; i < numHeaders; i++ {
+			md[strconv.Itoa(i)] = []string{strconv.Itoa(i)}
+		}
+		ctx = NewOutgoingContext(ctx, md)
+		ctx = AppendToOutgoingContext(ctx, "target-key", "target-value")
+
+		b.Run(fmt.Sprintf("FromOutgoingContext/n=%d", numHeaders), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				out, _ := FromOutgoingContext(ctx)
+				if len(out["target-key"]) != 1 {
+					b.Fatal("ensures not optimized away")
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("ValueFromOutgoingContext/n=%d", numHeaders), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				result := ValueFromOutgoingContext(ctx, "target-key")
+				if len(result) != 1 {
+					b.Fatal("ensures not optimized away")
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkFromIncomingContext(b *testing.B) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
@@ -409,6 +529,31 @@ func BenchmarkValueFromIncomingContext(b *testing.B) {
 	b.Run("key-not-found", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			result := ValueFromIncomingContext(ctx, "key-not-found")
+			if len(result) != 0 {
+				b.Fatal("ensures not optimized away")
+			}
+		}
+	})
+}
+
+func BenchmarkValueFromOutgoingContext(b *testing.B) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	ctx = NewOutgoingContext(ctx, MD{"k3": {"v3", "v4"}})
+	ctx = AppendToOutgoingContext(ctx, "k1", "v1", "k2", "v2")
+
+	b.Run("key-found", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			result := ValueFromOutgoingContext(ctx, "k1")
+			if len(result) != 1 {
+				b.Fatal("ensures not optimized away")
+			}
+		}
+	})
+
+	b.Run("key-not-found", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			result := ValueFromOutgoingContext(ctx, "key-not-found")
 			if len(result) != 0 {
 				b.Fatal("ensures not optimized away")
 			}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -554,6 +554,15 @@ func BenchmarkValueFromOutgoingContext(b *testing.B) {
 			ValueFromOutgoingContext(ctx, "key-not-found")
 		}
 	})
+
+	// Key present in both raw.md ("k3") and raw.added (appended below) —
+	// exercises the accumulate-across-both path, not just append-to-nil.
+	bothCtx := AppendToOutgoingContext(ctx, "k3", "v5")
+	b.Run("key-found-in-md-and-added", func(b *testing.B) {
+		for b.Loop() {
+			ValueFromOutgoingContext(bothCtx, "k3")
+		}
+	})
 }
 
 // TestString verifies that String shows keys and values only for keys known to

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/internal/grpctest"
 )
 
@@ -344,19 +345,23 @@ func (s) TestAppendToOutgoingContext_FromKVSlice(t *testing.T) {
 }
 
 func (s) TestValueFromOutgoingContext(t *testing.T) {
-	tCtx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
 	md := Pairs(
 		"X-My-Header-1", "42",
 		"x-my-header-3", "44",
+		"k1", "v1",
+		"k2", "v2",
 	)
 	// Verify that we match case-insensitively even if callers directly
 	// modify md.
 	md["X-INCORRECT-UPPERCASE"] = []string{"foo"}
-	ctx := NewOutgoingContext(tCtx, md)
+	ctx = NewOutgoingContext(ctx, md)
 	ctx = AppendToOutgoingContext(ctx, "x-my-header-2", "43-1")
 	ctx = AppendToOutgoingContext(ctx, "X-My-Header-2", "43-2")
+	ctx = AppendToOutgoingContext(ctx, "k1", "v3")
+	ctx = AppendToOutgoingContext(ctx, "k1", "v4")
 
 	for _, test := range []struct {
 		key  string
@@ -367,9 +372,8 @@ func (s) TestValueFromOutgoingContext(t *testing.T) {
 			want: []string{"42"},
 		},
 		{
-			// Split across raw.md (none here) and two AppendToOutgoingContext
-			// calls (raw.added) — must accumulate across all of them, in
-			// call order, same as FromOutgoingContext.
+			// Split across two AppendToOutgoingContext calls (raw.added) —
+			// must accumulate across both, in call order.
 			key:  "x-my-header-2",
 			want: []string{"43-1", "43-2"},
 		},
@@ -385,23 +389,25 @@ func (s) TestValueFromOutgoingContext(t *testing.T) {
 			key:  "x-incorrect-uppercase",
 			want: []string{"foo"},
 		},
+		{
+			// Present in both raw.md and two later AppendToOutgoingContext
+			// calls — must accumulate across all three, in order.
+			key:  "k1",
+			want: []string{"v1", "v3", "v4"},
+		},
 	} {
 		v := ValueFromOutgoingContext(ctx, test.key)
-		if !reflect.DeepEqual(v, test.want) {
-			t.Errorf("ValueFromOutgoingContext(ctx, %q) = %v, want %v", test.key, v, test.want)
+		if diff := cmp.Diff(test.want, v); diff != "" {
+			t.Errorf("ValueFromOutgoingContext(ctx, %q) returned unexpected diff (-want +got):\n%s", test.key, diff)
 		}
 	}
+}
 
-	// Accumulate raw.md with later appends, in order.
-	mergeCtx := NewOutgoingContext(tCtx, Pairs("k1", "v1", "k2", "v2"))
-	mergeCtx = AppendToOutgoingContext(mergeCtx, "k1", "v3")
-	mergeCtx = AppendToOutgoingContext(mergeCtx, "k1", "v4")
-	if v, want := ValueFromOutgoingContext(mergeCtx, "k1"), []string{"v1", "v3", "v4"}; !reflect.DeepEqual(v, want) {
-		t.Errorf("ValueFromOutgoingContext(ctx, \"k1\") = %v, want %v", v, want)
-	}
+func (s) TestValueFromOutgoingContext_NoMetadata(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
 
-	// No outgoing metadata at all.
-	if v := ValueFromOutgoingContext(tCtx, "x-my-header-1"); v != nil {
+	if v := ValueFromOutgoingContext(ctx, "x-my-header-1"); v != nil {
 		t.Errorf("ValueFromOutgoingContext on context with no outgoing metadata = %v, want nil", v)
 	}
 }
@@ -411,8 +417,9 @@ func (s) TestValueFromOutgoingContext_AddedCaseInsensitive(t *testing.T) {
 	defer cancel()
 	ctx = context.WithValue(ctx, mdOutgoingKey{}, rawMD{added: [][]string{{"X-My-Header", "42"}}})
 
-	if v, want := ValueFromOutgoingContext(ctx, "x-my-header"), []string{"42"}; !reflect.DeepEqual(v, want) {
-		t.Errorf("ValueFromOutgoingContext(ctx, \"x-my-header\") = %v, want %v", v, want)
+	v := ValueFromOutgoingContext(ctx, "x-my-header")
+	if diff := cmp.Diff([]string{"42"}, v); diff != "" {
+		t.Errorf("ValueFromOutgoingContext(ctx, \"x-my-header\") returned unexpected diff (-want +got):\n%s", diff)
 	}
 }
 

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -538,29 +538,33 @@ func BenchmarkValueFromIncomingContext(b *testing.B) {
 }
 
 func BenchmarkValueFromOutgoingContext(b *testing.B) {
+	// Realistic-length gRPC metadata keys, not "k1"/"k2"/"k3": short keys
+	// understate the cost of strings.EqualFold relative to a cheap exact
+	// match, which matters for the key-found cases below.
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	ctx = NewOutgoingContext(ctx, MD{"k3": {"v3", "v4"}})
-	ctx = AppendToOutgoingContext(ctx, "k1", "v1", "k2", "v2")
+	ctx = NewOutgoingContext(ctx, MD{"content-type": {"application/grpc"}})
+	ctx = AppendToOutgoingContext(ctx, "grpc-timeout", "10S", "x-request-id", "abc-def-123")
 
 	b.Run("key-found", func(b *testing.B) {
 		for b.Loop() {
-			ValueFromOutgoingContext(ctx, "k1")
+			ValueFromOutgoingContext(ctx, "grpc-timeout")
 		}
 	})
 
 	b.Run("key-not-found", func(b *testing.B) {
 		for b.Loop() {
-			ValueFromOutgoingContext(ctx, "key-not-found")
+			ValueFromOutgoingContext(ctx, "x-does-not-exist")
 		}
 	})
 
-	// Key present in both raw.md ("k3") and raw.added (appended below) —
-	// exercises the accumulate-across-both path, not just append-to-nil.
-	bothCtx := AppendToOutgoingContext(ctx, "k3", "v5")
+	// Key present in both raw.md ("content-type") and raw.added (appended
+	// below) — exercises the accumulate-across-both path, not just
+	// append-to-nil.
+	bothCtx := AppendToOutgoingContext(ctx, "content-type", "application/grpc+proto")
 	b.Run("key-found-in-md-and-added", func(b *testing.B) {
 		for b.Loop() {
-			ValueFromOutgoingContext(bothCtx, "k3")
+			ValueFromOutgoingContext(bothCtx, "content-type")
 		}
 	})
 }

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -487,20 +487,14 @@ func BenchmarkValueFromOutgoingContextVsFromOutgoingContext(b *testing.B) {
 		ctx = AppendToOutgoingContext(ctx, "target-key", "target-value")
 
 		b.Run(fmt.Sprintf("FromOutgoingContext/n=%d", numHeaders), func(b *testing.B) {
-			for n := 0; n < b.N; n++ {
-				out, _ := FromOutgoingContext(ctx)
-				if len(out["target-key"]) != 1 {
-					b.Fatal("ensures not optimized away")
-				}
+			for b.Loop() {
+				FromOutgoingContext(ctx)
 			}
 		})
 
 		b.Run(fmt.Sprintf("ValueFromOutgoingContext/n=%d", numHeaders), func(b *testing.B) {
-			for n := 0; n < b.N; n++ {
-				result := ValueFromOutgoingContext(ctx, "target-key")
-				if len(result) != 1 {
-					b.Fatal("ensures not optimized away")
-				}
+			for b.Loop() {
+				ValueFromOutgoingContext(ctx, "target-key")
 			}
 		})
 	}
@@ -550,20 +544,14 @@ func BenchmarkValueFromOutgoingContext(b *testing.B) {
 	ctx = AppendToOutgoingContext(ctx, "k1", "v1", "k2", "v2")
 
 	b.Run("key-found", func(b *testing.B) {
-		for n := 0; n < b.N; n++ {
-			result := ValueFromOutgoingContext(ctx, "k1")
-			if len(result) != 1 {
-				b.Fatal("ensures not optimized away")
-			}
+		for b.Loop() {
+			ValueFromOutgoingContext(ctx, "k1")
 		}
 	})
 
 	b.Run("key-not-found", func(b *testing.B) {
-		for n := 0; n < b.N; n++ {
-			result := ValueFromOutgoingContext(ctx, "key-not-found")
-			if len(result) != 0 {
-				b.Fatal("ensures not optimized away")
-			}
+		for b.Loop() {
+			ValueFromOutgoingContext(ctx, "key-not-found")
 		}
 	})
 }


### PR DESCRIPTION
Partially Fixes: #8860

### Why

There are use cases where only a single value needs to be read from outgoing gRPC metadata. Today the only way to do that is `metadata.FromOutgoingContext`, which merges and copies every header already staged into a brand-new map, even though the caller only wants one of them. The cost of that copy grows with however many headers have already accumulated in outgoing context — exactly the complaint raised in #8860.

### What

This PR adds `metadata.ValueFromOutgoingContext(ctx, key) []string`, symmetric to the existing `ValueFromIncomingContext`, for reading a single header from outgoing gRPC metadata without merging and copying every other header already staged via `AppendToOutgoingContext`.

This is the API @easwars suggested in https://github.com/grpc/grpc-go/issues/8860#issuecomment-3975157332:

> Would adding a `ValueFromOutgoingContext` that is similar to `ValueFromIncomingContext` work for you? Please note that `ValueFromOutgoingContext` will not be as fast as `ValueFromIncomingContext` as the implementation would have check entries from the `map` **and** the `added` entries.

per https://github.com/grpc/grpc-go/issues/8860#issuecomment-5121951898.

That tradeoff is exactly what this implementation does: it checks `rawMD.md` (case-insensitively, matching `ValueFromIncomingContext`'s semantics) and then walks `rawMD.added`, accumulating matches in the same order `FromOutgoingContext` would, without allocating a new map or copying unrelated keys/values.

Matching `rawMD.added` entries case-insensitively via `strings.EqualFold`, rather than assuming they're already lowercased by `AppendToOutgoingContext`, makes no assumption about how `rawMD.added` was populated — the same guarantee `FromOutgoingContext` already makes for both `rawMD.md` and `rawMD.added`.

The allocation of `vals` is deferred until a match is actually found in `rawMD.added` (per `gemini-code-assist`'s review suggestion), rather than always calling `copyOf` as soon as `rawMD.md` matches. When the key is found in both `rawMD.md` and `rawMD.added`, this avoids paying for a `copyOf` allocation that would otherwise immediately be discarded by the first `append`'s growth — roughly halving allocations for that case (see `key-found-in-md-and-added` in the benchmark below).

The `rawMD.added` loop also tries a direct `==` before falling back to `strings.EqualFold` (a second `gemini-code-assist` suggestion), since `AppendToOutgoingContext` already lowercases keys in practice. Benchmarked with realistic-length keys (e.g. `"grpc-timeout"`, not `"k1"`), this is a modest win when the key is found (~2-7% faster) at the cost of a small regression when it isn't (~6% slower — one extra comparison with no payoff) — a reasonable trade since looking up a header you expect to be present is the common case.

### Benchmark

`n` is the number of unrelated headers already staged (one `NewOutgoingContext` call plus one `AppendToOutgoingContext` call) before reading the target key:

```
goos: darwin
goarch: arm64
pkg: google.golang.org/grpc/metadata
cpu: Apple M4 Pro
FromOutgoingContext/n=1         141.7 ns/op    432 B/op    4 allocs/op
ValueFromOutgoingContext/n=1     56.0 ns/op     16 B/op    1 allocs/op
FromOutgoingContext/n=10        404.9 ns/op    968 B/op   15 allocs/op
ValueFromOutgoingContext/n=10   107.2 ns/op     16 B/op    1 allocs/op
FromOutgoingContext/n=50       1596.0 ns/op   3592 B/op   55 allocs/op
ValueFromOutgoingContext/n=50   314.7 ns/op     16 B/op    1 allocs/op
```

(measured with `b.Loop`, per review feedback, which also removes the need for the manual anti-optimization `b.Fatal` checks the previous numbers were measured with)

At n=50, roughly 5x faster with 55x fewer allocations. This is still O(n) in the number of already-staged headers in the worst case, since `rawMD.added` isn't indexed by key, but it avoids the wasted work of copying and lowercasing every header the caller doesn't want.

Separately, `BenchmarkValueFromOutgoingContext` (now using realistic-length keys like `"grpc-timeout"`/`"content-type"` instead of `"k1"`/`"k3"`, which understated `strings.EqualFold`'s cost) shows both `rawMD.added` optimizations above:

```
key-found                    59.6 ns/op    16 B/op   1 allocs/op
key-not-found                50.7 ns/op     0 B/op   0 allocs/op
key-found-in-md-and-added    38.7 ns/op    32 B/op   1 allocs/op
```

### Testing

- `TestValueFromOutgoingContext` covers exact match, case-insensitive match, a value present in `rawMD.md` accumulated with two later `AppendToOutgoingContext` calls (must match `FromOutgoingContext`'s order, per `TestAppendToOutgoingContext`), values split solely across multiple `AppendToOutgoingContext` calls, not-found, and no-outgoing-metadata-at-all.
- `TestValueFromOutgoingContext_AddedCaseInsensitive` constructs `rawMD.added` directly with a mixed-case key (bypassing `AppendToOutgoingContext`'s lowercasing) to verify the match is still found.
- `TestValueFromOutgoingContext_PanicsOnOddPairs` covers the defensive panic on a malformed `rawMD.added` entry, mirroring the identical guard already present in `FromOutgoingContext`.
- `BenchmarkValueFromOutgoingContext` mirrors the existing `BenchmarkValueFromIncomingContext` shape (key-found / key-not-found), plus a `key-found-in-md-and-added` case covering the deferred-allocation path above.
- `BenchmarkValueFromOutgoingContextVsFromOutgoingContext` produced the comparison table above.
- `ValueFromOutgoingContext` itself is at 100% statement coverage (`go test -cover`).
- `go test ./metadata/...`, `go vet ./metadata/...`, and `gofmt` are all clean. This branch is rebased on current `master`.

This is additive only — no existing exported behavior changes.

RELEASE NOTES:
* metadata: Add ValueFromOutgoingContext, which reads a single metadata value from outgoing context without copying the entire outgoing metadata into a new map.



