### PR TITLE
xdsclient: store per-resource error in resource state instead of overall error

### DIFF
--- a/internal/xds/clients/xdsclient/authority.go
+++ b/internal/xds/clients/xdsclient/authority.go
@@ -348,7 +348,7 @@ func (a *authority) handleADSResourceUpdate(serverConfig *ServerConfig, rType Re
 			onDone()
 		}
 	}
-	funcsToSchedule := []func(context.Context){}
+	var funcsToSchedule []func(context.Context)
 	defer func() {
 		if len(funcsToSchedule) == 0 {
 			// When there are no watchers for the resources received as part of
@@ -369,8 +369,6 @@ func (a *authority) handleADSResourceUpdate(serverConfig *ServerConfig, rType Re
 			continue
 		}
 
-		// On error, keep previous version of the resource. But update status
-		// and error.
 		if err := uErr.Err; err != nil {
 			if a.metricsReporter != nil {
 				a.metricsReporter.ReportMetric(&metrics.ResourceUpdateInvalid{
@@ -390,9 +388,15 @@ func (a *authority) handleADSResourceUpdate(serverConfig *ServerConfig, rType Re
 				}
 			}
 
-			// Update error state.
-			state.md.ErrState = md.ErrState
-			state.md.Status = md.Status
+			// On error, keep previous version of the resource. But update
+			// status to NACKed and capture the specific per-resource error (and
+			// not the overall error for the update) in the ErrState field.
+			state.md.Status = xdsresource.ServiceStatusNACKed
+			state.md.ErrState = &xdsresource.UpdateErrorMetadata{
+				Version:   md.ErrState.Version,
+				Err:       err,
+				Timestamp: md.ErrState.Timestamp,
+			}
 
 			continue
 		}
@@ -420,7 +424,6 @@ func (a *authority) handleADSResourceUpdate(serverConfig *ServerConfig, rType Re
 			state.cache = uErr.Resource
 
 			for watcher := range state.watchers {
-				watcher := watcher
 				resource := uErr.Resource
 				watcherCnt.Add(1)
 				funcsToSchedule = append(funcsToSchedule, func(context.Context) { watcher.ResourceChanged(resource, done) })
@@ -498,7 +501,6 @@ func (a *authority) handleADSResourceUpdate(serverConfig *ServerConfig, rType Re
 		state.cache = nil
 		state.md = xdsresource.UpdateMetadata{Status: xdsresource.ServiceStatusNotExist}
 		for watcher := range state.watchers {
-			watcher := watcher
 			watcherCnt.Add(1)
 			funcsToSchedule = append(funcsToSchedule, func(context.Context) {
 				watcher.ResourceError(xdsresource.NewErrorf(xdsresource.ErrorTypeResourceNotFound, "xds: resource %q of type %q has been removed", name, rType.TypeName), done)

--- a/internal/xds/clients/xdsclient/authority.go
+++ b/internal/xds/clients/xdsclient/authority.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -377,7 +376,7 @@ func (a *authority) handleADSResourceUpdate(serverConfig *ServerConfig, rType Re
 			}
 
 			// Notify watchers only if this is not a duplicated error from the previous update.
-			if errState := state.md.ErrState; errState == nil || errState.Err == nil || !strings.Contains(state.md.ErrState.Err.Error(), err.Error()) {
+			if errState := state.md.ErrState; errState == nil || errState.Err == nil || state.md.ErrState.Err.Error() != err.Error() {
 				for watcher := range state.watchers {
 					watcherCnt.Add(1)
 					if state.cache == nil {

--- a/internal/xds/clients/xdsclient/test/ads_stream_ack_nack_test.go
+++ b/internal/xds/clients/xdsclient/test/ads_stream_ack_nack_test.go
@@ -584,12 +584,11 @@ func (s) TestADS_NACKError_DuplicateSuppression(t *testing.T) {
 	}
 }
 
-// TestADS_NACKError_DuplicateSuppression_ConcatenatedErrorChange verifies that
-// when multiple invalid resources cause a concatenated error stored in
-// metadata, and a subsequent update carries a duplicate error for only a subset
-// of resources (changing the concatenated error string), the client still
-// suppresses the duplicate error notification to the watcher.
-func (s) TestADS_NACKError_DuplicateSuppression_ConcatenatedErrorChange(t *testing.T) {
+// TestADS_NACKError_DuplicateSuppression_MultipleResources verifies that
+// when multiple invalid resources cause errors, and a subsequent update carries
+// a duplicate error for only a subset of resources, the client still suppresses
+// the duplicate error notification to the watcher of the affected resource(s).
+func (s) TestADS_NACKError_DuplicateSuppression_MultipleResources(t *testing.T) {
 	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{})
 
 	const listenerName1 = "listener-1"
@@ -644,8 +643,7 @@ func (s) TestADS_NACKError_DuplicateSuppression_ConcatenatedErrorChange(t *testi
 	}
 
 	// Update 2: Management server sends listener 1 still invalid, but listener
-	// 2 now valid.  This changes the concatenated error stored in metadata
-	// (from Error1+Error2 to just Error1).
+	// 2 now valid.
 	resources2 := e2e.UpdateOptions{
 		NodeID: nodeID,
 		Listeners: []*v3listenerpb.Listener{
@@ -664,9 +662,7 @@ func (s) TestADS_NACKError_DuplicateSuppression_ConcatenatedErrorChange(t *testi
 		t.Fatalf("Timeout waiting for listener 2 resource update: %v", err)
 	}
 
-	// Verify that no duplicate error update was written to watcher 1 error
-	// channel, proving that the duplicate error on listener 1 was suppressed
-	// despite the concatenated error changing.
+	// Verify that no duplicate error update was written to watcher 1.
 	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if v, err := watcher1.resourceErrCh.Receive(sCtx); err == nil {

--- a/internal/xds/clients/xdsclient/test/dump_test.go
+++ b/internal/xds/clients/xdsclient/test/dump_test.go
@@ -475,3 +475,83 @@ func (s) TestDumpResources_ManyToMany(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// Tests that when a resource update is NACKed by the xDS client, the resource
+// dump mentions that the xDS client is using the old good version of the
+// resource, but contains the error state for the most recent bad update.
+func (s) TestDumpResources_ACK_NACK(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	// Spin up an xDS management server on a local port.
+	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{})
+
+	nodeID := uuid.New().String()
+	configs := map[string]grpctransport.Config{"insecure": {Credentials: insecure.NewBundle()}}
+	client := createXDSClient(t, mgmtServer.Address, nodeID, grpctransport.NewBuilder(configs))
+
+	// Start watching a listener resource.
+	client.WatchResource(xdsresource.V3ListenerURL, ldsName, noopListenerWatcher{})
+
+	// Configure the management server with a good version of the listener resource.
+	goodListener := e2e.DefaultClientListener(ldsName, rdsName)
+	if err := mgmtServer.Update(ctx, e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Listeners:      []*v3listenerpb.Listener{goodListener},
+		SkipValidation: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Dump resources and expect ACK config with version "1".
+	wantNode := &v3corepb.Node{
+		Id:                   nodeID,
+		UserAgentName:        "user-agent",
+		UserAgentVersionType: &v3corepb.Node_UserAgentVersion{UserAgentVersion: "0.0.0.0"},
+		ClientFeatures:       []string{"envoy.lb.does_not_support_overprovisioning", "xds.config.resource-in-sotw"},
+	}
+	goodListenerAny := testutils.MarshalAny(t, goodListener)
+	wantConfigs := []*v3statuspb.ClientConfig_GenericXdsConfig{
+		makeGenericXdsConfig("type.googleapis.com/envoy.config.listener.v3.Listener", ldsName, "1", v3adminpb.ClientResourceStatus_ACKED, goodListenerAny, nil),
+	}
+	wantResp := &v3statuspb.ClientStatusResponse{
+		Config: []*v3statuspb.ClientConfig{
+			{
+				Node:              wantNode,
+				GenericXdsConfigs: wantConfigs,
+			},
+		},
+	}
+	if err := checkResourceDump(ctx, wantResp, client); err != nil {
+		t.Fatal(err)
+	}
+
+	// Update the management server with a bad version of the listener resource
+	// which is expected to be NACKed by the xDS client.
+	badListener := badListenerResource(t, ldsName)
+	if err := mgmtServer.Update(ctx, e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Listeners:      []*v3listenerpb.Listener{badListener},
+		SkipValidation: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Dump resources and verify that the xDS client is using the old good
+	// version of the resource ("1"), but contains the error state for the most
+	// recent bad update ("2").
+	wantConfigs = []*v3statuspb.ClientConfig_GenericXdsConfig{
+		makeGenericXdsConfig("type.googleapis.com/envoy.config.listener.v3.Listener", ldsName, "1", v3adminpb.ClientResourceStatus_NACKED, goodListenerAny, &v3adminpb.UpdateFailureState{VersionInfo: "2"}),
+	}
+	wantResp = &v3statuspb.ClientStatusResponse{
+		Config: []*v3statuspb.ClientConfig{
+			{
+				Node:              wantNode,
+				GenericXdsConfigs: wantConfigs,
+			},
+		},
+	}
+	if err := checkResourceDump(ctx, wantResp, client); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Follow-up from this discussion: https://github.com/grpc/grpc-go/pull/9185#discussion_r3640269716

RELEASE NOTES: none