### PR TITLE
extproc: implement channel retention as part of A93

### DIFF
--- a/internal/xds/httpfilter/extproc/ext_proc.go
+++ b/internal/xds/httpfilter/extproc/ext_proc.go
@@ -440,6 +440,18 @@ func (i *clientInterceptor) NewStream(ctx context.Context, ri resolver.RPCInfo, 
 			procRecvDone: make(chan struct{}),
 		}
 
+		// Defer the closing of ext proc stream by the defined deferred close
+		// timeout to allow the server to read all messages from the proc stream.
+		onFinishFunc := func(error) {
+			time.AfterFunc(ocs.config.deferredCloseTimeout, ocs.procCancel)
+		}
+		newOpts := append(opts, grpc.OnFinish(onFinishFunc))
+
+		if ocs.dataplaneStream, err = newStream(ocs.ctx, newOpts...); err != nil {
+			ocs.cancel()
+			return nil, ocs.streamError(err)
+		}
+		ocs.recordMetric(clientHeadersDurationMetric, timeSince(ocs.clientHeadersStartTime).Seconds())
 		// Start background goroutine to receive any messages from the external
 		// processor server and discard them.
 		go ocs.discardProcessorResponsesLoop()
@@ -451,19 +463,6 @@ func (i *clientInterceptor) NewStream(ctx context.Context, ri resolver.RPCInfo, 
 				return ocs.handleInitError(fmt.Errorf("failed to send client headers to external processor server: %v", err), newStream, opts...)
 			}
 		}
-
-		// Defer the closing of ext proc stream by the defined deferred close
-		// timeout to allow the server to read all messages from the proc stream.
-		onFinishFunc := func(error) {
-			time.AfterFunc(ocs.config.deferredCloseTimeout, ocs.procCancel)
-		}
-		newOpts := append(opts, grpc.OnFinish(onFinishFunc))
-
-		if ocs.dataplaneStream, err = newStream(ocs.ctx, newOpts...); err != nil {
-			ocs.cancel()
-			return nil, err
-		}
-		ocs.recordMetric(clientHeadersDurationMetric, timeSince(ocs.clientHeadersStartTime).Seconds())
 
 		return ocs, nil
 	}

--- a/internal/xds/httpfilter/extproc/ext_proc.go
+++ b/internal/xds/httpfilter/extproc/ext_proc.go
@@ -306,7 +306,7 @@ func (cf *clientFilter) getOrCreateExtProcChannel(server xdsresource.GRPCService
 	// Create a new refcounted client. The onZero cleanup function will remove the
 	// client from the map and close the underlying channel.
 	var rc *grpcsync.RefCounted[v3procservicegrpc.ExternalProcessorClient]
-	rc, err = grpcsync.NewRefCounted(client, func() {
+	rc = grpcsync.NewRefCounted(&client, func() {
 		cf.removeProcChannel(key, rc)
 		cancel()
 	})
@@ -419,7 +419,8 @@ func (i *clientInterceptor) NewStream(ctx context.Context, ri resolver.RPCInfo, 
 	// they go over the wire, we must establish the ext_proc stream now rather
 	// than deferring it.
 	var err error
-	if csCommon.procStream, err = i.procClient.Value().Process(procCtx, grpc.OnFinish(func(error) {
+	procClient := *i.procClient.Value()
+	if csCommon.procStream, err = procClient.Process(procCtx, grpc.OnFinish(func(error) {
 		i.procClient.Decrement()
 	})); err != nil {
 		i.procClient.Decrement()

--- a/internal/xds/httpfilter/extproc/ext_proc.go
+++ b/internal/xds/httpfilter/extproc/ext_proc.go
@@ -235,6 +235,50 @@ type clientFilter struct {
 
 func (*clientFilter) Close() {}
 
+// getProcChannel returns an existing refcounted client from the map if present
+// and its refcount is incremented successfully.
+func (cf *clientFilter) getProcChannel(key grpcServiceKey) *grpcsync.RefCounted[v3procservicegrpc.ExternalProcessorClient] {
+	cf.mu.Lock()
+	defer cf.mu.Unlock()
+	if rc, ok := cf.procChannels[key]; ok && rc.TryIncrement() {
+		return rc
+	}
+	return nil
+}
+
+// storeProcChannel stores the created channel in the map if no valid channel
+// exists for the key. If another goroutine already stored a channel while
+// unlocked, it increments the existing channel's refcount and returns it.
+func (cf *clientFilter) storeProcChannel(key grpcServiceKey, rc *grpcsync.RefCounted[v3procservicegrpc.ExternalProcessorClient]) *grpcsync.RefCounted[v3procservicegrpc.ExternalProcessorClient] {
+	cf.mu.Lock()
+	defer cf.mu.Unlock()
+	if existing, ok := cf.procChannels[key]; ok && existing.TryIncrement() {
+		return existing
+	}
+	cf.procChannels[key] = rc
+	return rc
+}
+
+// removeProcChannel removes rc from the map if it is still associated with key.
+//
+// We check (cf.procChannels[key] == rc) before deleting because:
+//  1. When a channel's reference count drops to 0, this cleanup callback runs
+//     asynchronously on a background goroutine.
+//  2. Before this callback acquires cf.mu, a subsequent call to
+//     getOrCreateExtProcChannel could see that the old channel has refcount 0,
+//     ignore it, and store a newly created channel in cf.procChannels[key].
+//  3. The equality check ensures we only delete from the map if it still points
+//     to this expiring channel, preventing us from accidentally deleting a new
+//     replacement channel.
+func (cf *clientFilter) removeProcChannel(key grpcServiceKey, rc *grpcsync.RefCounted[v3procservicegrpc.ExternalProcessorClient]) {
+	cf.mu.Lock()
+	defer cf.mu.Unlock()
+	// Only delete from the map if it hasn't already been replaced by a newer channel.
+	if cf.procChannels[key] == rc {
+		delete(cf.procChannels, key)
+	}
+}
+
 // getOrCreateExtProcChannel retrieves an existing refcounted external processor
 // client from the procChannels map and increases its refcount or creates a new
 // one if it doesn't exist.
@@ -246,14 +290,11 @@ func (cf *clientFilter) getOrCreateExtProcChannel(server xdsresource.GRPCService
 		callCredentials:    server.CallCredentials,
 	}
 
-	cf.mu.Lock()
 	// If the channel for the key is present in the map and its refcount is
 	// greater than 0, increment the refcount and return the channel.
-	if rc, ok := cf.procChannels[key]; ok && rc.TryIncrement() {
-		cf.mu.Unlock()
+	if rc := cf.getProcChannel(key); rc != nil {
 		return rc, nil
 	}
-	cf.mu.Unlock()
 
 	// Create the external processor channel without holding the lock.
 	cc, cancel, err := iextproc.CreateExtProcChannel(server)
@@ -266,11 +307,7 @@ func (cf *clientFilter) getOrCreateExtProcChannel(server xdsresource.GRPCService
 	// client from the map and close the underlying channel.
 	var rc *grpcsync.RefCounted[v3procservicegrpc.ExternalProcessorClient]
 	rc, err = grpcsync.NewRefCounted(client, func() {
-		cf.mu.Lock()
-		if cf.procChannels[key] == rc {
-			delete(cf.procChannels, key)
-		}
-		cf.mu.Unlock()
+		cf.removeProcChannel(key, rc)
 		cancel()
 	})
 	if err != nil {
@@ -278,16 +315,12 @@ func (cf *clientFilter) getOrCreateExtProcChannel(server xdsresource.GRPCService
 		return nil, err
 	}
 
-	cf.mu.Lock()
 	// Double-check if another goroutine created and stored a channel for this
 	// key while we were unlocked.
-	if existing, ok := cf.procChannels[key]; ok && existing.TryIncrement() {
-		cf.mu.Unlock()
+	if existing := cf.storeProcChannel(key, rc); existing != rc {
 		rc.Decrement()
 		return existing, nil
 	}
-	cf.procChannels[key] = rc
-	cf.mu.Unlock()
 	return rc, nil
 }
 
@@ -346,6 +379,9 @@ func createProcContext(ctx context.Context, server xdsresource.GRPCServiceConfig
 }
 
 func (i *clientInterceptor) NewStream(ctx context.Context, ri resolver.RPCInfo, newStream func(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStream, error), opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	// Increment procClient's refcount so this RPC stream keeps the connection
+	// open even if the interceptor is closed. Decremented when the Process
+	// stream finishes (via grpc.OnFinish) or fails to start.
 	i.procClient.Increment()
 	outgoingMD, added, _ := metadataFromOutgoingContextRaw(ctx)
 	// Create a cancelable context to cancel the dataplane stream and close any
@@ -496,8 +532,10 @@ type commonStream struct {
 	target                 string
 	clientHeadersStartTime time.Time
 
-	onFinish            []func(err error) // stores the finish callbacks from the call options
-	dataplaneRecvCalled atomic.Bool       // tracks if RecvMsg has been called on dataplaneStream by the application
+	// onFinish stores OnFinishCallOption callbacks to execute if calling the
+	// delegate (newStream) fails or if the RPC fails before delegating.
+	onFinish            []func(err error)
+	dataplaneRecvCalled atomic.Bool // tracks if RecvMsg has been called on dataplaneStream by the application
 }
 
 func (cs *commonStream) recordMetric(handle *estats.Float64HistoHandle, duration float64) {
@@ -528,8 +566,8 @@ func (cs *commonStream) handleInitError(err error, newStream func(context.Contex
 
 // callOnFinish executes all registered OnFinish CallOption callbacks.
 func (cs *commonStream) callOnFinish(err error) {
-	for _, of := range cs.onFinish {
-		of(err)
+	for _, f := range cs.onFinish {
+		f(err)
 	}
 }
 
@@ -549,7 +587,10 @@ func (cs *commonStream) callOnFinish(err error) {
 //
 // For streaming RPCs where RecvMsg has already been called by the application,
 // we avoid invoking a dummy RecvMsg because ClientStream.RecvMsg is not safe
-// for concurrent calls by multiple goroutines on the same stream.
+// for concurrent calls by multiple goroutines on the same stream. Multiple
+// goroutines may enter here concurrently; mutual exclusion is not required
+// because cs.cancel() makes subsequent RecvMsg calls after context cancellation
+// are idempotent.
 func (cs *commonStream) cleanupDataplane() {
 	cs.cancel()
 	if cs.dataplaneStream != nil && !cs.dataplaneRecvCalled.Load() {

--- a/internal/xds/httpfilter/extproc/ext_proc.go
+++ b/internal/xds/httpfilter/extproc/ext_proc.go
@@ -210,17 +210,73 @@ func (builder) BuildClientFilter(opts httpfilter.ClientFilterOptions) httpfilter
 	return &clientFilter{
 		metricsRecorder: opts.MetricsRecorder,
 		target:          opts.Target,
+		procChannels:    make(map[grpcServiceKey]*grpcsync.RefCounted[v3procservicegrpc.ExternalProcessorClient]),
 	}
 }
 
 var _ httpfilter.ClientFilterBuilder = builder{}
 
+// grpcServiceKey uniquely identifies an external processor server configuration
+// by its target URI, channel credentials, and call credentials. It is used as a
+// map key in clientFilter to share and reuse the external processor channels.
+type grpcServiceKey struct {
+	TargetURI          string
+	ChannelCredentials string
+	CallCredentials    string
+}
+
 type clientFilter struct {
 	metricsRecorder estats.MetricsRecorder
 	target          string
+
+	mu           sync.Mutex
+	procChannels map[grpcServiceKey]*grpcsync.RefCounted[v3procservicegrpc.ExternalProcessorClient]
 }
 
-func (clientFilter) Close() {}
+func (*clientFilter) Close() {}
+
+// getOrCreateExtProcChannel retrieves an existing refcounted external processor
+// client from the procChannels map and increases its refcount or creates a new
+// one if it doesn't exist.
+func (cf *clientFilter) getOrCreateExtProcChannel(server xdsresource.GRPCServiceConfig) (*grpcsync.RefCounted[v3procservicegrpc.ExternalProcessorClient], error) {
+	// Create the grpcServiceKey.
+	key := grpcServiceKey{
+		TargetURI:          server.TargetURI,
+		ChannelCredentials: server.ChannelCredentials,
+		CallCredentials:    server.CallCredentials,
+	}
+
+	cf.mu.Lock()
+	defer cf.mu.Unlock()
+
+	// If the channel for the key is present in the map and its refcount is
+	// greater than 0, increment the refcount and return the channel.
+	if rc, ok := cf.procChannels[key]; ok && rc.TryIncrement() {
+		return rc, nil
+	}
+
+	// Create the external processor channel.
+	cc, cancel, err := iextproc.CreateExtProcChannel(server)
+	if err != nil {
+		return nil, fmt.Errorf("extproc: failed to create channel to the external processor server %q: %v", server.TargetURI, err)
+	}
+
+	client := v3procservicegrpc.NewExternalProcessorClient(cc)
+	// Create a new refcounted client. The onZero cleanup function will remove the
+	// client from the map and close the underlying channel.
+	rc, err := grpcsync.NewRefCounted(client, func() {
+		cf.mu.Lock()
+		delete(cf.procChannels, key)
+		cf.mu.Unlock()
+		cancel()
+	})
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	cf.procChannels[key] = rc
+	return rc, nil
+}
 
 func (cf *clientFilter) BuildClientInterceptor(base, override httpfilter.FilterConfig) (httpfilter.ClientInterceptor, error) {
 	b, ok := base.(baseConfig)
@@ -238,15 +294,14 @@ func (cf *clientFilter) BuildClientInterceptor(base, override httpfilter.FilterC
 
 	config := newInterceptorConfig(b, ov)
 
-	// Create a channel to the external processor server.
-	cc, cancel, err := iextproc.CreateExtProcChannel(config.server)
+	// Create or reuse a refcounted channel to the external processor server.
+	rc, err := cf.getOrCreateExtProcChannel(config.server)
 	if err != nil {
-		return nil, fmt.Errorf("extproc: failed to create channel to the external processor server %q: %v", config.server.TargetURI, err)
+		return nil, err
 	}
 	return &clientInterceptor{
 		config:          config,
-		procClient:      v3procservicegrpc.NewExternalProcessorClient(cc),
-		closeClient:     cancel,
+		procClient:      rc,
 		metricsRecorder: cf.metricsRecorder,
 		target:          cf.target,
 	}, nil
@@ -254,14 +309,13 @@ func (cf *clientFilter) BuildClientInterceptor(base, override httpfilter.FilterC
 
 type clientInterceptor struct {
 	config          baseConfig
-	procClient      v3procservicegrpc.ExternalProcessorClient
-	closeClient     func() error
+	procClient      *grpcsync.RefCounted[v3procservicegrpc.ExternalProcessorClient]
 	metricsRecorder estats.MetricsRecorder
 	target          string
 }
 
 func (i *clientInterceptor) Close() {
-	i.closeClient()
+	i.procClient.Decrement()
 }
 
 // createProcContext creates a new child context for the RPC to the external
@@ -279,11 +333,20 @@ func createProcContext(ctx context.Context, server xdsresource.GRPCServiceConfig
 }
 
 func (i *clientInterceptor) NewStream(ctx context.Context, ri resolver.RPCInfo, newStream func(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStream, error), opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	i.procClient.Increment()
 	outgoingMD, added, _ := metadataFromOutgoingContextRaw(ctx)
 	// Create a cancelable context to cancel the dataplane stream and close any
 	// goroutines in case of error.
 	cancelCtx, cancel := context.WithCancel(ctx)
 	procCtx, procCancel := createProcContext(cancelCtx, i.config.server)
+
+	// Collect OnFinishCallOption functions from the call options.
+	var onFinish []func(error)
+	for _, o := range opts {
+		if onFinishOpt, ok := o.(grpc.OnFinishCallOption); ok && onFinishOpt.OnFinish != nil {
+			onFinish = append(onFinish, onFinishOpt.OnFinish)
+		}
+	}
 
 	csCommon := &commonStream{
 		ctx:                    cancelCtx,
@@ -299,6 +362,7 @@ func (i *clientInterceptor) NewStream(ctx context.Context, ri resolver.RPCInfo, 
 		// initializing attributes upfront avoids repeated protobuf construction on
 		// subsequent SendMsg and RecvMsg calls.
 		reqAttrs: constructRequestAttributes(ri, outgoingMD, added, i.config.requestAttributes),
+		onFinish: onFinish,
 	}
 
 	// In the ClientStream API, outgoing headers are sent immediately when the
@@ -306,7 +370,10 @@ func (i *clientInterceptor) NewStream(ctx context.Context, ri resolver.RPCInfo, 
 	// they go over the wire, we must establish the ext_proc stream now rather
 	// than deferring it.
 	var err error
-	if csCommon.procStream, err = i.procClient.Process(procCtx); err != nil {
+	if csCommon.procStream, err = i.procClient.Value().Process(procCtx, grpc.OnFinish(func(error) {
+		i.procClient.Decrement()
+	})); err != nil {
+		i.procClient.Decrement()
 		return csCommon.handleInitError(fmt.Errorf("failed to create a stream to external processor: %v", err), newStream, opts...)
 	}
 
@@ -325,7 +392,7 @@ func (i *clientInterceptor) NewStream(ctx context.Context, ri resolver.RPCInfo, 
 			}
 		}
 
-		// Defer the closing of ext proc stream by the defined defferred close
+		// Defer the closing of ext proc stream by the defined deferred close
 		// timeout to allow the server to read all messages from the proc stream.
 		onFinishFunc := func(error) {
 			time.AfterFunc(ocs.config.deferredCloseTimeout, ocs.procCancel)
@@ -415,6 +482,9 @@ type commonStream struct {
 	metricsRecorder        estats.MetricsRecorder
 	target                 string
 	clientHeadersStartTime time.Time
+
+	onFinish            []func(err error) // stores the finish callbacks from the call options
+	dataplaneRecvCalled atomic.Bool       // tracks if RecvMsg has been called on dataplaneStream by the application
 }
 
 func (cs *commonStream) recordMetric(handle *estats.Float64HistoHandle, duration float64) {
@@ -441,6 +511,36 @@ func (cs *commonStream) handleInitError(err error, newStream func(context.Contex
 	}
 	cs.recordMetric(clientHeadersDurationMetric, time.Since(cs.clientHeadersStartTime).Seconds())
 	return cs.dataplaneStream, nil
+}
+
+// callOnFinish executes all registered OnFinish CallOption callbacks.
+func (cs *commonStream) callOnFinish(err error) {
+	for _, of := range cs.onFinish {
+		of(err)
+	}
+}
+
+// cleanupDataplane cancels the stream's context to immediately tear down the
+// active dataplane connection and unblock any pending client I/O.
+//
+// Additionally, after context cancellation, if the application has not called
+// RecvMsg on the dataplane stream, it invokes a dummy RecvMsg on it.
+// In gRPC-Go, unary RPCs do not start a background goroutine waiting for context
+// expiration to call cs.finish(err). If an application or interceptor layer
+// abandons an RPC after NewStream without calling SendMsg, CloseSend, or RecvMsg
+// on the dataplane stream, calling RecvMsg on the canceled stream forces
+// gRPC-Go's internal clientStream to encounter context.Canceled and execute
+// cleanup. This guarantees that all registered OnFinish CallOption callbacks are
+// executed and reference counts are decremented so that channels do not leak.
+//
+// For streaming RPCs where RecvMsg has already been called by the application,
+// we avoid invoking a dummy RecvMsg because ClientStream.RecvMsg is not safe for
+// concurrent calls by multiple goroutines on the same stream.
+func (cs *commonStream) cleanupDataplane() {
+	cs.cancel()
+	if cs.dataplaneStream != nil && !cs.dataplaneRecvCalled.Load() {
+		cs.dataplaneStream.RecvMsg(new(v3procservicepb.ProcessingResponse))
+	}
 }
 
 // newProcessingRequest creates a new ProcessingRequest with ObservabilityMode,
@@ -625,6 +725,7 @@ func (ocs *observabilityClientStream) RecvMsg(m any) error {
 		}
 	}
 
+	ocs.dataplaneRecvCalled.Store(true)
 	if err := ocs.dataplaneStream.RecvMsg(m); err != nil {
 		if trerr := ocs.initiateResponseTrailerProcessing(ocs.dataplaneStream.Trailer()); trerr != nil {
 			return trerr
@@ -757,7 +858,7 @@ func (ocs *observabilityClientStream) failObsProcStream(err error) {
 	ocs.procCancel()
 	if err != io.EOF && !ocs.config.failureModeAllow {
 		ocs.procStreamErr.Store(status.Errorf(codes.Internal, "extproc: external processor RPC failed: %v", err))
-		ocs.cancel()
+		ocs.cleanupDataplane()
 		return
 	}
 	ocs.procStreamBypass.Store(true)
@@ -969,6 +1070,7 @@ func (cs *clientStream) recvFromDataplane(m any) error {
 	if err != nil {
 		return err
 	}
+	cs.dataplaneRecvCalled.Store(true)
 	if err := s.RecvMsg(m); err != nil {
 		// If RecvMsg returns error, fail the RPC in case external processor stream
 		// has failed. Otherwise process the trailers.
@@ -1408,6 +1510,8 @@ func (cs *clientStream) createDataplaneStream(ctx context.Context, newStream fun
 	defer close(cs.dataplaneSetup)
 	cs.dataplaneStream, cs.dataplaneCreationErr = newStream(ctx, opts...)
 	if cs.dataplaneCreationErr != nil {
+		// Execute the OnFinish call options if the delegate failed.
+		cs.callOnFinish(cs.dataplaneCreationErr)
 		cs.cancel()
 	}
 	return cs.dataplaneCreationErr
@@ -1422,11 +1526,13 @@ func (cs *clientStream) failProcStream(err error) bool {
 	}
 	cs.procCancel()
 	if err != io.EOF && (cs.ignoreFailureMode.Load() || !cs.config.failureModeAllow) {
+		// Execute the OnFinish call options if the delegate is never called.
+		if cs.dataplaneStream == nil {
+			cs.callOnFinish(err)
+		}
 		cs.procStreamErr.Store(status.Errorf(codes.Internal, "extproc: %v", err))
 		cs.procStreamFailed.Fire()
-		// Cancel the stream's context to immediately tear down the active dataplane
-		// connection and unblock any pending client I/O.
-		cs.cancel()
+		cs.cleanupDataplane()
 		return false
 	}
 	cs.triggerBypass()
@@ -1439,11 +1545,13 @@ func (cs *clientStream) cancelStream(err error) {
 	if !cs.procStreamClosed.CompareAndSwap(false, true) {
 		return
 	}
+	// Execute the OnFinish call options if the delegate is never called.
+	if cs.dataplaneStream == nil {
+		cs.callOnFinish(err)
+	}
 	cs.procStreamErr.Store(err)
 	cs.procStreamFailed.Fire()
-	// Cancel the stream's context to immediately tear down the active
-	// dataplane connection and unblock any pending client I/O.
-	cs.cancel()
+	cs.cleanupDataplane()
 }
 
 // handleHeaderError handles failures that occur during receiving or processing

--- a/internal/xds/httpfilter/extproc/ext_proc.go
+++ b/internal/xds/httpfilter/extproc/ext_proc.go
@@ -220,9 +220,9 @@ var _ httpfilter.ClientFilterBuilder = builder{}
 // by its target URI, channel credentials, and call credentials. It is used as a
 // map key in clientFilter to share and reuse the external processor channels.
 type grpcServiceKey struct {
-	TargetURI          string
-	ChannelCredentials string
-	CallCredentials    string
+	targetURI          string
+	channelCredentials string
+	callCredentials    string
 }
 
 type clientFilter struct {
@@ -241,9 +241,9 @@ func (*clientFilter) Close() {}
 func (cf *clientFilter) getOrCreateExtProcChannel(server xdsresource.GRPCServiceConfig) (*grpcsync.RefCounted[v3procservicegrpc.ExternalProcessorClient], error) {
 	// Create the grpcServiceKey.
 	key := grpcServiceKey{
-		TargetURI:          server.TargetURI,
-		ChannelCredentials: server.ChannelCredentials,
-		CallCredentials:    server.CallCredentials,
+		targetURI:          server.TargetURI,
+		channelCredentials: server.ChannelCredentials,
+		callCredentials:    server.CallCredentials,
 	}
 
 	cf.mu.Lock()
@@ -533,22 +533,23 @@ func (cs *commonStream) callOnFinish(err error) {
 	}
 }
 
-// cleanupDataplane cancels the stream's context to immediately tear down the
-// active dataplane connection and unblock any pending client I/O.
+// cleanupDataplane cancels the dataplane stream's context to immediately tear
+// down the active dataplane connection and unblock any pending client I/O.
 //
 // Additionally, after context cancellation, if the application has not called
-// RecvMsg on the dataplane stream, it invokes a dummy RecvMsg on it.
-// In gRPC-Go, unary RPCs do not start a background goroutine waiting for context
+// RecvMsg on the dataplane stream, it invokes a dummy RecvMsg on it. In
+// gRPC-Go, unary RPCs do not start a background goroutine waiting for context
 // expiration to call cs.finish(err). If an application or interceptor layer
-// abandons an RPC after NewStream without calling SendMsg, CloseSend, or RecvMsg
-// on the dataplane stream, calling RecvMsg on the canceled stream forces
-// gRPC-Go's internal clientStream to encounter context.Canceled and execute
-// cleanup. This guarantees that all registered OnFinish CallOption callbacks are
-// executed and reference counts are decremented so that channels do not leak.
+// abandons an RPC after NewStream without calling SendMsg, CloseSend, or
+// RecvMsg on the dataplane stream, calling RecvMsg on the canceled stream
+// forces gRPC-Go's internal clientStream to encounter context.Canceled and
+// execute cleanup. This guarantees that all registered OnFinish CallOption
+// callbacks are executed and reference counts are decremented so that channels
+// do not leak.
 //
 // For streaming RPCs where RecvMsg has already been called by the application,
-// we avoid invoking a dummy RecvMsg because ClientStream.RecvMsg is not safe for
-// concurrent calls by multiple goroutines on the same stream.
+// we avoid invoking a dummy RecvMsg because ClientStream.RecvMsg is not safe
+// for concurrent calls by multiple goroutines on the same stream.
 func (cs *commonStream) cleanupDataplane() {
 	cs.cancel()
 	if cs.dataplaneStream != nil && !cs.dataplaneRecvCalled.Load() {
@@ -738,7 +739,9 @@ func (ocs *observabilityClientStream) RecvMsg(m any) error {
 		}
 	}
 
-	ocs.dataplaneRecvCalled.Store(true)
+	if !ocs.dataplaneRecvCalled.Load() {
+		ocs.dataplaneRecvCalled.Store(true)
+	}
 	if err := ocs.dataplaneStream.RecvMsg(m); err != nil {
 		if trerr := ocs.initiateResponseTrailerProcessing(ocs.dataplaneStream.Trailer()); trerr != nil {
 			return trerr
@@ -1083,7 +1086,9 @@ func (cs *clientStream) recvFromDataplane(m any) error {
 	if err != nil {
 		return err
 	}
-	cs.dataplaneRecvCalled.Store(true)
+	if !cs.dataplaneRecvCalled.Load() {
+		cs.dataplaneRecvCalled.Store(true)
+	}
 	if err := s.RecvMsg(m); err != nil {
 		// If RecvMsg returns error, fail the RPC in case external processor stream
 		// has failed. Otherwise process the trailers.

--- a/internal/xds/httpfilter/extproc/ext_proc.go
+++ b/internal/xds/httpfilter/extproc/ext_proc.go
@@ -320,10 +320,6 @@ func (cf *clientFilter) getOrCreateExtProcChannel(server xdsresource.GRPCService
 		cf.removeProcChannel(key, rc)
 		cancel()
 	})
-	if err != nil {
-		cancel()
-		return nil, err
-	}
 
 	// Double-check if another goroutine created and stored a channel for this
 	// key while we were unlocked.

--- a/internal/xds/httpfilter/extproc/ext_proc.go
+++ b/internal/xds/httpfilter/extproc/ext_proc.go
@@ -429,6 +429,11 @@ func (i *clientInterceptor) NewStream(ctx context.Context, ri resolver.RPCInfo, 
 	if csCommon.procStream, err = procClient.Process(procCtx, grpc.OnFinish(func(error) {
 		i.procClient.Decrement()
 	})); err != nil {
+		// Since Process failed to create the stream, its OnFinish callback will
+		// not be called, so we must manually decrement the procClient refcount.
+		// We do not invoke other registered OnFinish call options here because
+		// NewStream might return an error directly, and it is the caller's
+		// responsibility to handle cleanup if NewStream fails or returns an error.
 		i.procClient.Decrement()
 		return csCommon.handleInitError(fmt.Errorf("failed to create a stream to external processor: %v", err), newStream, opts...)
 	}

--- a/internal/xds/httpfilter/extproc/ext_proc.go
+++ b/internal/xds/httpfilter/extproc/ext_proc.go
@@ -247,15 +247,15 @@ func (cf *clientFilter) getOrCreateExtProcChannel(server xdsresource.GRPCService
 	}
 
 	cf.mu.Lock()
-	defer cf.mu.Unlock()
-
 	// If the channel for the key is present in the map and its refcount is
 	// greater than 0, increment the refcount and return the channel.
 	if rc, ok := cf.procChannels[key]; ok && rc.TryIncrement() {
+		cf.mu.Unlock()
 		return rc, nil
 	}
+	cf.mu.Unlock()
 
-	// Create the external processor channel.
+	// Create the external processor channel without holding the lock.
 	cc, cancel, err := iextproc.CreateExtProcChannel(server)
 	if err != nil {
 		return nil, fmt.Errorf("extproc: failed to create channel to the external processor server %q: %v", server.TargetURI, err)
@@ -264,9 +264,12 @@ func (cf *clientFilter) getOrCreateExtProcChannel(server xdsresource.GRPCService
 	client := v3procservicegrpc.NewExternalProcessorClient(cc)
 	// Create a new refcounted client. The onZero cleanup function will remove the
 	// client from the map and close the underlying channel.
-	rc, err := grpcsync.NewRefCounted(client, func() {
+	var rc *grpcsync.RefCounted[v3procservicegrpc.ExternalProcessorClient]
+	rc, err = grpcsync.NewRefCounted(client, func() {
 		cf.mu.Lock()
-		delete(cf.procChannels, key)
+		if cf.procChannels[key] == rc {
+			delete(cf.procChannels, key)
+		}
 		cf.mu.Unlock()
 		cancel()
 	})
@@ -274,7 +277,17 @@ func (cf *clientFilter) getOrCreateExtProcChannel(server xdsresource.GRPCService
 		cancel()
 		return nil, err
 	}
+
+	cf.mu.Lock()
+	// Double-check if another goroutine created and stored a channel for this
+	// key while we were unlocked.
+	if existing, ok := cf.procChannels[key]; ok && existing.TryIncrement() {
+		cf.mu.Unlock()
+		rc.Decrement()
+		return existing, nil
+	}
 	cf.procChannels[key] = rc
+	cf.mu.Unlock()
 	return rc, nil
 }
 
@@ -539,7 +552,7 @@ func (cs *commonStream) callOnFinish(err error) {
 func (cs *commonStream) cleanupDataplane() {
 	cs.cancel()
 	if cs.dataplaneStream != nil && !cs.dataplaneRecvCalled.Load() {
-		cs.dataplaneStream.RecvMsg(new(v3procservicepb.ProcessingResponse))
+		cs.dataplaneStream.RecvMsg(new(any))
 	}
 }
 

--- a/internal/xds/httpfilter/extproc/ext_proc.go
+++ b/internal/xds/httpfilter/extproc/ext_proc.go
@@ -1292,6 +1292,9 @@ func (cs *clientStream) responseForwardingToProcServerLoop(msgType protoreflect.
 		}
 
 		newMsg := msgType.New().Interface()
+		if !cs.dataplaneRecvCalled.Load() {
+			cs.dataplaneRecvCalled.Store(true)
+		}
 		if err := dataplaneStream.RecvMsg(newMsg); err != nil {
 			cs.initiateResponseTrailerProcessing()
 			return

--- a/internal/xds/httpfilter/extproc/ext_proc.go
+++ b/internal/xds/httpfilter/extproc/ext_proc.go
@@ -440,6 +440,10 @@ func (i *clientInterceptor) NewStream(ctx context.Context, ri resolver.RPCInfo, 
 			procRecvDone: make(chan struct{}),
 		}
 
+		// Start background goroutine to receive any messages from the external
+		// processor server and discard them.
+		go ocs.discardProcessorResponsesLoop()
+
 		// If the request header processing mode is set to "Send", forward the
 		// headers to the external processor server.
 		if i.config.processingModes.requestHeaderMode == modeSend {
@@ -460,9 +464,6 @@ func (i *clientInterceptor) NewStream(ctx context.Context, ri resolver.RPCInfo, 
 			return nil, err
 		}
 		ocs.recordMetric(clientHeadersDurationMetric, timeSince(ocs.clientHeadersStartTime).Seconds())
-		// Start background goroutine to receive any messages from the external
-		// processor server and discard them.
-		go ocs.discardProcessorResponsesLoop()
 
 		return ocs, nil
 	}

--- a/internal/xds/httpfilter/extproc/ext_proc_ext_test.go
+++ b/internal/xds/httpfilter/extproc/ext_proc_ext_test.go
@@ -5074,11 +5074,11 @@ func (s) TestExtProcChannelRetention_XDSConfigUpdate(t *testing.T) {
 	}
 }
 
-// TestExtProcChannelRetention_UnaryRPCFail verifies that when ext proc is
+// TestExtProcChannelRetention_UnaryRPC verifies that when ext proc is
 // configured for a unary RPC and the RPC fails after successfully establishing
 // the dataplane stream but before invoking any Send/Recv functions on it, the
 // channel is closed on failure.
-func (s) TestExtProcChannelRetention_UnaryRPCFail(t *testing.T) {
+func (s) TestExtProcChannelRetention_UnaryRPC(t *testing.T) {
 	tests := []struct {
 		name              string
 		observabilityMode bool
@@ -5130,11 +5130,11 @@ func (s) TestExtProcChannelRetention_UnaryRPCFail(t *testing.T) {
 
 			cc, err := setupTestClient(t, extProcAddr, &v3procfilterpb.ExternalProcessor{
 				ProcessingMode: &v3procfilterpb.ProcessingMode{
-					RequestHeaderMode:   v3procfilterpb.ProcessingMode_SKIP,
+					RequestHeaderMode:   v3procfilterpb.ProcessingMode_SEND,
 					ResponseHeaderMode:  v3procfilterpb.ProcessingMode_SEND,
 					RequestBodyMode:     v3procfilterpb.ProcessingMode_GRPC,
-					ResponseBodyMode:    v3procfilterpb.ProcessingMode_NONE,
-					ResponseTrailerMode: v3procfilterpb.ProcessingMode_SKIP,
+					ResponseBodyMode:    v3procfilterpb.ProcessingMode_GRPC,
+					ResponseTrailerMode: v3procfilterpb.ProcessingMode_SEND,
 				},
 				FailureModeAllow:  false,
 				ObservabilityMode: test.observabilityMode,
@@ -5149,10 +5149,10 @@ func (s) TestExtProcChannelRetention_UnaryRPCFail(t *testing.T) {
 			// Expect the unary RPC to fail because the proc server fails immediately.
 			client := testgrpc.NewTestServiceClient(cc)
 			reqMsg := &testpb.SimpleRequest{Payload: &testpb.Payload{Body: []byte(reqBodyC1)}}
-			if _, err = client.UnaryCall(ctx, reqMsg); status.Code(err) != codes.Internal || !strings.Contains(err.Error(), "proc server immediate failure") {
-				t.Fatalf("UnaryCall() status code = %v ,err %v, want %v , error %v", status.Code(err), err, codes.Internal, "proc server immediate failure")
-			}
-
+			// Do not check the error because for observability mode, in some cases
+			// the RPC could succeed before the proc server has a chance to fail the
+			// RPC. But in that case too, the interceptor should be closed.
+			client.UnaryCall(ctx, reqMsg)
 			// Close the client channel so that interceptor.Close() is called.
 			cc.Close()
 

--- a/internal/xds/httpfilter/extproc/ext_proc_ext_test.go
+++ b/internal/xds/httpfilter/extproc/ext_proc_ext_test.go
@@ -4630,110 +4630,127 @@ func verifyMetric(t *testing.T, md stats.MetricsData, expectedName string, expec
 // Only when the external processor RPC finishes does its OnFinish CallOption
 // drop the reference count to 0 and close the external processor channel.
 func (s) TestExtProcChannelRetention(t *testing.T) {
-	blockChan := make(chan struct{})
-	processFunc := func(stream v3procservicegrpc.ExternalProcessor_ProcessServer) error {
-		// Receive response header and respond with no mutations.
-		req, err := stream.Recv()
-		if err != nil {
-			return err
-		}
-		if req.GetRequestHeaders() == nil {
-			return fmt.Errorf("proc server got %v, want response headers", req)
-		}
-		if err := stream.Send(requestHeadersResponse(nil, nil)); err != nil {
-			return err
-		}
-		// Receive response trailers and respond with no mutations.
-		req, err = stream.Recv()
-		if err != nil {
-			return err
-		}
-		if req.GetResponseTrailers() == nil {
-			return fmt.Errorf("proc server got %v, want response trailers", req)
-		}
-		if err := stream.Send(responseTrailersResponse(nil, nil)); err != nil {
-			return err
-		}
-		// Block here so that the external processor RPC remains open after
-		// the dataplane RPC completes.
-		select {
-		case <-blockChan:
-		case <-stream.Context().Done():
-		}
-		return nil
-	}
-	lisAddr, _ := startTestExtProcessor(t, processFunc)
-
-	closeChan := make(chan struct{}, 1)
-
-	origCreate := internal.CreateExtProcChannel
-	internal.CreateExtProcChannel = func(cfg xdsresource.GRPCServiceConfig) (grpc.ClientConnInterface, func() error, error) {
-		cc, err := grpc.NewClient(cfg.TargetURI, grpc.WithTransportCredentials(insecure.NewCredentials()))
-		if err != nil {
-			return nil, nil, err
-		}
-		closeFunc := func() error {
-			close(closeChan)
-			return cc.Close()
-		}
-		return cc, closeFunc, nil
-	}
-	t.Cleanup(func() {
-		internal.CreateExtProcChannel = origCreate
-	})
-
-	stub := stubserver.StartTestService(t, nil)
-	defer stub.Stop()
-
-	cc, err := setupTestClient(t, lisAddr, &v3procfilterpb.ExternalProcessor{
-		ProcessingMode: &v3procfilterpb.ProcessingMode{
-			RequestHeaderMode:   v3procfilterpb.ProcessingMode_SEND,
-			ResponseHeaderMode:  v3procfilterpb.ProcessingMode_SKIP,
-			ResponseTrailerMode: v3procfilterpb.ProcessingMode_SEND,
+	tests := []struct {
+		name              string
+		observabilityMode bool
+	}{
+		{
+			name:              "observability_mode_disabled",
+			observabilityMode: false,
 		},
-		FailureModeAllow: false,
-	}, stub.Address)
-	if err != nil {
-		t.Fatalf("Failed to dial: %v", err)
+		{
+			name:              "observability_mode_enabled",
+			observabilityMode: true,
+		},
 	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			blockChan := make(chan struct{})
+			processFunc := func(stream v3procservicegrpc.ExternalProcessor_ProcessServer) error {
+				// Receive response header and respond with no mutations.
+				req, err := stream.Recv()
+				if err != nil {
+					return err
+				}
+				if req.GetRequestHeaders() == nil {
+					return fmt.Errorf("proc server got %v, want response headers", req)
+				}
+				if err := stream.Send(requestHeadersResponse(nil, nil)); err != nil {
+					return err
+				}
+				// Receive response trailers and respond with no mutations.
+				req, err = stream.Recv()
+				if err != nil {
+					return err
+				}
+				if req.GetResponseTrailers() == nil {
+					return fmt.Errorf("proc server got %v, want response trailers", req)
+				}
+				if err := stream.Send(responseTrailersResponse(nil, nil)); err != nil {
+					return err
+				}
+				// Block here so that the external processor RPC remains open after
+				// the dataplane RPC completes.
+				select {
+				case <-blockChan:
+				case <-stream.Context().Done():
+				}
+				return nil
+			}
+			extProcAddr, _ := startTestExtProcessor(t, processFunc)
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
+			closeChan := make(chan struct{})
 
-	client := testgrpc.NewTestServiceClient(cc)
-	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
-		t.Fatalf("EmptyCall() failed: %v", err)
-	}
+			// Override CreateExtProcChannel to signal when the channel is closed.
+			origCreate := internal.CreateExtProcChannel
+			internal.CreateExtProcChannel = func(cfg xdsresource.GRPCServiceConfig) (grpc.ClientConnInterface, func() error, error) {
+				cc, err := grpc.NewClient(cfg.TargetURI, grpc.WithTransportCredentials(insecure.NewCredentials()))
+				if err != nil {
+					return nil, nil, err
+				}
+				closeFunc := func() error {
+					close(closeChan)
+					return cc.Close()
+				}
+				return cc, closeFunc, nil
+			}
+			defer func() { internal.CreateExtProcChannel = origCreate }()
 
-	// The dataplane RPC has completed. Now close the client channel so that
-	// interceptor.Close() is called.
-	cc.Close()
+			stub := stubserver.StartTestService(t, nil)
+			defer stub.Stop()
 
-	// Verify that the external processor channel has NOT been closed yet, because
-	// the Process RPC is still blocked in processFunc.
-	select {
-	case <-closeChan:
-		t.Fatalf("Extproc channel closed before Process RPC completed")
-	case <-time.After(defaultTestShortTimeout):
-	}
+			cc, err := setupTestClient(t, extProcAddr, &v3procfilterpb.ExternalProcessor{
+				ProcessingMode: &v3procfilterpb.ProcessingMode{
+					RequestHeaderMode:   v3procfilterpb.ProcessingMode_SEND,
+					ResponseHeaderMode:  v3procfilterpb.ProcessingMode_SKIP,
+					ResponseTrailerMode: v3procfilterpb.ProcessingMode_SEND,
+				},
+				FailureModeAllow:  false,
+				ObservabilityMode: test.observabilityMode,
+			}, stub.Address)
+			if err != nil {
+				t.Fatalf("Failed to dial: %v", err)
+			}
 
-	// Unblock processFunc so that the Process RPC completes and invokes its
-	// OnFinish CallOption callback.
-	close(blockChan)
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+			defer cancel()
 
-	// Verify that the extproc channel is now closed.
-	select {
-	case <-closeChan:
-	case <-time.After(defaultTestTimeout):
-		t.Fatalf("Timeout waiting for extproc channel to close after Process RPC completed")
+			client := testgrpc.NewTestServiceClient(cc)
+			if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
+				t.Fatalf("EmptyCall() failed: %v", err)
+			}
+
+			// The dataplane RPC has completed. Now close the client channel so that
+			// interceptor.Close() is called.
+			cc.Close()
+
+			// Verify that the external processor channel has NOT been closed yet, because
+			// the Process RPC is still blocked in processFunc.
+			select {
+			case <-closeChan:
+				t.Fatalf("Extproc channel closed before Process RPC completed")
+			case <-time.After(defaultTestShortTimeout):
+			}
+
+			// Unblock processFunc so that the Process RPC completes and invokes its
+			// OnFinish CallOption callback.
+			close(blockChan)
+
+			// Verify that the extproc channel is now closed.
+			select {
+			case <-closeChan:
+			case <-time.After(defaultTestTimeout):
+				t.Fatalf("Timeout waiting for extproc channel to close after Process RPC completed")
+			}
+		})
 	}
 }
 
 // TestExtProcChannelRetention_XDSConfigUpdate verifies that when an xDS config
-// update changes the external processor filter configuration to refer to a
-// different gRPC service (thereby closing the old interceptor), the old
-// external processor channel remains open until any ongoing RPCs on that old
-// channel have completed.
+// update changes the external processor configuration to refer to a different
+// gRPC service (thereby closing the old interceptor), the old external
+// processor channel remains open until any ongoing RPCs on that old channel
+// have completed.
 func (s) TestExtProcChannelRetention_XDSConfigUpdate(t *testing.T) {
 	processFunc1 := func(stream v3procservicegrpc.ExternalProcessor_ProcessServer) error {
 		// Receive response header and respond with no mutations.
@@ -4765,150 +4782,162 @@ func (s) TestExtProcChannelRetention_XDSConfigUpdate(t *testing.T) {
 		return nil
 	}
 
-	lisAddr1, _ := startTestExtProcessor(t, processFunc1)
-	lisAddr2, _ := startTestExtProcessor(t, processFunc2)
-
-	closeChan := make(chan struct{}, 1)
-
-	origCreate := internal.CreateExtProcChannel
-	internal.CreateExtProcChannel = func(cfg xdsresource.GRPCServiceConfig) (grpc.ClientConnInterface, func() error, error) {
-		cc, err := grpc.NewClient(cfg.TargetURI, grpc.WithTransportCredentials(insecure.NewCredentials()))
-		if err != nil {
-			return nil, nil, err
-		}
-		if cfg.TargetURI == lisAddr1 {
-			closeFunc := func() error {
-				close(closeChan)
-				return cc.Close()
-			}
-			return cc, closeFunc, nil
-		}
-		closeFunc := func() error {
-			return cc.Close()
-		}
-		return cc, closeFunc, nil
-	}
-	t.Cleanup(func() {
-		internal.CreateExtProcChannel = origCreate
-	})
-
-	blockChan := make(chan struct{})
-	enteredChan := make(chan struct{})
-	stub := stubserver.StartTestService(t, &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
-			close(enteredChan)
-			select {
-			case <-blockChan:
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			}
-			return &testpb.Empty{}, nil
+	tests := []struct {
+		name              string
+		observabilityMode bool
+	}{
+		{
+			name:              "observability_mode_disabled",
+			observabilityMode: false,
 		},
-	})
-	defer stub.Stop()
+		{
+			name:              "observability_mode_enabled",
+			observabilityMode: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			extProcAddr1, _ := startTestExtProcessor(t, processFunc1)
+			extProcAddr2, _ := startTestExtProcessor(t, processFunc2)
 
-	managementServer, nodeID, _, xdsResolver := setup.ManagementServerAndResolver(t)
-	const serviceName = "test-service"
+			closeChan := make(chan struct{})
 
-	updateExtProc := func(extProcAddr string) {
-		resources := e2e.DefaultClientResources(e2e.ResourceParams{
-			DialTarget: serviceName,
-			NodeID:     nodeID,
-			Host:       "localhost",
-			Port:       testutils.ParsePort(t, stub.Address),
-			SecLevel:   e2e.SecurityLevelNone,
-		})
-		hcm := new(v3httppb.HttpConnectionManager)
-		apiListener := resources.Listeners[0].GetApiListener().GetApiListener()
-		if err := apiListener.UnmarshalTo(hcm); err != nil {
-			t.Fatalf("Failed to unmarshal apiListener: %v", err)
-		}
-		extProcConfig := &v3procfilterpb.ExternalProcessor{
-			ProcessingMode: &v3procfilterpb.ProcessingMode{
-				RequestHeaderMode:   v3procfilterpb.ProcessingMode_SEND,
-				ResponseHeaderMode:  v3procfilterpb.ProcessingMode_SKIP,
-				ResponseTrailerMode: v3procfilterpb.ProcessingMode_SEND,
-			},
-			FailureModeAllow: false,
-			GrpcService: &v3corepb.GrpcService{
-				TargetSpecifier: &v3corepb.GrpcService_GoogleGrpc_{
-					GoogleGrpc: &v3corepb.GrpcService_GoogleGrpc{
-						TargetUri: extProcAddr,
-					},
+			// Override CreateExtProcChannel to signal when the channel is closed and
+			// dial to correct proc server.
+			origCreate := internal.CreateExtProcChannel
+			internal.CreateExtProcChannel = func(cfg xdsresource.GRPCServiceConfig) (grpc.ClientConnInterface, func() error, error) {
+				cc, err := grpc.NewClient(cfg.TargetURI, grpc.WithTransportCredentials(insecure.NewCredentials()))
+				if err != nil {
+					return nil, nil, err
+				}
+				closeFunc := func() error {
+					return cc.Close()
+				}
+				if cfg.TargetURI == extProcAddr1 {
+					closeFunc = func() error {
+						close(closeChan)
+						return cc.Close()
+					}
+				}
+				return cc, closeFunc, nil
+			}
+			defer func() { internal.CreateExtProcChannel = origCreate }()
+
+			blockChan := make(chan struct{})
+			enteredChan := make(chan struct{})
+			stub := stubserver.StartTestService(t, &stubserver.StubServer{
+				EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
+					close(enteredChan)
+					select {
+					case <-blockChan:
+					case <-ctx.Done():
+						return nil, ctx.Err()
+					}
+					return &testpb.Empty{}, nil
 				},
-			},
-		}
-		hcm.HttpFilters = append([]*v3httppb.HttpFilter{e2e.HTTPFilter("extproc", extProcConfig)}, hcm.HttpFilters...)
-		hcmAny := testutils.MarshalAny(t, hcm)
-		resources.Listeners[0].ApiListener.ApiListener = hcmAny
-		resources.Listeners[0].FilterChains[0].Filters[0].ConfigType = &v3listenerpb.Filter_TypedConfig{TypedConfig: hcmAny}
+			})
+			defer stub.Stop()
 
-		ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-		defer cancel()
-		if err := managementServer.Update(ctx, resources); err != nil {
-			t.Fatalf("Failed to update management server: %v", err)
-		}
+			managementServer, nodeID, _, xdsResolver := setup.ManagementServerAndResolver(t)
+			const serviceName = "test-service"
+
+			updateExtProc := func(extProcAddr string) {
+				resources := e2e.DefaultClientResources(e2e.ResourceParams{
+					DialTarget: serviceName,
+					NodeID:     nodeID,
+					Host:       "localhost",
+					Port:       testutils.ParsePort(t, stub.Address),
+					SecLevel:   e2e.SecurityLevelNone,
+				})
+				hcm := new(v3httppb.HttpConnectionManager)
+				apiListener := resources.Listeners[0].GetApiListener().GetApiListener()
+				if err := apiListener.UnmarshalTo(hcm); err != nil {
+					t.Fatalf("Failed to unmarshal apiListener: %v", err)
+				}
+				extProcConfig := &v3procfilterpb.ExternalProcessor{
+					ProcessingMode: &v3procfilterpb.ProcessingMode{
+						RequestHeaderMode:   v3procfilterpb.ProcessingMode_SEND,
+						ResponseHeaderMode:  v3procfilterpb.ProcessingMode_SKIP,
+						ResponseTrailerMode: v3procfilterpb.ProcessingMode_SEND,
+					},
+					FailureModeAllow:  false,
+					ObservabilityMode: test.observabilityMode,
+					GrpcService: &v3corepb.GrpcService{
+						TargetSpecifier: &v3corepb.GrpcService_GoogleGrpc_{
+							GoogleGrpc: &v3corepb.GrpcService_GoogleGrpc{
+								TargetUri: extProcAddr,
+							},
+						},
+					},
+				}
+				hcm.HttpFilters = append([]*v3httppb.HttpFilter{e2e.HTTPFilter("extproc", extProcConfig)}, hcm.HttpFilters...)
+				hcmAny := testutils.MarshalAny(t, hcm)
+				resources.Listeners[0].ApiListener.ApiListener = hcmAny
+				resources.Listeners[0].FilterChains[0].Filters[0].ConfigType = &v3listenerpb.Filter_TypedConfig{TypedConfig: hcmAny}
+
+				ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+				defer cancel()
+				if err := managementServer.Update(ctx, resources); err != nil {
+					t.Fatalf("Failed to update management server: %v", err)
+				}
+			}
+
+			// Configure initial xDS resource pointing to extproc server 1.
+			updateExtProc(extProcAddr1)
+
+			dialOpts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(xdsResolver)}
+			cc, err := grpc.NewClient("xds:///"+serviceName, dialOpts...)
+			if err != nil {
+				t.Fatalf("Failed to dial: %v", err)
+			}
+			defer cc.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+			defer cancel()
+
+			client := testgrpc.NewTestServiceClient(cc)
+
+			// Make the first RPC using extproc server 1 in a background goroutine.
+			// The RPC remains in flight because the backend is blocked on blockChan.
+			go func() {
+				if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
+					t.Errorf("First EmptyCall() failed: %v", err)
+				}
+			}()
+
+			<-enteredChan
+
+			// Verify that the proc channel is not closed yet because the RPC has not
+			// completed.
+			select {
+			case <-closeChan:
+				t.Fatalf("Expected extproc channel to NOT close immediately")
+			case <-time.After(defaultTestShortTimeout):
+			}
+
+			// Send an xDS config update changing the external processor to server 2.
+			// This will close the old interceptor for server 1.
+			updateExtProc(extProcAddr2)
+
+			// Verify that the proc channel is not closed yet because the RPC has not
+			// completed.
+			select {
+			case <-closeChan:
+				t.Fatalf("Expected extproc channel to NOT close immediately after XDS update")
+			case <-time.After(defaultTestShortTimeout):
+			}
+
+			// Unblock RPC so that it completes and invokes OnFinish.
+			close(blockChan)
+
+			// Verify that proc channel is now closed.
+			select {
+			case <-closeChan:
+			case <-time.After(defaultTestTimeout):
+				t.Fatalf("Timeout waiting for extproc channel to close after RPC completed")
+			}
+		})
 	}
-
-	// Configure initial xDS resource pointing to extproc server 1.
-	updateExtProc(lisAddr1)
-
-	dialOpts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(xdsResolver)}
-	cc, err := grpc.NewClient("xds:///"+serviceName, dialOpts...)
-	if err != nil {
-		t.Fatalf("Failed to dial: %v", err)
-	}
-	defer cc.Close()
-
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-
-	client := testgrpc.NewTestServiceClient(cc)
-
-	rpcDone := make(chan struct{})
-	// Make the first RPC using extproc server 1 in a background goroutine.
-	// The RPC remains in flight because the backend is blocked on blockChan.
-	go func() {
-		defer close(rpcDone)
-		if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
-			t.Errorf("First EmptyCall() failed: %v", err)
-		}
-	}()
-
-	<-enteredChan
-
-	// Verify that the proc channel is not closed yet because the RPC has not
-	// completed.
-	select {
-	case <-closeChan:
-		t.Fatalf("Expected extproc channel to NOT close immediately")
-	case <-time.After(defaultTestShortTimeout):
-	}
-
-	// Send an xDS config update changing the external processor to server 2.
-	// This will close the old interceptor for server 1.
-	updateExtProc(lisAddr2)
-
-	// Verify that the proc channel is not closed yet because the RPC has not
-	// completed.
-	select {
-	case <-closeChan:
-		t.Fatalf("Expected extproc channel to NOT close immediately")
-	case <-time.After(defaultTestShortTimeout):
-	}
-
-	// Unblock RPC so that it completes and invokes OnFinish.
-	close(blockChan)
-
-	<-rpcDone
-
-	// Verify that proc channel is now closed.
-	select {
-	case <-closeChan:
-	case <-time.After(defaultTestTimeout):
-		t.Fatalf("Timeout waiting for extproc channel to close after RPC completed")
-	}
-
 }
 
 // TestExtProcChannelRetention_UnaryRPCFail verifies that when ext proc is
@@ -4916,76 +4945,89 @@ func (s) TestExtProcChannelRetention_XDSConfigUpdate(t *testing.T) {
 // the dataplane stream but before invoking any Send/Recv functions on it, the
 // channel is closed on failure.
 func (s) TestExtProcChannelRetention_UnaryRPCFail(t *testing.T) {
-	lisAddr, _ := startTestExtProcessor(t, func(v3procservicegrpc.ExternalProcessor_ProcessServer) error {
-		return status.Error(codes.Unavailable, "proc server immediate failure")
-	})
-
-	closeChan := make(chan struct{})
-
-	origCreate := internal.CreateExtProcChannel
-	internal.CreateExtProcChannel = func(cfg xdsresource.GRPCServiceConfig) (grpc.ClientConnInterface, func() error, error) {
-		cc, err := grpc.NewClient(cfg.TargetURI, grpc.WithTransportCredentials(insecure.NewCredentials()))
-		if err != nil {
-			return nil, nil, err
-		}
-		closeFunc := func() error {
-			close(closeChan)
-			return cc.Close()
-		}
-		return cc, closeFunc, nil
-	}
-	t.Cleanup(func() {
-		internal.CreateExtProcChannel = origCreate
-	})
-
-	stub := stubserver.StartTestService(t, &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
-			if body := string(in.GetPayload().GetBody()); body != reqBodyC1 {
-				return nil, fmt.Errorf("unexpected request body: %q, want %q", body, reqBodyC1)
-			}
-			if err := grpc.SendHeader(ctx, metadata.Pairs("test-header", "test-val")); err != nil {
-				return nil, err
-			}
-			return &testpb.SimpleResponse{Payload: in.GetPayload()}, nil
+	tests := []struct {
+		name              string
+		observabilityMode bool
+	}{
+		{
+			name:              "observability_mode_disabled",
+			observabilityMode: false,
 		},
-	})
-	defer stub.Stop()
-
-	cc, err := setupTestClient(t, lisAddr, &v3procfilterpb.ExternalProcessor{
-		ProcessingMode: &v3procfilterpb.ProcessingMode{
-			RequestHeaderMode:   v3procfilterpb.ProcessingMode_SKIP,
-			ResponseHeaderMode:  v3procfilterpb.ProcessingMode_SEND,
-			RequestBodyMode:     v3procfilterpb.ProcessingMode_GRPC,
-			ResponseBodyMode:    v3procfilterpb.ProcessingMode_NONE,
-			ResponseTrailerMode: v3procfilterpb.ProcessingMode_SKIP,
+		{
+			name:              "observability_mode_enabled",
+			observabilityMode: true,
 		},
-		FailureModeAllow: false,
-	}, stub.Address)
-	if err != nil {
-		t.Fatalf("Failed to dial: %v", err)
 	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			extProcAddr, _ := startTestExtProcessor(t, func(v3procservicegrpc.ExternalProcessor_ProcessServer) error {
+				return status.Error(codes.Unavailable, "proc server immediate failure")
+			})
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
+			closeChan := make(chan struct{})
 
-	// Expect the unary RPC to fail because the proc server fails immediately.
-	client := testgrpc.NewTestServiceClient(cc)
-	reqMsg := &testpb.SimpleRequest{Payload: &testpb.Payload{Body: []byte(reqBodyC1)}}
-	_, err = client.UnaryCall(ctx, reqMsg)
-	if got, want := status.Code(err), codes.Internal; got != want {
-		t.Fatalf("UnaryCall() status code = %v, want %v", got, want)
-	}
-	if !strings.Contains(err.Error(), "proc server immediate failure") {
-		t.Fatalf("UnaryCall() error = %v, want error containing %q", err, "proc server immediate failure")
-	}
+			// Override CreateExtProcChannel to signal when the channel is closed.
+			origCreate := internal.CreateExtProcChannel
+			internal.CreateExtProcChannel = func(cfg xdsresource.GRPCServiceConfig) (grpc.ClientConnInterface, func() error, error) {
+				cc, err := grpc.NewClient(cfg.TargetURI, grpc.WithTransportCredentials(insecure.NewCredentials()))
+				if err != nil {
+					return nil, nil, err
+				}
+				closeFunc := func() error {
+					close(closeChan)
+					return cc.Close()
+				}
+				return cc, closeFunc, nil
+			}
+			defer func() { internal.CreateExtProcChannel = origCreate }()
 
-	// Close the client channel so that interceptor.Close() is called.
-	cc.Close()
+			stub := stubserver.StartTestService(t, &stubserver.StubServer{
+				UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+					if body := string(in.GetPayload().GetBody()); body != reqBodyC1 {
+						return nil, fmt.Errorf("unexpected request body: %q, want %q", body, reqBodyC1)
+					}
+					if err := grpc.SendHeader(ctx, metadata.Pairs("test-header", "test-val")); err != nil {
+						return nil, err
+					}
+					return &testpb.SimpleResponse{Payload: in.GetPayload()}, nil
+				},
+			})
+			defer stub.Stop()
 
-	// Verify that the extproc channel is closed.
-	select {
-	case <-closeChan:
-	case <-time.After(defaultTestTimeout):
-		t.Fatalf("Timeout waiting for extproc channel to close after interceptor is closed")
+			cc, err := setupTestClient(t, extProcAddr, &v3procfilterpb.ExternalProcessor{
+				ProcessingMode: &v3procfilterpb.ProcessingMode{
+					RequestHeaderMode:   v3procfilterpb.ProcessingMode_SKIP,
+					ResponseHeaderMode:  v3procfilterpb.ProcessingMode_SEND,
+					RequestBodyMode:     v3procfilterpb.ProcessingMode_GRPC,
+					ResponseBodyMode:    v3procfilterpb.ProcessingMode_NONE,
+					ResponseTrailerMode: v3procfilterpb.ProcessingMode_SKIP,
+				},
+				FailureModeAllow:  false,
+				ObservabilityMode: test.observabilityMode,
+			}, stub.Address)
+			if err != nil {
+				t.Fatalf("Failed to dial: %v", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+			defer cancel()
+
+			// Expect the unary RPC to fail because the proc server fails immediately.
+			client := testgrpc.NewTestServiceClient(cc)
+			reqMsg := &testpb.SimpleRequest{Payload: &testpb.Payload{Body: []byte(reqBodyC1)}}
+			if _, err = client.UnaryCall(ctx, reqMsg); status.Code(err) != codes.Internal || !strings.Contains(err.Error(), "proc server immediate failure") {
+				t.Fatalf("UnaryCall() status code = %v ,err %v, want %v , error %v", status.Code(err), err, codes.Internal, "proc server immediate failure")
+			}
+
+			// Close the client channel so that interceptor.Close() is called.
+			cc.Close()
+
+			// Verify that the extproc channel is closed.
+			select {
+			case <-closeChan:
+			case <-time.After(defaultTestTimeout):
+				t.Fatalf("Timeout waiting for extproc channel to close after interceptor is closed")
+			}
+		})
 	}
 }

--- a/internal/xds/httpfilter/extproc/ext_proc_ext_test.go
+++ b/internal/xds/httpfilter/extproc/ext_proc_ext_test.go
@@ -4950,6 +4950,8 @@ func (s) TestExtProcChannelRetention_XDSConfigUpdate(t *testing.T) {
 
 			blockChan := make(chan struct{})
 			enteredChan := make(chan struct{})
+			// EmptyCallF is expected to block until the test unblocks it (by
+			// closing blockChan), while UnaryCallF completes immediately.
 			stub := stubserver.StartTestService(t, &stubserver.StubServer{
 				EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
 					close(enteredChan)
@@ -5118,21 +5120,15 @@ func (s) TestExtProcChannelRetention_UnaryRPC(t *testing.T) {
 			defer func() { internal.CreateExtProcChannel = origCreate }()
 
 			stub := stubserver.StartTestService(t, &stubserver.StubServer{
-				UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
-					if body := string(in.GetPayload().GetBody()); body != reqBodyC1 {
-						return nil, fmt.Errorf("unexpected request body: %q, want %q", body, reqBodyC1)
-					}
-					if err := grpc.SendHeader(ctx, metadata.Pairs("test-header", "test-val")); err != nil {
-						return nil, err
-					}
-					return &testpb.SimpleResponse{Payload: in.GetPayload()}, nil
+				EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
+					return &testpb.Empty{}, nil
 				},
 			})
 			defer stub.Stop()
 
 			cc, err := setupTestClient(t, extProcAddr, &v3procfilterpb.ExternalProcessor{
 				ProcessingMode: &v3procfilterpb.ProcessingMode{
-					RequestHeaderMode:   v3procfilterpb.ProcessingMode_SEND,
+					RequestHeaderMode:   v3procfilterpb.ProcessingMode_SKIP,
 					ResponseHeaderMode:  v3procfilterpb.ProcessingMode_SEND,
 					RequestBodyMode:     v3procfilterpb.ProcessingMode_GRPC,
 					ResponseBodyMode:    v3procfilterpb.ProcessingMode_GRPC,
@@ -5150,11 +5146,10 @@ func (s) TestExtProcChannelRetention_UnaryRPC(t *testing.T) {
 
 			// Expect the unary RPC to fail because the proc server fails immediately.
 			client := testgrpc.NewTestServiceClient(cc)
-			reqMsg := &testpb.SimpleRequest{Payload: &testpb.Payload{Body: []byte(reqBodyC1)}}
 			// Do not check the error because for observability mode, in some cases
 			// the RPC could succeed before the proc server has a chance to fail the
 			// RPC. But in that case too, the interceptor should be closed.
-			client.UnaryCall(ctx, reqMsg)
+			client.EmptyCall(ctx, &testpb.Empty{})
 			// Close the client channel so that interceptor.Close() is called.
 			cc.Close()
 

--- a/internal/xds/httpfilter/extproc/ext_proc_ext_test.go
+++ b/internal/xds/httpfilter/extproc/ext_proc_ext_test.go
@@ -4886,7 +4886,7 @@ func (s) TestExtProcChannelRetention(t *testing.T) {
 // processor channel remains open until any ongoing RPCs on that old channel
 // have completed.
 func (s) TestExtProcChannelRetention_XDSConfigUpdate(t *testing.T) {
-	processFunc1 := func(stream v3procservicegrpc.ExternalProcessor_ProcessServer) error {
+	processFunc := func(stream v3procservicegrpc.ExternalProcessor_ProcessServer) error {
 		// Receive response header and respond with no mutations.
 		req, err := stream.Recv()
 		if err != nil {
@@ -4912,10 +4912,6 @@ func (s) TestExtProcChannelRetention_XDSConfigUpdate(t *testing.T) {
 		return nil
 	}
 
-	processFunc2 := func(v3procservicegrpc.ExternalProcessor_ProcessServer) error {
-		return nil
-	}
-
 	tests := []struct {
 		name              string
 		observabilityMode bool
@@ -4931,12 +4927,12 @@ func (s) TestExtProcChannelRetention_XDSConfigUpdate(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			extProcAddr1, _ := startTestExtProcessor(t, processFunc1)
-			extProcAddr2, _ := startTestExtProcessor(t, processFunc2)
+			extProcAddr1, _ := startTestExtProcessor(t, processFunc)
+			extProcAddr2, _ := startTestExtProcessor(t, processFunc)
 
-			closeChan := make(chan struct{})
+			closeChan := make(chan string, 1)
 
-			// Override CreateExtProcChannel to signal when the channel is closed and
+			// Override CreateExtProcChannel to signal when a channel is closed and
 			// dial to correct proc server.
 			origCreate := internal.CreateExtProcChannel
 			internal.CreateExtProcChannel = func(cfg xdsresource.GRPCServiceConfig) (grpc.ClientConnInterface, func() error, error) {
@@ -4945,13 +4941,8 @@ func (s) TestExtProcChannelRetention_XDSConfigUpdate(t *testing.T) {
 					return nil, nil, err
 				}
 				closeFunc := func() error {
+					closeChan <- cfg.TargetURI
 					return cc.Close()
-				}
-				if cfg.TargetURI == extProcAddr1 {
-					closeFunc = func() error {
-						close(closeChan)
-						return cc.Close()
-					}
 				}
 				return cc, closeFunc, nil
 			}
@@ -4968,6 +4959,9 @@ func (s) TestExtProcChannelRetention_XDSConfigUpdate(t *testing.T) {
 						return nil, ctx.Err()
 					}
 					return &testpb.Empty{}, nil
+				},
+				UnaryCallF: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+					return &testpb.SimpleResponse{}, nil
 				},
 			})
 			defer stub.Stop()
@@ -5041,11 +5035,11 @@ func (s) TestExtProcChannelRetention_XDSConfigUpdate(t *testing.T) {
 
 			<-enteredChan
 
-			// Verify that the proc channel is not closed yet because the RPC has not
-			// completed.
+			// Verify that no proc channel has closed yet because the first RPC has
+			// not completed.
 			select {
-			case <-closeChan:
-				t.Fatalf("Expected extproc channel to NOT close immediately")
+			case addr := <-closeChan:
+				t.Fatalf("Unexpected close of extproc channel %s", addr)
 			case <-time.After(defaultTestShortTimeout):
 			}
 
@@ -5053,20 +5047,28 @@ func (s) TestExtProcChannelRetention_XDSConfigUpdate(t *testing.T) {
 			// This will close the old interceptor for server 1.
 			updateExtProc(extProcAddr2)
 
-			// Verify that the proc channel is not closed yet because the RPC has not
-			// completed.
+			// Make a second RPC and verify that it succeeds.
+			if _, err := client.UnaryCall(ctx, &testpb.SimpleRequest{}); err != nil {
+				t.Fatalf("UnaryCall() failed: %v", err)
+			}
+
+			// Verify that the first extproc channel is still not closed because the
+			// first RPC on that channel has not completed yet.
 			select {
-			case <-closeChan:
-				t.Fatalf("Expected extproc channel to NOT close immediately after XDS update")
+			case addr := <-closeChan:
+				t.Fatalf("Unexpected close of extproc channel %s while first RPC is in flight", addr)
 			case <-time.After(defaultTestShortTimeout):
 			}
 
-			// Unblock RPC so that it completes and invokes OnFinish.
+			// Unblock the first RPC so that it completes and invokes OnFinish.
 			close(blockChan)
 
-			// Verify that proc channel is now closed.
+			// Verify that proc channel 1 is now closed.
 			select {
-			case <-closeChan:
+			case addr := <-closeChan:
+				if addr != extProcAddr1 {
+					t.Fatalf("Closed extproc channel = %s, want %s", addr, extProcAddr1)
+				}
 			case <-time.After(defaultTestTimeout):
 				t.Fatalf("Timeout waiting for extproc channel to close after RPC completed")
 			}

--- a/internal/xds/httpfilter/extproc/ext_proc_ext_test.go
+++ b/internal/xds/httpfilter/extproc/ext_proc_ext_test.go
@@ -4623,3 +4623,357 @@ func verifyMetric(t *testing.T, md stats.MetricsData, expectedName string, expec
 		t.Fatalf("Unexpected data for metric %v, got: %v, want: > 0", expectedName, md.FloatIncr)
 	}
 }
+
+// TestExtProcChannelRetention verifies that the refcounted external processor
+// channel remains open while an external processor RPC (Process) is still in
+// flight—even after the dataplane RPC has completed and its channel is closed.
+// Only when the external processor RPC finishes does its OnFinish CallOption
+// drop the reference count to 0 and close the external processor channel.
+func (s) TestExtProcChannelRetention(t *testing.T) {
+	blockChan := make(chan struct{})
+	processFunc := func(stream v3procservicegrpc.ExternalProcessor_ProcessServer) error {
+		// Receive response header and respond with no mutations.
+		req, err := stream.Recv()
+		if err != nil {
+			return err
+		}
+		if req.GetRequestHeaders() == nil {
+			return fmt.Errorf("proc server got %v, want response headers", req)
+		}
+		if err := stream.Send(requestHeadersResponse(nil, nil)); err != nil {
+			return err
+		}
+		// Receive response trailers and respond with no mutations.
+		req, err = stream.Recv()
+		if err != nil {
+			return err
+		}
+		if req.GetResponseTrailers() == nil {
+			return fmt.Errorf("proc server got %v, want response trailers", req)
+		}
+		if err := stream.Send(responseTrailersResponse(nil, nil)); err != nil {
+			return err
+		}
+		// Block here so that the external processor RPC remains open after
+		// the dataplane RPC completes.
+		select {
+		case <-blockChan:
+		case <-stream.Context().Done():
+		}
+		return nil
+	}
+	lisAddr, _ := startTestExtProcessor(t, processFunc)
+
+	closeChan := make(chan struct{}, 1)
+
+	origCreate := internal.CreateExtProcChannel
+	internal.CreateExtProcChannel = func(cfg xdsresource.GRPCServiceConfig) (grpc.ClientConnInterface, func() error, error) {
+		cc, err := grpc.NewClient(cfg.TargetURI, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err != nil {
+			return nil, nil, err
+		}
+		closeFunc := func() error {
+			close(closeChan)
+			return cc.Close()
+		}
+		return cc, closeFunc, nil
+	}
+	t.Cleanup(func() {
+		internal.CreateExtProcChannel = origCreate
+	})
+
+	stub := stubserver.StartTestService(t, nil)
+	defer stub.Stop()
+
+	cc, err := setupTestClient(t, lisAddr, &v3procfilterpb.ExternalProcessor{
+		ProcessingMode: &v3procfilterpb.ProcessingMode{
+			RequestHeaderMode:   v3procfilterpb.ProcessingMode_SEND,
+			ResponseHeaderMode:  v3procfilterpb.ProcessingMode_SKIP,
+			ResponseTrailerMode: v3procfilterpb.ProcessingMode_SEND,
+		},
+		FailureModeAllow: false,
+	}, stub.Address)
+	if err != nil {
+		t.Fatalf("Failed to dial: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	client := testgrpc.NewTestServiceClient(cc)
+	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
+		t.Fatalf("EmptyCall() failed: %v", err)
+	}
+
+	// The dataplane RPC has completed. Now close the client channel so that
+	// interceptor.Close() is called.
+	cc.Close()
+
+	// Verify that the external processor channel has NOT been closed yet, because
+	// the Process RPC is still blocked in processFunc.
+	select {
+	case <-closeChan:
+		t.Fatalf("Extproc channel closed before Process RPC completed")
+	case <-time.After(defaultTestShortTimeout):
+	}
+
+	// Unblock processFunc so that the Process RPC completes and invokes its
+	// OnFinish CallOption callback.
+	close(blockChan)
+
+	// Verify that the extproc channel is now closed.
+	select {
+	case <-closeChan:
+	case <-time.After(defaultTestTimeout):
+		t.Fatalf("Timeout waiting for extproc channel to close after Process RPC completed")
+	}
+}
+
+// TestExtProcChannelRetention_XDSConfigUpdate verifies that when an xDS config
+// update changes the external processor filter configuration to refer to a
+// different gRPC service (thereby closing the old interceptor), the old
+// external processor channel remains open until any ongoing RPCs on that old
+// channel have completed.
+func (s) TestExtProcChannelRetention_XDSConfigUpdate(t *testing.T) {
+	blockChan := make(chan struct{})
+	processFunc1 := func(stream v3procservicegrpc.ExternalProcessor_ProcessServer) error {
+		// Receive response header and respond with no mutations.
+		req, err := stream.Recv()
+		if err != nil {
+			return err
+		}
+		if req.GetRequestHeaders() == nil {
+			return fmt.Errorf("proc server got %v, want response headers", req)
+		}
+		if err := stream.Send(requestHeadersResponse(nil, nil)); err != nil {
+			return err
+		}
+		// Receive response trailers and respond with no mutations.
+		req, err = stream.Recv()
+		if err != nil {
+			return err
+		}
+		if req.GetResponseTrailers() == nil {
+			return fmt.Errorf("proc server got %v, want response trailers", req)
+		}
+		if err := stream.Send(responseTrailersResponse(nil, nil)); err != nil {
+			return err
+		}
+		// Block here so that the external processor RPC on server 1 remains open
+		// after the dataplane RPC completes.
+		select {
+		case <-blockChan:
+		case <-stream.Context().Done():
+		}
+		return nil
+	}
+
+	processFunc2 := func(v3procservicegrpc.ExternalProcessor_ProcessServer) error {
+		return nil
+	}
+
+	lisAddr1, _ := startTestExtProcessor(t, processFunc1)
+	lisAddr2, _ := startTestExtProcessor(t, processFunc2)
+
+	closeChan := make(chan struct{}, 1)
+
+	origCreate := internal.CreateExtProcChannel
+	internal.CreateExtProcChannel = func(cfg xdsresource.GRPCServiceConfig) (grpc.ClientConnInterface, func() error, error) {
+		cc, err := grpc.NewClient(cfg.TargetURI, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err != nil {
+			return nil, nil, err
+		}
+		if cfg.TargetURI == lisAddr1 {
+			closeFunc := func() error {
+				close(closeChan)
+				return cc.Close()
+			}
+			return cc, closeFunc, nil
+		}
+		closeFunc := func() error {
+			return cc.Close()
+		}
+		return cc, closeFunc, nil
+	}
+	t.Cleanup(func() {
+		internal.CreateExtProcChannel = origCreate
+	})
+
+	stub := stubserver.StartTestService(t, nil)
+	defer stub.Stop()
+
+	managementServer, nodeID, _, xdsResolver := setup.ManagementServerAndResolver(t)
+	const serviceName = "test-service"
+
+	updateExtProc := func(extProcAddr string) {
+		resources := e2e.DefaultClientResources(e2e.ResourceParams{
+			DialTarget: serviceName,
+			NodeID:     nodeID,
+			Host:       "localhost",
+			Port:       testutils.ParsePort(t, stub.Address),
+			SecLevel:   e2e.SecurityLevelNone,
+		})
+		hcm := new(v3httppb.HttpConnectionManager)
+		apiListener := resources.Listeners[0].GetApiListener().GetApiListener()
+		if err := apiListener.UnmarshalTo(hcm); err != nil {
+			t.Fatalf("Failed to unmarshal apiListener: %v", err)
+		}
+		extProcConfig := &v3procfilterpb.ExternalProcessor{
+			ProcessingMode: &v3procfilterpb.ProcessingMode{
+				RequestHeaderMode:   v3procfilterpb.ProcessingMode_SEND,
+				ResponseHeaderMode:  v3procfilterpb.ProcessingMode_SKIP,
+				ResponseTrailerMode: v3procfilterpb.ProcessingMode_SEND,
+			},
+			FailureModeAllow: false,
+			GrpcService: &v3corepb.GrpcService{
+				TargetSpecifier: &v3corepb.GrpcService_GoogleGrpc_{
+					GoogleGrpc: &v3corepb.GrpcService_GoogleGrpc{
+						TargetUri: extProcAddr,
+					},
+				},
+			},
+		}
+		hcm.HttpFilters = append([]*v3httppb.HttpFilter{e2e.HTTPFilter("extproc", extProcConfig)}, hcm.HttpFilters...)
+		hcmAny := testutils.MarshalAny(t, hcm)
+		resources.Listeners[0].ApiListener.ApiListener = hcmAny
+		resources.Listeners[0].FilterChains[0].Filters[0].ConfigType = &v3listenerpb.Filter_TypedConfig{TypedConfig: hcmAny}
+
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+		defer cancel()
+		if err := managementServer.Update(ctx, resources); err != nil {
+			t.Fatalf("Failed to update management server: %v", err)
+		}
+	}
+
+	// Configure initial xDS resource pointing to extproc server 1.
+	updateExtProc(lisAddr1)
+
+	dialOpts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(xdsResolver)}
+	cc, err := grpc.NewClient("xds:///"+serviceName, dialOpts...)
+	if err != nil {
+		t.Fatalf("Failed to dial: %v", err)
+	}
+	defer cc.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	client := testgrpc.NewTestServiceClient(cc)
+
+	// Make the first RPC using extproc server 1. The dataplane RPC will finish,
+	// but the extproc Process RPC remains open because processFunc1 is blocked on
+	// blockChan.
+	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
+		t.Fatalf("First EmptyCall() failed: %v", err)
+	}
+
+	// Verify that the proc channel is not closed yet because the proc RPC has not
+	// completed.
+	select {
+	case <-closeChan:
+		t.Fatalf("Expected extproc channel to NOT close immediately")
+	case <-time.After(defaultTestShortTimeout):
+	}
+
+	// Send an xDS config update changing the external processor to server 2.
+	// This will close the old interceptor for server 1.
+	updateExtProc(lisAddr2)
+
+	// Verify that the proc channel is not closed yet because the proc RPC has not
+	// completed.
+	select {
+	case <-closeChan:
+		t.Fatalf("Expected extproc channel to NOT close immediately")
+	case <-time.After(defaultTestShortTimeout):
+	}
+
+	// Unblock proc RPC so that it completes and invokes OnFinish.
+	close(blockChan)
+
+	// Verify that proc channel is now closed.
+	select {
+	case <-closeChan:
+	case <-time.After(defaultTestTimeout):
+		t.Fatalf("Timeout waiting for extproc channel to close after RPC completed")
+	}
+
+}
+
+// TestExtProcChannelRetention_UnaryRPCFail verifies that when ext proc is
+// configured for a unary RPC and the RPC fails after successfully establishing
+// the dataplane stream but before invoking any Send/Recv functions on it, the
+// channel is closed on failure.
+func (s) TestExtProcChannelRetention_UnaryRPCFail(t *testing.T) {
+	lisAddr, _ := startTestExtProcessor(t, func(v3procservicegrpc.ExternalProcessor_ProcessServer) error {
+		return status.Error(codes.Unavailable, "proc server immediate failure")
+	})
+
+	closeChan := make(chan struct{})
+
+	origCreate := internal.CreateExtProcChannel
+	internal.CreateExtProcChannel = func(cfg xdsresource.GRPCServiceConfig) (grpc.ClientConnInterface, func() error, error) {
+		cc, err := grpc.NewClient(cfg.TargetURI, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err != nil {
+			return nil, nil, err
+		}
+		closeFunc := func() error {
+			close(closeChan)
+			return cc.Close()
+		}
+		return cc, closeFunc, nil
+	}
+	t.Cleanup(func() {
+		internal.CreateExtProcChannel = origCreate
+	})
+
+	stub := stubserver.StartTestService(t, &stubserver.StubServer{
+		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+			if body := string(in.GetPayload().GetBody()); body != reqBodyC1 {
+				return nil, fmt.Errorf("unexpected request body: %q, want %q", body, reqBodyC1)
+			}
+			if err := grpc.SendHeader(ctx, metadata.Pairs("test-header", "test-val")); err != nil {
+				return nil, err
+			}
+			return &testpb.SimpleResponse{Payload: in.GetPayload()}, nil
+		},
+	})
+	defer stub.Stop()
+
+	cc, err := setupTestClient(t, lisAddr, &v3procfilterpb.ExternalProcessor{
+		ProcessingMode: &v3procfilterpb.ProcessingMode{
+			RequestHeaderMode:   v3procfilterpb.ProcessingMode_SKIP,
+			ResponseHeaderMode:  v3procfilterpb.ProcessingMode_SEND,
+			RequestBodyMode:     v3procfilterpb.ProcessingMode_GRPC,
+			ResponseBodyMode:    v3procfilterpb.ProcessingMode_NONE,
+			ResponseTrailerMode: v3procfilterpb.ProcessingMode_SKIP,
+		},
+		FailureModeAllow: false,
+	}, stub.Address)
+	if err != nil {
+		t.Fatalf("Failed to dial: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	// Expect the unary RPC to fail because the proc server fails immediately.
+	client := testgrpc.NewTestServiceClient(cc)
+	reqMsg := &testpb.SimpleRequest{Payload: &testpb.Payload{Body: []byte(reqBodyC1)}}
+	_, err = client.UnaryCall(ctx, reqMsg)
+	if got, want := status.Code(err), codes.Internal; got != want {
+		t.Fatalf("UnaryCall() status code = %v, want %v", got, want)
+	}
+	if !strings.Contains(err.Error(), "proc server immediate failure") {
+		t.Fatalf("UnaryCall() error = %v, want error containing %q", err, "proc server immediate failure")
+	}
+
+	// Close the client channel so that interceptor.Close() is called.
+	cc.Close()
+
+	// Verify that the extproc channel is closed.
+	select {
+	case <-closeChan:
+	case <-time.After(defaultTestTimeout):
+		t.Fatalf("Timeout waiting for extproc channel to close after interceptor is closed")
+	}
+}

--- a/internal/xds/httpfilter/extproc/ext_proc_ext_test.go
+++ b/internal/xds/httpfilter/extproc/ext_proc_ext_test.go
@@ -4735,7 +4735,6 @@ func (s) TestExtProcChannelRetention(t *testing.T) {
 // external processor channel remains open until any ongoing RPCs on that old
 // channel have completed.
 func (s) TestExtProcChannelRetention_XDSConfigUpdate(t *testing.T) {
-	blockChan := make(chan struct{})
 	processFunc1 := func(stream v3procservicegrpc.ExternalProcessor_ProcessServer) error {
 		// Receive response header and respond with no mutations.
 		req, err := stream.Recv()
@@ -4758,12 +4757,6 @@ func (s) TestExtProcChannelRetention_XDSConfigUpdate(t *testing.T) {
 		}
 		if err := stream.Send(responseTrailersResponse(nil, nil)); err != nil {
 			return err
-		}
-		// Block here so that the external processor RPC on server 1 remains open
-		// after the dataplane RPC completes.
-		select {
-		case <-blockChan:
-		case <-stream.Context().Done():
 		}
 		return nil
 	}
@@ -4799,7 +4792,19 @@ func (s) TestExtProcChannelRetention_XDSConfigUpdate(t *testing.T) {
 		internal.CreateExtProcChannel = origCreate
 	})
 
-	stub := stubserver.StartTestService(t, nil)
+	blockChan := make(chan struct{})
+	enteredChan := make(chan struct{})
+	stub := stubserver.StartTestService(t, &stubserver.StubServer{
+		EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
+			close(enteredChan)
+			select {
+			case <-blockChan:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			return &testpb.Empty{}, nil
+		},
+	})
 	defer stub.Stop()
 
 	managementServer, nodeID, _, xdsResolver := setup.ManagementServerAndResolver(t)
@@ -4860,14 +4865,19 @@ func (s) TestExtProcChannelRetention_XDSConfigUpdate(t *testing.T) {
 
 	client := testgrpc.NewTestServiceClient(cc)
 
-	// Make the first RPC using extproc server 1. The dataplane RPC will finish,
-	// but the extproc Process RPC remains open because processFunc1 is blocked on
-	// blockChan.
-	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
-		t.Fatalf("First EmptyCall() failed: %v", err)
-	}
+	rpcDone := make(chan struct{})
+	// Make the first RPC using extproc server 1 in a background goroutine.
+	// The RPC remains in flight because the backend is blocked on blockChan.
+	go func() {
+		defer close(rpcDone)
+		if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
+			t.Errorf("First EmptyCall() failed: %v", err)
+		}
+	}()
 
-	// Verify that the proc channel is not closed yet because the proc RPC has not
+	<-enteredChan
+
+	// Verify that the proc channel is not closed yet because the RPC has not
 	// completed.
 	select {
 	case <-closeChan:
@@ -4879,7 +4889,7 @@ func (s) TestExtProcChannelRetention_XDSConfigUpdate(t *testing.T) {
 	// This will close the old interceptor for server 1.
 	updateExtProc(lisAddr2)
 
-	// Verify that the proc channel is not closed yet because the proc RPC has not
+	// Verify that the proc channel is not closed yet because the RPC has not
 	// completed.
 	select {
 	case <-closeChan:
@@ -4887,8 +4897,10 @@ func (s) TestExtProcChannelRetention_XDSConfigUpdate(t *testing.T) {
 	case <-time.After(defaultTestShortTimeout):
 	}
 
-	// Unblock proc RPC so that it completes and invokes OnFinish.
+	// Unblock RPC so that it completes and invokes OnFinish.
 	close(blockChan)
+
+	<-rpcDone
 
 	// Verify that proc channel is now closed.
 	select {

--- a/internal/xds/resolver/serviceconfig.go
+++ b/internal/xds/resolver/serviceconfig.go
@@ -197,7 +197,7 @@ func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RP
 	if !ok {
 		return nil, annotateErrorWithNodeID(status.Errorf(codes.Internal, "error retrieving cluster for match: %v (%T)", rc, rc), cs.xdsNodeID)
 	}
-	cluster := *rc.Value()
+	cluster := rc.Value()
 	lbCtx := clustermanager.SetPickedCluster(rpcInfo.Context, cluster.name)
 	lbCtx = xdsresource.NewContextWithXDSConfig(lbCtx, cs.xdsConfig)
 	lbCtx = iringhash.SetXDSRequestHash(lbCtx, cs.generateHash(rpcInfo, rt.hashPolicies))
@@ -228,7 +228,6 @@ func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RP
 			}
 			// Decrement the refcount of the route cluster and close the interceptor
 			// if refcount goes to zero.
-			//
 			rc.Decrement()
 		})
 	} else if info, ok := cs.plugins[cluster.name]; ok {

--- a/internal/xds/resolver/serviceconfig.go
+++ b/internal/xds/resolver/serviceconfig.go
@@ -249,6 +249,10 @@ func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RP
 				cluster.interceptor.Close()
 			}
 		})
+	} else {
+		// This should be unreachable because all route clusters are normalized
+		// into cs.clusters or cs.plugins during config selector creation.
+		panic(fmt.Sprintf("matched cluster %q not found in ConfigSelector", cluster.name))
 	}
 
 	if rt.maxStreamDuration != 0 {

--- a/internal/xds/resolver/serviceconfig.go
+++ b/internal/xds/resolver/serviceconfig.go
@@ -25,6 +25,7 @@ import (
 	rand "math/rand/v2"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	xxhash "github.com/cespare/xxhash/v2"
@@ -108,13 +109,14 @@ type virtualHost struct {
 type routeCluster struct {
 	name        string                       // Name of the cluster.
 	interceptor httpfilter.ClientInterceptor // HTTP filters to run for RPCs matching this route.
+	refcount    atomic.Int32                 // Refcount for this cluster.
 }
 
 type route struct {
-	m                 *xdsresource.CompositeMatcher  // converted from route matchers
-	actionType        xdsresource.RouteActionType    // holds route action type
-	clusters          wrr.WRR                        // holds *routeCluster entries
-	interceptors      []httpfilter.ClientInterceptor // Interceptors across clusters belonging to this route
+	m                 *xdsresource.CompositeMatcher // converted from route matchers
+	actionType        xdsresource.RouteActionType   // holds route action type
+	clusters          wrr.WRR                       // holds *routeCluster entries
+	routeClusters     []*routeCluster               // Route clusters belonging to this route
 	maxStreamDuration time.Duration
 	retryConfig       *xdsresource.RetryConfig
 	hashPolicies      []*xdsresource.HashPolicy
@@ -208,7 +210,9 @@ func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RP
 		Context:     lbCtx,
 		Interceptor: cluster.interceptor,
 	}
-
+	// Add a ref to the selected cluster to keep the interceptors alive until RPC
+	// is committed.
+	cluster.refcount.Add(1)
 	if info, ok := cs.clusters[cluster.name]; ok {
 		// Add a ref to the selected cluster, as this RPC needs this
 		// cluster until it is committed.
@@ -223,6 +227,11 @@ func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RP
 				// manager to handle the update flow once and for all.
 				info.unsubscribe()
 			}
+			// Decrement the refcount of the route cluster and close the interceptor
+			// if refcount goes to zero.
+			if v := cluster.refcount.Add(-1); v == 0 {
+				cluster.interceptor.Close()
+			}
 		})
 	} else if info, ok := cs.plugins[cluster.name]; ok {
 		// Add a ref to the selected plugin, as this RPC needs this
@@ -233,6 +242,11 @@ func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RP
 				// This entry will be removed from activePlugins when
 				// producing a new service config update.
 				cs.sendNewServiceConfig()
+			}
+			// Decrement the refcount of the route cluster and close the interceptor
+			// if refcount goes to zero.
+			if v := cluster.refcount.Add(-1); v == 0 {
+				cluster.interceptor.Close()
 			}
 		})
 	}
@@ -331,10 +345,14 @@ func (cs *configSelector) stop() {
 		return
 	}
 
-	// Stop all interceptors associated with this config selector.
+	// Decrement the refcount of all the route clusters associated with this
+	// config selector and close the interceptors of the route cluster if it's
+	// refcount goes to zero.
 	for _, r := range cs.routes {
-		for _, i := range r.interceptors {
-			i.Close()
+		for _, rc := range r.routeClusters {
+			if v := rc.refcount.Add(-1); v == 0 {
+				rc.interceptor.Close()
+			}
 		}
 	}
 

--- a/internal/xds/resolver/serviceconfig.go
+++ b/internal/xds/resolver/serviceconfig.go
@@ -25,11 +25,11 @@ import (
 	rand "math/rand/v2"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	xxhash "github.com/cespare/xxhash/v2"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/grpcutil"
 	iresolver "google.golang.org/grpc/internal/resolver"
 	iringhash "google.golang.org/grpc/internal/ringhash"
@@ -109,14 +109,13 @@ type virtualHost struct {
 type routeCluster struct {
 	name        string                       // Name of the cluster.
 	interceptor httpfilter.ClientInterceptor // HTTP filters to run for RPCs matching this route.
-	refcount    atomic.Int32                 // Refcount for this cluster.
 }
 
 type route struct {
-	m                 *xdsresource.CompositeMatcher // converted from route matchers
-	actionType        xdsresource.RouteActionType   // holds route action type
-	clusters          wrr.WRR                       // holds *routeCluster entries
-	routeClusters     []*routeCluster               // Route clusters belonging to this route
+	m                 *xdsresource.CompositeMatcher        // converted from route matchers
+	actionType        xdsresource.RouteActionType          // holds route action type
+	clusters          wrr.WRR                              // holds *routeCluster entries
+	routeClusters     []*grpcsync.RefCounted[routeCluster] // Route clusters belonging to this route
 	maxStreamDuration time.Duration
 	retryConfig       *xdsresource.RetryConfig
 	hashPolicies      []*xdsresource.HashPolicy
@@ -194,11 +193,11 @@ func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RP
 		return nil, annotateErrorWithNodeID(errUnsupportedClientRouteAction, cs.xdsNodeID)
 	}
 
-	cluster, ok := rt.clusters.Next().(*routeCluster)
+	rc, ok := rt.clusters.Next().(*grpcsync.RefCounted[routeCluster])
 	if !ok {
-		return nil, annotateErrorWithNodeID(status.Errorf(codes.Internal, "error retrieving cluster for match: %v (%T)", cluster, cluster), cs.xdsNodeID)
+		return nil, annotateErrorWithNodeID(status.Errorf(codes.Internal, "error retrieving cluster for match: %v (%T)", rc, rc), cs.xdsNodeID)
 	}
-
+	cluster := *rc.Value()
 	lbCtx := clustermanager.SetPickedCluster(rpcInfo.Context, cluster.name)
 	lbCtx = xdsresource.NewContextWithXDSConfig(lbCtx, cs.xdsConfig)
 	lbCtx = iringhash.SetXDSRequestHash(lbCtx, cs.generateHash(rpcInfo, rt.hashPolicies))
@@ -212,7 +211,7 @@ func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RP
 	}
 	// Add a ref to the selected cluster to keep the interceptors alive until RPC
 	// is committed.
-	cluster.refcount.Add(1)
+	rc.Increment()
 	if info, ok := cs.clusters[cluster.name]; ok {
 		// Add a ref to the selected cluster, as this RPC needs this
 		// cluster until it is committed.
@@ -229,9 +228,8 @@ func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RP
 			}
 			// Decrement the refcount of the route cluster and close the interceptor
 			// if refcount goes to zero.
-			if v := cluster.refcount.Add(-1); v == 0 {
-				cluster.interceptor.Close()
-			}
+			//
+			rc.Decrement()
 		})
 	} else if info, ok := cs.plugins[cluster.name]; ok {
 		// Add a ref to the selected plugin, as this RPC needs this
@@ -245,9 +243,7 @@ func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RP
 			}
 			// Decrement the refcount of the route cluster and close the interceptor
 			// if refcount goes to zero.
-			if v := cluster.refcount.Add(-1); v == 0 {
-				cluster.interceptor.Close()
-			}
+			rc.Decrement()
 		})
 	} else {
 		// This should be unreachable because all route clusters are normalized
@@ -354,9 +350,7 @@ func (cs *configSelector) stop() {
 	// refcount goes to zero.
 	for _, r := range cs.routes {
 		for _, rc := range r.routeClusters {
-			if v := rc.refcount.Add(-1); v == 0 {
-				rc.interceptor.Close()
-			}
+			rc.Decrement()
 		}
 	}
 

--- a/internal/xds/resolver/xds_resolver.go
+++ b/internal/xds/resolver/xds_resolver.go
@@ -334,8 +334,9 @@ func (r *xdsResolver) Error(err error) {
 
 // sendNewServiceConfig prunes active clusters, generates a new service config
 // based on the current set of active clusters, and sends an update to the
-// channel with that service config and the provided config selector.  Returns
-// false if an error occurs while sending an update to the channel.
+// channel with that service config and the provided config selector. It is safe
+// to ignore the error from `cc.UpdateState` because the clientconn uses the
+// given configSelector even if it returns an error.
 //
 // Only executed in the context of a serializer callback.
 func (r *xdsResolver) sendNewServiceConfig(cs stoppableConfigSelector) {
@@ -424,12 +425,11 @@ func (r *xdsResolver) newConfigSelector() (_ *configSelector, err error) {
 				}
 				return nil, err
 			}
-			rc := grpcsync.NewRefCounted(&routeCluster{
+			routeCluster := &routeCluster{
 				name:        clusterName,
 				interceptor: interceptor,
-			}, func() {
-				interceptor.Close()
-			})
+			}
+			rc := grpcsync.NewRefCounted(routeCluster, func() { interceptor.Close() })
 			cs.routes[i].routeClusters = append(cs.routes[i].routeClusters, rc)
 			clusters.Add(rc, 1)
 			ci := r.addOrGetActiveClusterInfo(clusterName, "")
@@ -449,12 +449,11 @@ func (r *xdsResolver) newConfigSelector() (_ *configSelector, err error) {
 					}
 					return nil, err
 				}
-				rc := grpcsync.NewRefCounted(&routeCluster{
+				routeCluster := &routeCluster{
 					name:        clusterName,
 					interceptor: interceptor,
-				}, func() {
-					interceptor.Close()
-				})
+				}
+				rc := grpcsync.NewRefCounted(routeCluster, func() { interceptor.Close() })
 				cs.routes[i].routeClusters = append(cs.routes[i].routeClusters, rc)
 				clusters.Add(rc, int64(wc.Weight))
 				ci := r.addOrGetActiveClusterInfo(clusterName, wc.Name)

--- a/internal/xds/resolver/xds_resolver.go
+++ b/internal/xds/resolver/xds_resolver.go
@@ -436,11 +436,13 @@ func (r *xdsResolver) newConfigSelector() (_ *configSelector, err error) {
 				}
 				return nil, err
 			}
-			clusters.Add(&routeCluster{
+			rc := &routeCluster{
 				name:        clusterName,
 				interceptor: interceptor,
-			}, 1)
-			interceptors = append(interceptors, interceptor)
+			}
+			rc.refcount.Add(1)
+			cs.routes[i].routeClusters = append(cs.routes[i].routeClusters, rc)
+			clusters.Add(rc, 1)
 			ci := r.addOrGetActiveClusterInfo(clusterName, "")
 			ci.cfg = xdsChildConfig{ChildPolicy: balancerConfig(r.xdsConfig.RouteConfig.ClusterSpecifierPlugins[rt.ClusterSpecifierPlugin])}
 			cs.plugins[clusterName] = ci
@@ -458,18 +460,19 @@ func (r *xdsResolver) newConfigSelector() (_ *configSelector, err error) {
 					}
 					return nil, err
 				}
-				clusters.Add(&routeCluster{
+				rc := &routeCluster{
 					name:        clusterName,
 					interceptor: interceptor,
-				}, int64(wc.Weight))
-				interceptors = append(interceptors, interceptor)
+				}
+				rc.refcount.Add(1)
+				cs.routes[i].routeClusters = append(cs.routes[i].routeClusters, rc)
+				clusters.Add(rc, int64(wc.Weight))
 				ci := r.addOrGetActiveClusterInfo(clusterName, wc.Name)
 				ci.cfg = xdsChildConfig{ChildPolicy: newBalancerConfig(cdsName, cdsBalancerConfig{Cluster: wc.Name})}
 				cs.clusters[clusterName] = ci
 			}
 		}
 		cs.routes[i].clusters = clusters
-		cs.routes[i].interceptors = interceptors
 		cs.routes[i].m = xdsresource.RouteToMatcher(rt)
 		cs.routes[i].actionType = rt.ActionType
 		if rt.MaxStreamDuration == nil {

--- a/internal/xds/resolver/xds_resolver.go
+++ b/internal/xds/resolver/xds_resolver.go
@@ -376,12 +376,7 @@ func (r *xdsResolver) sendNewServiceConfig(cs stoppableConfigSelector) bool {
 	}, cs)
 	state = xdsresource.SetXDSConfig(state, r.xdsConfig)
 	state = xdsdepmgr.SetXDSClusterSubscriber(state, r.dm)
-	if err := r.cc.UpdateState(xdsclient.SetClient(state, r.xdsClient)); err != nil {
-		if r.logger.V(2) {
-			r.logger.Infof("Channel rejected new state: %+v with error: %v", state, err)
-		}
-		return false
-	}
+	r.cc.UpdateState(xdsclient.SetClient(state, r.xdsClient))
 	return true
 }
 
@@ -436,11 +431,12 @@ func (r *xdsResolver) newConfigSelector() (_ *configSelector, err error) {
 				}
 				return nil, err
 			}
-			rc := &routeCluster{
+			rc := grpcsync.NewRefCounted(&routeCluster{
 				name:        clusterName,
 				interceptor: interceptor,
-			}
-			rc.refcount.Add(1)
+			}, func() {
+				interceptor.Close()
+			})
 			cs.routes[i].routeClusters = append(cs.routes[i].routeClusters, rc)
 			clusters.Add(rc, 1)
 			ci := r.addOrGetActiveClusterInfo(clusterName, "")
@@ -460,11 +456,12 @@ func (r *xdsResolver) newConfigSelector() (_ *configSelector, err error) {
 					}
 					return nil, err
 				}
-				rc := &routeCluster{
+				rc := grpcsync.NewRefCounted(&routeCluster{
 					name:        clusterName,
 					interceptor: interceptor,
-				}
-				rc.refcount.Add(1)
+				}, func() {
+					interceptor.Close()
+				})
 				cs.routes[i].routeClusters = append(cs.routes[i].routeClusters, rc)
 				clusters.Add(rc, int64(wc.Weight))
 				ci := r.addOrGetActiveClusterInfo(clusterName, wc.Name)

--- a/internal/xds/resolver/xds_resolver.go
+++ b/internal/xds/resolver/xds_resolver.go
@@ -317,13 +317,7 @@ func (r *xdsResolver) Update(config *xdsresource.XDSConfig) {
 			r.onResourceError(err)
 			return
 		}
-		if !r.sendNewServiceConfig(cs) {
-			// Channel didn't like the update we provided (unexpected); erase
-			// this config selector and ignore this update, continuing with
-			// the previous config selector.
-			cs.stop()
-			return
-		}
+		r.sendNewServiceConfig(cs)
 
 		if r.curConfigSelector != nil {
 			r.curConfigSelector.stop()
@@ -344,7 +338,7 @@ func (r *xdsResolver) Error(err error) {
 // false if an error occurs while sending an update to the channel.
 //
 // Only executed in the context of a serializer callback.
-func (r *xdsResolver) sendNewServiceConfig(cs stoppableConfigSelector) bool {
+func (r *xdsResolver) sendNewServiceConfig(cs stoppableConfigSelector) {
 	// Delete entries from r.activeClusters with zero references;
 	// otherwise serviceConfigJSON will generate a config including
 	// them.
@@ -362,7 +356,7 @@ func (r *xdsResolver) sendNewServiceConfig(cs stoppableConfigSelector) bool {
 		// more meaningful error, as opposed to one that says that pick_first
 		// received no addresses.
 		r.cc.ReportError(errCS.err)
-		return true
+		return
 	}
 
 	sc := serviceConfigJSON(r.activeClusters, r.activePlugins)
@@ -377,7 +371,6 @@ func (r *xdsResolver) sendNewServiceConfig(cs stoppableConfigSelector) bool {
 	state = xdsresource.SetXDSConfig(state, r.xdsConfig)
 	state = xdsdepmgr.SetXDSClusterSubscriber(state, r.dm)
 	r.cc.UpdateState(xdsclient.SetClient(state, r.xdsClient))
-	return true
 }
 
 // newConfigSelector creates a new config selector using the most recently

--- a/internal/xds/resolver/xds_resolver_test.go
+++ b/internal/xds/resolver/xds_resolver_test.go
@@ -1287,7 +1287,7 @@ func (s) TestResolver_AutoHostRewrite(t *testing.T) {
 // TestResolverKeepWatchOpen_ActiveRPCs tests that the dependency manager keeps
 // a cluster watch open when there are active RPCs using that cluster, even if
 // the cluster is no longer referenced by the current route configuration.
-func TestResolverKeepWatchOpen_ActiveRPCs(t *testing.T) {
+func (s) TestResolverKeepWatchOpen_ActiveRPCs(t *testing.T) {
 	clusterA := "cluster-A"
 	clusterB := "cluster-B"
 

--- a/internal/xds/resolver/xds_resolver_test.go
+++ b/internal/xds/resolver/xds_resolver_test.go
@@ -1287,7 +1287,7 @@ func (s) TestResolver_AutoHostRewrite(t *testing.T) {
 // TestResolverKeepWatchOpen_ActiveRPCs tests that the dependency manager keeps
 // a cluster watch open when there are active RPCs using that cluster, even if
 // the cluster is no longer referenced by the current route configuration.
-func (s) TestResolverKeepWatchOpen_ActiveRPCs(t *testing.T) {
+func TestResolverKeepWatchOpen_ActiveRPCs(t *testing.T) {
 	clusterA := "cluster-A"
 	clusterB := "cluster-B"
 
@@ -1372,7 +1372,7 @@ func (s) TestResolverKeepWatchOpen_ActiveRPCs(t *testing.T) {
 	waitForResourceNames(ctx, t, cdsResourceRequestedCh, wantNames)
 
 	// ServiceConfig update should also contain only cluster B.
-	verifyUpdateFromResolver(ctx, t, stateCh, wantServiceConfig(clusterB))
+	cs = verifyUpdateFromResolver(ctx, t, stateCh, wantServiceConfig(clusterB))
 
 	// Verify that RPCs pass again.
 	res, err = cs.SelectConfig(iresolver.RPCInfo{Context: ctx, Method: "/service/method"})

--- a/test/xds/xds_resolver_e2e_test.go
+++ b/test/xds/xds_resolver_e2e_test.go
@@ -529,12 +529,14 @@ func (s) TestResolverDelayedInterceptorClose_ActiveRPCs(t *testing.T) {
 		t.Fatalf("Failed to create xDS resolver for testing: %v", err)
 	}
 
+	// Intercept resolver builder.
 	jsonCh := make(chan string, 1)
 	ib := &wrappingBuilder{
 		Builder: r,
 		jsonCh:  jsonCh,
 	}
 
+	// Start test backend.
 	server := stubserver.StartTestService(t, nil)
 	defer server.Stop()
 
@@ -662,12 +664,14 @@ func (s) TestResolverImmediateInterceptorClose_NoActiveRPCs(t *testing.T) {
 		t.Fatalf("Failed to create xDS resolver for testing: %v", err)
 	}
 
+	// Intercept resolver builder.
 	jsonCh := make(chan string, 1)
 	ib := &wrappingBuilder{
 		Builder: r,
 		jsonCh:  jsonCh,
 	}
 
+	// Start test backends.
 	server := stubserver.StartTestService(t, nil)
 	defer server.Stop()
 

--- a/test/xds/xds_resolver_e2e_test.go
+++ b/test/xds/xds_resolver_e2e_test.go
@@ -92,6 +92,7 @@ type testFilterBuilder struct {
 	typeURL      string
 	blockChan    chan struct{}
 	enteredChan  chan struct{}
+	closeChan    chan struct{}
 	newStreamErr error
 }
 
@@ -121,6 +122,7 @@ func (tb *testFilterBuilder) BuildClientInterceptor(httpfilter.FilterConfig, htt
 	return &testInterceptor{
 		blockChan:    tb.blockChan,
 		enteredChan:  tb.enteredChan,
+		closeChan:    tb.closeChan,
 		newStreamErr: tb.newStreamErr,
 	}, nil
 }
@@ -128,6 +130,7 @@ func (tb *testFilterBuilder) BuildClientInterceptor(httpfilter.FilterConfig, htt
 type testInterceptor struct {
 	blockChan    chan struct{}
 	enteredChan  chan struct{}
+	closeChan    chan struct{}
 	newStreamErr error
 }
 
@@ -147,13 +150,16 @@ func (i *testInterceptor) NewStream(ctx context.Context, _ iresolver.RPCInfo, ne
 	return newStream(ctx, opts...)
 }
 
-func (i *testInterceptor) Close() {}
+func (i *testInterceptor) Close() {
+	i.closeChan <- struct{}{}
+}
 
 func newTestFilterBuilder(t testing.TB, typeURL string) *testFilterBuilder {
 	tb := &testFilterBuilder{
 		typeURL:     typeURL,
 		blockChan:   make(chan struct{}),
 		enteredChan: make(chan struct{}, 1),
+		closeChan:   make(chan struct{}, 3),
 	}
 	httpfilter.Register(tb)
 	t.Cleanup(func() {
@@ -501,5 +507,244 @@ func (s) TestResolverPrunesCluster_StreamCreationFailure(t *testing.T) {
 	// Read the third state update from the intercepting resolver. Cluster-A's
 	// reference count drops to 0, causing the resolver to unsubscribe and
 	// prune it.
+	verifyServiceConfig(ctx, t, jsonCh, clusterB)
+}
+
+// TestResolverDelayedInterceptorClose_ActiveRPCs verifies that when a route
+// configuration is updated (causing the old config selector to stop), an HTTP
+// filter interceptor for a route/cluster with an active in-flight RPC is not
+// closed immediately. It remains active until all active RPCs to that cluster
+// in that route complete and its refcount drops to 0.
+func (s) TestResolverDelayedInterceptorClose_ActiveRPCs(t *testing.T) {
+	testFilterTypeURL := t.Name()
+	tb := newTestFilterBuilder(t, testFilterTypeURL)
+	blockChan, enteredChan, closeChan := tb.blockChan, tb.enteredChan, tb.closeChan
+
+	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{})
+	nodeID := uuid.New().String()
+	bc := e2e.DefaultBootstrapContents(t, nodeID, mgmtServer.Address)
+
+	r, err := internal.NewXDSResolverWithConfigForTesting.(func([]byte) (resolver.Builder, error))(bc)
+	if err != nil {
+		t.Fatalf("Failed to create xDS resolver for testing: %v", err)
+	}
+
+	jsonCh := make(chan string, 1)
+	ib := &wrappingBuilder{
+		Builder: r,
+		jsonCh:  jsonCh,
+	}
+
+	server := stubserver.StartTestService(t, nil)
+	defer server.Stop()
+
+	const (
+		serviceName = "my-service-xds"
+		clusterA    = "cluster-A"
+		clusterB    = "cluster-B"
+	)
+	hcm := &v3httppb.HttpConnectionManager{
+		RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
+			RouteConfig: &v3routepb.RouteConfiguration{
+				Name: "route-" + serviceName,
+				VirtualHosts: []*v3routepb.VirtualHost{{
+					Domains: []string{serviceName},
+					Routes: []*v3routepb.Route{{
+						Match:  &v3routepb.RouteMatch{PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: ""}},
+						Action: &v3routepb.Route_Route{Route: &v3routepb.RouteAction{ClusterSpecifier: &v3routepb.RouteAction_Cluster{Cluster: clusterA}}},
+					}},
+				}},
+			},
+		},
+		HttpFilters: []*v3httppb.HttpFilter{
+			{
+				Name: "delaying-filter",
+				ConfigType: &v3httppb.HttpFilter_TypedConfig{
+					TypedConfig: testutils.MarshalAny(t, &v3xdsxdstypepb.TypedStruct{
+						TypeUrl: testFilterTypeURL,
+					}),
+				},
+			},
+			e2e.RouterHTTPFilter,
+		},
+	}
+	resources := e2e.UpdateOptions{
+		NodeID:    nodeID,
+		Listeners: []*v3listenerpb.Listener{{Name: serviceName, ApiListener: &v3listenerpb.ApiListener{ApiListener: testutils.MarshalAny(t, hcm)}}},
+		Clusters:  []*v3clusterpb.Cluster{e2e.DefaultCluster(clusterA, clusterA, e2e.SecurityLevelNone)},
+		Endpoints: []*v3endpointpb.ClusterLoadAssignment{e2e.DefaultEndpoint(clusterA, "localhost", []uint32{testutils.ParsePort(t, server.Address)})},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(ib))
+	if err != nil {
+		t.Fatalf("Failed to create a gRPC client: %v", err)
+	}
+	defer cc.Close()
+
+	client := testgrpc.NewTestServiceClient(cc)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := client.EmptyCall(ctx, &testpb.Empty{})
+		errCh <- err
+	}()
+
+	select {
+	case <-enteredChan:
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for RPC to reach HTTP filter")
+	}
+
+	verifyServiceConfig(ctx, t, jsonCh, clusterA)
+
+	// Update route configuration on the management server to point to cluster B.
+	hcm.GetRouteConfig().VirtualHosts[0].Routes[0].Action = &v3routepb.Route_Route{Route: &v3routepb.RouteAction{ClusterSpecifier: &v3routepb.RouteAction_Cluster{Cluster: clusterB}}}
+	resources.Listeners = []*v3listenerpb.Listener{{Name: serviceName, ApiListener: &v3listenerpb.ApiListener{ApiListener: testutils.MarshalAny(t, hcm)}}}
+	resources.Clusters = append(resources.Clusters, e2e.DefaultCluster(clusterB, clusterB, e2e.SecurityLevelNone))
+	resources.Endpoints = append(resources.Endpoints, e2e.DefaultEndpoint(clusterB, "localhost", []uint32{testutils.ParsePort(t, server.Address)}))
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	verifyServiceConfig(ctx, t, jsonCh, clusterA, clusterB)
+
+	// Verify that because an RPC is still in flight on cluster-A, the interceptor
+	// is NOT closed prematurely when the old config selector is stopped.
+	select {
+	case <-closeChan:
+		t.Fatal("Unexpected interceptor Close() called while RPC is still active")
+	case <-time.After(defaultTestShortTimeout):
+	}
+
+	// Unblock the active RPC and verify it completes successfully.
+	blockChan <- struct{}{}
+	select {
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for RPC to succeed")
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("RPC failed with unexpected error: %v", err)
+		}
+	}
+
+	// Once the RPC finishes, its OnFinish CallOption decrements the refcount
+	// of cluster-A to 0. Verifies that interceptor.Close() is now called.
+	select {
+	case <-closeChan:
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for interceptor Close() after RPC finished")
+	}
+
+	verifyServiceConfig(ctx, t, jsonCh, clusterB)
+}
+
+// Test verifies that when a route configuration is updated and there are no
+// active in-flight RPCs on a route/cluster, the HTTP filter interceptor is
+// closed immediately when the old config selector is stopped.
+func (s) TestResolverImmediateInterceptorClose_NoActiveRPCs(t *testing.T) {
+	testFilterTypeURL := t.Name()
+	tb := newTestFilterBuilder(t, testFilterTypeURL)
+	closeChan := tb.closeChan
+	close(tb.blockChan) // Do not block RPCs in the filter
+
+	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{})
+	nodeID := uuid.New().String()
+	bc := e2e.DefaultBootstrapContents(t, nodeID, mgmtServer.Address)
+
+	r, err := internal.NewXDSResolverWithConfigForTesting.(func([]byte) (resolver.Builder, error))(bc)
+	if err != nil {
+		t.Fatalf("Failed to create xDS resolver for testing: %v", err)
+	}
+
+	jsonCh := make(chan string, 1)
+	ib := &wrappingBuilder{
+		Builder: r,
+		jsonCh:  jsonCh,
+	}
+
+	server := stubserver.StartTestService(t, nil)
+	defer server.Stop()
+
+	const (
+		serviceName = "my-service-xds"
+		clusterA    = "cluster-A"
+		clusterB    = "cluster-B"
+	)
+	hcm := &v3httppb.HttpConnectionManager{
+		RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
+			RouteConfig: &v3routepb.RouteConfiguration{
+				Name: "route-" + serviceName,
+				VirtualHosts: []*v3routepb.VirtualHost{{
+					Domains: []string{serviceName},
+					Routes: []*v3routepb.Route{{
+						Match:  &v3routepb.RouteMatch{PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: ""}},
+						Action: &v3routepb.Route_Route{Route: &v3routepb.RouteAction{ClusterSpecifier: &v3routepb.RouteAction_Cluster{Cluster: clusterA}}},
+					}},
+				}},
+			},
+		},
+		HttpFilters: []*v3httppb.HttpFilter{
+			{
+				Name: "closing-filter",
+				ConfigType: &v3httppb.HttpFilter_TypedConfig{
+					TypedConfig: testutils.MarshalAny(t, &v3xdsxdstypepb.TypedStruct{
+						TypeUrl: testFilterTypeURL,
+					}),
+				},
+			},
+			e2e.RouterHTTPFilter,
+		},
+	}
+	resources := e2e.UpdateOptions{
+		NodeID:    nodeID,
+		Listeners: []*v3listenerpb.Listener{{Name: serviceName, ApiListener: &v3listenerpb.ApiListener{ApiListener: testutils.MarshalAny(t, hcm)}}},
+		Clusters:  []*v3clusterpb.Cluster{e2e.DefaultCluster(clusterA, clusterA, e2e.SecurityLevelNone)},
+		Endpoints: []*v3endpointpb.ClusterLoadAssignment{e2e.DefaultEndpoint(clusterA, "localhost", []uint32{testutils.ParsePort(t, server.Address)})},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(ib))
+	if err != nil {
+		t.Fatalf("Failed to create a gRPC client: %v", err)
+	}
+	defer cc.Close()
+
+	client := testgrpc.NewTestServiceClient(cc)
+	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
+		t.Fatalf("EmptyCall() failed: %v", err)
+	}
+
+	verifyServiceConfig(ctx, t, jsonCh, clusterA)
+
+	// Update route configuration on the management server to point to cluster B.
+	hcm.GetRouteConfig().VirtualHosts[0].Routes[0].Action = &v3routepb.Route_Route{Route: &v3routepb.RouteAction{ClusterSpecifier: &v3routepb.RouteAction_Cluster{Cluster: clusterB}}}
+	resources.Listeners = []*v3listenerpb.Listener{{Name: serviceName, ApiListener: &v3listenerpb.ApiListener{ApiListener: testutils.MarshalAny(t, hcm)}}}
+	resources.Clusters = append(resources.Clusters, e2e.DefaultCluster(clusterB, clusterB, e2e.SecurityLevelNone))
+	resources.Endpoints = append(resources.Endpoints, e2e.DefaultEndpoint(clusterB, "localhost", []uint32{testutils.ParsePort(t, server.Address)}))
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	verifyServiceConfig(ctx, t, jsonCh, clusterA, clusterB)
+
+	// Because there are no active RPCs on cluster-A, interceptor.Close() should
+	// be invoked immediately when the old config selector is stopped.
+	select {
+	case <-closeChan:
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for interceptor Close() when no active RPCs exist")
+	}
+
 	verifyServiceConfig(ctx, t, jsonCh, clusterB)
 }


### PR DESCRIPTION
This PR implements the channel retention for ext proc filter. It has the following changes: 
1. Adds refcounting to route cluster to ensure interceptors remain open if there are any inflight RPCs or the config selector is active instead of closing the interceptors unconditionally on XDS Config update.
2. Adds refcounting for ext proc channel which is incremented when interceptor is built and for every RPC and decremented when interceptor closes and proc RPC finishes.
3. Call RecvMsg on the dataplane stream if not called whenever the context is cancelled to handle cases where the dataplane stream is created but the RPC fails without every invoking any function on the dataplane stream
	This is a problem for unary RPC because it does not spawn a goroutine waiting for ctx cancellation to do the cleanup.
4. Error checking on `cc.UpdateState` in sendNewServiceConfig was removed

Reason : Previously, if `cc.UpdateState(s)` returned an error (e.g., when a sub-balancer reported a removed cluster or NACK), xdsResolver called `cs.stop()` on the new ConfigSelector and continued tracking the old one. However, `ClientConn.UpdateState(s)` unconditionally installs the new ConfigSelector (cs) before updating the LB policy—even if `updateClientConnState` subsequently errors.
This caused `ClientConn` and `xdsResolver` to become desynchronized: ClientConn actively routed RPCs using cs, while xdsResolver had already stopped it. With routeCluster now refcounted, calling `cs.stop()` decrements its refcount to 0, causing any RPC calling `SelectConfig` on cs to hit a dead resource and fail with "Resource already closed or dead".
Removing the error check ensures xdsResolver unconditionally adopts cs, keeping both components in sync, preserving cs's refcount, and allowing RPCs to cleanly reach error pickers configured by cluster_manager LB policy.

#ext-proc-a93

RELEASE NOTES: None