### PR TITLE
xds: add internal ResourceNameFunc server option

### DIFF
--- a/internal/xds/server/server_options.go
+++ b/internal/xds/server/server_options.go
@@ -35,11 +35,11 @@ func OverrideListenerResourceName(f func(net.Addr) string) grpc.ServerOption {
 }
 
 // OverrideListenerResourceNameFromServerOption returns the resource name
-// function carried by opt, if opt was created by OverrideListenerResourceName.
-func OverrideListenerResourceNameFromServerOption(opt grpc.ServerOption) (func(net.Addr) string, bool) {
+// function carried by opt, or nil if opt does not contain one.
+func OverrideListenerResourceNameFromServerOption(opt grpc.ServerOption) func(net.Addr) string {
 	o, ok := opt.(*overrideListenerResourceNameOption)
 	if !ok {
-		return nil, false
+		return nil
 	}
-	return o.f, true
+	return o.f
 }

--- a/internal/xds/server/server_options.go
+++ b/internal/xds/server/server_options.go
@@ -55,7 +55,13 @@ func ApplyServerOptions(opts []grpc.ServerOption, so *Options) {
 }
 
 // OverrideListenerResourceName returns a server option that overrides the LDS
-// resource name selected for an xDS server listener.
+// resource name selected for an xDS server listener. The supplied function is
+// called by Serve with the address returned by the listener's Addr method, and
+// its return value is used as-is as the LDS listener resource name.
+//
+// The function is called once for each Serve invocation that gets past listener
+// validation and the server-stopped check. If Serve is called concurrently, the
+// function may be called concurrently and must be safe for concurrent use.
 func OverrideListenerResourceName(f func(net.Addr) string) grpc.ServerOption {
 	return NewServerOption(func(o *Options) {
 		o.OverrideListenerResourceName = f

--- a/internal/xds/server/server_options.go
+++ b/internal/xds/server/server_options.go
@@ -23,21 +23,21 @@ import (
 	"google.golang.org/grpc"
 )
 
-type resourceNameOption struct {
+type overrideListenerResourceNameOption struct {
 	grpc.EmptyServerOption
 	f func(net.Addr) string
 }
 
-// ResourceNameFunc returns a server option that overrides the LDS resource
-// name selected for an xDS server listener.
-func ResourceNameFunc(f func(net.Addr) string) grpc.ServerOption {
-	return &resourceNameOption{f: f}
+// OverrideListenerResourceName returns a server option that overrides the LDS
+// resource name selected for an xDS server listener.
+func OverrideListenerResourceName(f func(net.Addr) string) grpc.ServerOption {
+	return &overrideListenerResourceNameOption{f: f}
 }
 
-// ResourceNameFuncFromServerOption returns the resource name function carried
-// by opt, if opt was created by ResourceNameFunc.
-func ResourceNameFuncFromServerOption(opt grpc.ServerOption) (func(net.Addr) string, bool) {
-	o, ok := opt.(*resourceNameOption)
+// OverrideListenerResourceNameFromServerOption returns the resource name
+// function carried by opt, if opt was created by OverrideListenerResourceName.
+func OverrideListenerResourceNameFromServerOption(opt grpc.ServerOption) (func(net.Addr) string, bool) {
+	o, ok := opt.(*overrideListenerResourceNameOption)
 	if !ok {
 		return nil, false
 	}

--- a/internal/xds/server/server_options.go
+++ b/internal/xds/server/server_options.go
@@ -1,0 +1,45 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"net"
+
+	"google.golang.org/grpc"
+)
+
+type resourceNameOption struct {
+	grpc.EmptyServerOption
+	f func(net.Addr) string
+}
+
+// ResourceNameFunc returns a server option that overrides the LDS resource
+// name selected for an xDS server listener.
+func ResourceNameFunc(f func(net.Addr) string) grpc.ServerOption {
+	return &resourceNameOption{f: f}
+}
+
+// ResourceNameFuncFromServerOption returns the resource name function carried
+// by opt, if opt was created by ResourceNameFunc.
+func ResourceNameFuncFromServerOption(opt grpc.ServerOption) (func(net.Addr) string, bool) {
+	o, ok := opt.(*resourceNameOption)
+	if !ok {
+		return nil, false
+	}
+	return o.f, true
+}

--- a/internal/xds/server/server_options.go
+++ b/internal/xds/server/server_options.go
@@ -24,11 +24,11 @@ import (
 	"google.golang.org/grpc/internal/xds/xdsclient"
 )
 
-// ServerOptions contains options used by an xDS-enabled gRPC server.
+// Options contains options used by an xDS-enabled gRPC server.
 //
 // This type is internal so that the public xds package can expose server
 // options without also owning their application and storage.
-type ServerOptions struct {
+type Options struct {
 	ModeCallback                 ServingModeCallback
 	ClientPoolForTesting         *xdsclient.Pool
 	OverrideListenerResourceName func(net.Addr) string
@@ -36,17 +36,17 @@ type ServerOptions struct {
 
 type serverOption struct {
 	grpc.EmptyServerOption
-	apply func(*ServerOptions)
+	apply func(*Options)
 }
 
 // NewServerOption returns a grpc.ServerOption which applies f to the internal
 // xDS server options.
-func NewServerOption(f func(*ServerOptions)) grpc.ServerOption {
+func NewServerOption(f func(*Options)) grpc.ServerOption {
 	return &serverOption{apply: f}
 }
 
 // ApplyServerOptions applies all internal xDS server options in opts to so.
-func ApplyServerOptions(opts []grpc.ServerOption, so *ServerOptions) {
+func ApplyServerOptions(opts []grpc.ServerOption, so *Options) {
 	for _, opt := range opts {
 		if o, ok := opt.(*serverOption); ok {
 			o.apply(so)
@@ -57,7 +57,7 @@ func ApplyServerOptions(opts []grpc.ServerOption, so *ServerOptions) {
 // OverrideListenerResourceName returns a server option that overrides the LDS
 // resource name selected for an xDS server listener.
 func OverrideListenerResourceName(f func(net.Addr) string) grpc.ServerOption {
-	return NewServerOption(func(o *ServerOptions) {
+	return NewServerOption(func(o *Options) {
 		o.OverrideListenerResourceName = f
 	})
 }

--- a/internal/xds/server/server_options.go
+++ b/internal/xds/server/server_options.go
@@ -21,25 +21,43 @@ import (
 	"net"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/internal/xds/xdsclient"
 )
 
-type overrideListenerResourceNameOption struct {
+// ServerOptions contains options used by an xDS-enabled gRPC server.
+//
+// This type is internal so that the public xds package can expose server
+// options without also owning their application and storage.
+type ServerOptions struct {
+	ModeCallback                 ServingModeCallback
+	ClientPoolForTesting         *xdsclient.Pool
+	OverrideListenerResourceName func(net.Addr) string
+}
+
+type serverOption struct {
 	grpc.EmptyServerOption
-	f func(net.Addr) string
+	apply func(*ServerOptions)
+}
+
+// NewServerOption returns a grpc.ServerOption which applies f to the internal
+// xDS server options.
+func NewServerOption(f func(*ServerOptions)) grpc.ServerOption {
+	return &serverOption{apply: f}
+}
+
+// ApplyServerOptions applies all internal xDS server options in opts to so.
+func ApplyServerOptions(opts []grpc.ServerOption, so *ServerOptions) {
+	for _, opt := range opts {
+		if o, ok := opt.(*serverOption); ok {
+			o.apply(so)
+		}
+	}
 }
 
 // OverrideListenerResourceName returns a server option that overrides the LDS
 // resource name selected for an xDS server listener.
 func OverrideListenerResourceName(f func(net.Addr) string) grpc.ServerOption {
-	return &overrideListenerResourceNameOption{f: f}
-}
-
-// OverrideListenerResourceNameFromServerOption returns the resource name
-// function carried by opt, or nil if opt does not contain one.
-func OverrideListenerResourceNameFromServerOption(opt grpc.ServerOption) func(net.Addr) string {
-	o, ok := opt.(*overrideListenerResourceNameOption)
-	if !ok {
-		return nil
-	}
-	return o.f
+	return NewServerOption(func(o *ServerOptions) {
+		o.OverrideListenerResourceName = f
+	})
 }

--- a/xds/server.go
+++ b/xds/server.go
@@ -104,7 +104,8 @@ func NewGRPCServer(opts ...grpc.ServerOption) (*GRPCServer, error) {
 
 	// Validate the bootstrap configuration for server specific fields.
 
-	// Listener resource name template is mandatory on the server side unless resourceNameFunc is provided.
+	// Listener resource name template is mandatory on the server side unless a
+	// listener resource name override is provided.
 	if s.opts.resourceNameFunc == nil {
 		cfg := xdsClient.BootstrapConfig()
 		if cfg.ServerListenerResourceNameTemplate() == "" {
@@ -131,7 +132,7 @@ func (s *GRPCServer) handleServerOptions(opts []grpc.ServerOption) {
 			o.apply(so)
 			continue
 		}
-		if f, ok := server.ResourceNameFuncFromServerOption(opt); ok {
+		if f, ok := server.OverrideListenerResourceNameFromServerOption(opt); ok {
 			so.resourceNameFunc = f
 		}
 	}

--- a/xds/server.go
+++ b/xds/server.go
@@ -242,24 +242,6 @@ func (s *GRPCServer) GracefulStop() {
 	}
 }
 
-// UnderlyingServer returns the underlying gRPC server. This is useful for
-// wrappers that need access to the concrete *grpc.Server, for example, to
-// use with grpcweb.
-//
-// It returns nil if the underlying server is not a *grpc.Server (e.g., in
-// unit tests where the server is faked).
-//
-// # Experimental
-//
-// Notice: This API is EXPERIMENTAL and may be changed or removed in a
-// later release.
-func (s *GRPCServer) UnderlyingServer() *grpc.Server {
-	if srv, ok := s.gs.(*grpc.Server); ok {
-		return srv
-	}
-	return nil
-}
-
 // xdsUnaryInterceptor is the unary interceptor added to the gRPC server to
 // perform any xDS specific functionality on unary RPCs.
 func xdsUnaryInterceptor(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {

--- a/xds/server.go
+++ b/xds/server.go
@@ -64,7 +64,7 @@ type GRPCServer struct {
 	gs             grpcServer
 	quit           *grpcsync.Event
 	logger         *internalgrpclog.PrefixLogger
-	opts           *serverOptions
+	opts           *server.ServerOptions
 	xdsC           xdsclient.XDSClient
 	xdsClientClose func()
 }
@@ -94,8 +94,8 @@ func NewGRPCServer(opts ...grpc.ServerOption) (*GRPCServer, error) {
 	// simplifies the code by eliminating the need for a mutex to protect the
 	// xdsC and xdsClientClose fields.
 	pool := xdsClientPool
-	if s.opts.clientPoolForTesting != nil {
-		pool = s.opts.clientPoolForTesting
+	if s.opts.ClientPoolForTesting != nil {
+		pool = s.opts.ClientPoolForTesting
 	}
 	xdsClient, xdsClientClose, err := pool.NewClient(xdsclient.NameForServer, mrl)
 	if err != nil {
@@ -106,7 +106,7 @@ func NewGRPCServer(opts ...grpc.ServerOption) (*GRPCServer, error) {
 
 	// Listener resource name template is mandatory on the server side unless a
 	// listener resource name override is provided.
-	if s.opts.overrideListenerResourceName == nil {
+	if s.opts.OverrideListenerResourceName == nil {
 		cfg := xdsClient.BootstrapConfig()
 		if cfg.ServerListenerResourceNameTemplate() == "" {
 			xdsClientClose()
@@ -127,36 +127,28 @@ func NewGRPCServer(opts ...grpc.ServerOption) (*GRPCServer, error) {
 // the user, and handles the xDS server specific options.
 func (s *GRPCServer) handleServerOptions(opts []grpc.ServerOption) {
 	so := s.defaultServerOptions()
-	for _, opt := range opts {
-		if o, ok := opt.(*serverOption); ok {
-			o.apply(so)
-			continue
-		}
-		if f := server.OverrideListenerResourceNameFromServerOption(opt); f != nil {
-			so.overrideListenerResourceName = f
-		}
-	}
+	server.ApplyServerOptions(opts, so)
 	s.opts = so
 }
 
-func (s *GRPCServer) defaultServerOptions() *serverOptions {
-	return &serverOptions{
+func (s *GRPCServer) defaultServerOptions() *server.ServerOptions {
+	return &server.ServerOptions{
 		// A default serving mode change callback which simply logs at the
 		// default-visible log level. This will be used if the application does not
 		// register a mode change callback.
 		//
-		// Note that this means that `s.opts.modeCallback` will never be nil and can
+		// Note that this means that `s.opts.ModeCallback` will never be nil and can
 		// safely be invoked directly from `handleServingModeChanges`.
-		modeCallback: s.loggingServerModeChangeCallback,
+		ModeCallback: s.loggingServerModeChangeCallback,
 	}
 }
 
-func (s *GRPCServer) loggingServerModeChangeCallback(addr net.Addr, args ServingModeChangeArgs) {
-	switch args.Mode {
+func (s *GRPCServer) loggingServerModeChangeCallback(addr net.Addr, mode connectivity.ServingMode, err error) {
+	switch mode {
 	case connectivity.ServingModeServing:
-		s.logger.Errorf("Listener %q entering mode: %q", addr.String(), args.Mode)
+		s.logger.Errorf("Listener %q entering mode: %q", addr.String(), mode)
 	case connectivity.ServingModeNotServing:
-		s.logger.Errorf("Listener %q entering mode: %q due to error: %v", addr.String(), args.Mode, args.Err)
+		s.logger.Errorf("Listener %q entering mode: %q due to error: %v", addr.String(), mode, err)
 	}
 }
 
@@ -196,8 +188,8 @@ func (s *GRPCServer) Serve(lis net.Listener) error {
 	// string, it will be replaced with the server's listening "IP:port" (e.g.,
 	// "0.0.0.0:8080", "[::]:8080").
 	var name string
-	if s.opts.overrideListenerResourceName != nil {
-		name = s.opts.overrideListenerResourceName(lis.Addr())
+	if s.opts.OverrideListenerResourceName != nil {
+		name = s.opts.OverrideListenerResourceName(lis.Addr())
 	} else {
 		cfg := s.xdsC.BootstrapConfig()
 		name = cfg.ServerListenerResourceNameTemplate()
@@ -210,12 +202,7 @@ func (s *GRPCServer) Serve(lis net.Listener) error {
 		Listener:             lis,
 		ListenerResourceName: name,
 		XDSClient:            s.xdsC,
-		ModeCallback: func(addr net.Addr, mode connectivity.ServingMode, err error) {
-			s.opts.modeCallback(addr, ServingModeChangeArgs{
-				Mode: mode,
-				Err:  err,
-			})
-		},
+		ModeCallback:         s.opts.ModeCallback,
 	})
 	return s.gs.Serve(lw)
 }

--- a/xds/server.go
+++ b/xds/server.go
@@ -129,6 +129,10 @@ func (s *GRPCServer) handleServerOptions(opts []grpc.ServerOption) {
 	for _, opt := range opts {
 		if o, ok := opt.(*serverOption); ok {
 			o.apply(so)
+			continue
+		}
+		if f, ok := server.ResourceNameFuncFromServerOption(opt); ok {
+			so.resourceNameFunc = f
 		}
 	}
 	s.opts = so

--- a/xds/server.go
+++ b/xds/server.go
@@ -104,11 +104,13 @@ func NewGRPCServer(opts ...grpc.ServerOption) (*GRPCServer, error) {
 
 	// Validate the bootstrap configuration for server specific fields.
 
-	// Listener resource name template is mandatory on the server side.
-	cfg := xdsClient.BootstrapConfig()
-	if cfg.ServerListenerResourceNameTemplate() == "" {
-		xdsClientClose()
-		return nil, errors.New("missing server_listener_resource_name_template in the bootstrap configuration")
+	// Listener resource name template is mandatory on the server side unless resourceNameFunc is provided.
+	if s.opts.resourceNameFunc == nil {
+		cfg := xdsClient.BootstrapConfig()
+		if cfg.ServerListenerResourceNameTemplate() == "" {
+			xdsClientClose()
+			return nil, errors.New("missing server_listener_resource_name_template in the bootstrap configuration")
+		}
 	}
 
 	s.xdsC = xdsClient
@@ -188,8 +190,14 @@ func (s *GRPCServer) Serve(lis net.Listener) error {
 	// to subscribe to for a gRPC server. If the token `%s` is present in the
 	// string, it will be replaced with the server's listening "IP:port" (e.g.,
 	// "0.0.0.0:8080", "[::]:8080").
-	cfg := s.xdsC.BootstrapConfig()
-	name := bootstrap.PopulateResourceTemplate(cfg.ServerListenerResourceNameTemplate(), lis.Addr().String())
+	var name string
+	if s.opts.resourceNameFunc != nil {
+		name = s.opts.resourceNameFunc(lis.Addr())
+	} else {
+		cfg := s.xdsC.BootstrapConfig()
+		name = cfg.ServerListenerResourceNameTemplate()
+		name = bootstrap.PopulateResourceTemplate(name, lis.Addr().String())
+	}
 
 	// Create a listenerWrapper which handles all functionality required by
 	// this particular instance of Serve().
@@ -228,6 +236,24 @@ func (s *GRPCServer) GracefulStop() {
 	if s.xdsC != nil {
 		s.xdsClientClose()
 	}
+}
+
+// UnderlyingServer returns the underlying gRPC server. This is useful for
+// wrappers that need access to the concrete *grpc.Server, for example, to
+// use with grpcweb.
+//
+// It returns nil if the underlying server is not a *grpc.Server (e.g., in
+// unit tests where the server is faked).
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func (s *GRPCServer) UnderlyingServer() *grpc.Server {
+	if srv, ok := s.gs.(*grpc.Server); ok {
+		return srv
+	}
+	return nil
 }
 
 // xdsUnaryInterceptor is the unary interceptor added to the gRPC server to

--- a/xds/server.go
+++ b/xds/server.go
@@ -64,7 +64,7 @@ type GRPCServer struct {
 	gs             grpcServer
 	quit           *grpcsync.Event
 	logger         *internalgrpclog.PrefixLogger
-	opts           *server.ServerOptions
+	opts           *server.Options
 	xdsC           xdsclient.XDSClient
 	xdsClientClose func()
 }
@@ -131,8 +131,8 @@ func (s *GRPCServer) handleServerOptions(opts []grpc.ServerOption) {
 	s.opts = so
 }
 
-func (s *GRPCServer) defaultServerOptions() *server.ServerOptions {
-	return &server.ServerOptions{
+func (s *GRPCServer) defaultServerOptions() *server.Options {
+	return &server.Options{
 		// A default serving mode change callback which simply logs at the
 		// default-visible log level. This will be used if the application does not
 		// register a mode change callback.

--- a/xds/server.go
+++ b/xds/server.go
@@ -106,7 +106,7 @@ func NewGRPCServer(opts ...grpc.ServerOption) (*GRPCServer, error) {
 
 	// Listener resource name template is mandatory on the server side unless a
 	// listener resource name override is provided.
-	if s.opts.resourceNameFunc == nil {
+	if s.opts.overrideListenerResourceName == nil {
 		cfg := xdsClient.BootstrapConfig()
 		if cfg.ServerListenerResourceNameTemplate() == "" {
 			xdsClientClose()
@@ -132,8 +132,8 @@ func (s *GRPCServer) handleServerOptions(opts []grpc.ServerOption) {
 			o.apply(so)
 			continue
 		}
-		if f, ok := server.OverrideListenerResourceNameFromServerOption(opt); ok {
-			so.resourceNameFunc = f
+		if f := server.OverrideListenerResourceNameFromServerOption(opt); f != nil {
+			so.overrideListenerResourceName = f
 		}
 	}
 	s.opts = so
@@ -196,8 +196,8 @@ func (s *GRPCServer) Serve(lis net.Listener) error {
 	// string, it will be replaced with the server's listening "IP:port" (e.g.,
 	// "0.0.0.0:8080", "[::]:8080").
 	var name string
-	if s.opts.resourceNameFunc != nil {
-		name = s.opts.resourceNameFunc(lis.Addr())
+	if s.opts.overrideListenerResourceName != nil {
+		name = s.opts.overrideListenerResourceName(lis.Addr())
 	} else {
 		cfg := s.xdsC.BootstrapConfig()
 		name = cfg.ServerListenerResourceNameTemplate()

--- a/xds/server_options.go
+++ b/xds/server_options.go
@@ -24,24 +24,21 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/internal/xds/bootstrap"
+	internalserver "google.golang.org/grpc/internal/xds/server"
 	"google.golang.org/grpc/internal/xds/xdsclient"
 )
-
-type serverOptions struct {
-	modeCallback                 ServingModeCallbackFunc
-	clientPoolForTesting         *xdsclient.Pool
-	overrideListenerResourceName func(net.Addr) string
-}
-
-type serverOption struct {
-	grpc.EmptyServerOption
-	apply func(*serverOptions)
-}
 
 // ServingModeCallback returns a grpc.ServerOption which allows users to
 // register a callback to get notified about serving mode changes.
 func ServingModeCallback(cb ServingModeCallbackFunc) grpc.ServerOption {
-	return &serverOption{apply: func(o *serverOptions) { o.modeCallback = cb }}
+	return internalserver.NewServerOption(func(o *internalserver.ServerOptions) {
+		o.ModeCallback = func(addr net.Addr, mode connectivity.ServingMode, err error) {
+			cb(addr, ServingModeChangeArgs{
+				Mode: mode,
+				Err:  err,
+			})
+		}
+	})
 }
 
 // ServingModeCallbackFunc is the callback that users can register to get
@@ -78,7 +75,9 @@ func BootstrapContentsForTesting(bootstrapContents []byte) grpc.ServerOption {
 	config, err := bootstrap.NewConfigFromContents(bootstrapContents)
 	if err != nil {
 		logger.Warningf("Failed to parse bootstrap contents %s for server options: %v", string(bootstrapContents), err)
-		return &serverOption{apply: func(o *serverOptions) { o.clientPoolForTesting = nil }}
+		return internalserver.NewServerOption(func(o *internalserver.ServerOptions) {
+			o.ClientPoolForTesting = nil
+		})
 	}
 	return ClientPoolForTesting(xdsclient.NewPool(config))
 }
@@ -97,5 +96,7 @@ func BootstrapContentsForTesting(bootstrapContents []byte) grpc.ServerOption {
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a
 // later release.
 func ClientPoolForTesting(pool *xdsclient.Pool) grpc.ServerOption {
-	return &serverOption{apply: func(o *serverOptions) { o.clientPoolForTesting = pool }}
+	return internalserver.NewServerOption(func(o *internalserver.ServerOptions) {
+		o.ClientPoolForTesting = pool
+	})
 }

--- a/xds/server_options.go
+++ b/xds/server_options.go
@@ -31,7 +31,7 @@ import (
 // ServingModeCallback returns a grpc.ServerOption which allows users to
 // register a callback to get notified about serving mode changes.
 func ServingModeCallback(cb ServingModeCallbackFunc) grpc.ServerOption {
-	return internalserver.NewServerOption(func(o *internalserver.ServerOptions) {
+	return internalserver.NewServerOption(func(o *internalserver.Options) {
 		o.ModeCallback = func(addr net.Addr, mode connectivity.ServingMode, err error) {
 			cb(addr, ServingModeChangeArgs{
 				Mode: mode,
@@ -75,7 +75,7 @@ func BootstrapContentsForTesting(bootstrapContents []byte) grpc.ServerOption {
 	config, err := bootstrap.NewConfigFromContents(bootstrapContents)
 	if err != nil {
 		logger.Warningf("Failed to parse bootstrap contents %s for server options: %v", string(bootstrapContents), err)
-		return internalserver.NewServerOption(func(o *internalserver.ServerOptions) {
+		return internalserver.NewServerOption(func(o *internalserver.Options) {
 			o.ClientPoolForTesting = nil
 		})
 	}
@@ -96,7 +96,7 @@ func BootstrapContentsForTesting(bootstrapContents []byte) grpc.ServerOption {
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a
 // later release.
 func ClientPoolForTesting(pool *xdsclient.Pool) grpc.ServerOption {
-	return internalserver.NewServerOption(func(o *internalserver.ServerOptions) {
+	return internalserver.NewServerOption(func(o *internalserver.Options) {
 		o.ClientPoolForTesting = pool
 	})
 }

--- a/xds/server_options.go
+++ b/xds/server_options.go
@@ -30,6 +30,7 @@ import (
 type serverOptions struct {
 	modeCallback         ServingModeCallbackFunc
 	clientPoolForTesting *xdsclient.Pool
+	resourceNameFunc     func(net.Addr) string
 }
 
 type serverOption struct {
@@ -41,6 +42,22 @@ type serverOption struct {
 // register a callback to get notified about serving mode changes.
 func ServingModeCallback(cb ServingModeCallbackFunc) grpc.ServerOption {
 	return &serverOption{apply: func(o *serverOptions) { o.modeCallback = cb }}
+}
+
+// ResourceNameFunc returns a grpc.ServerOption which allows users to override
+// the LDS listener resource name that the xDS-enabled server subscribes to.
+// When set, this takes precedence over the
+// server_listener_resource_name_template in the bootstrap configuration.
+//
+// The provided function is called at Serve() time with the listener's address
+// and must return the full xDS listener resource name to watch.
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func ResourceNameFunc(f func(net.Addr) string) grpc.ServerOption {
+	return &serverOption{apply: func(o *serverOptions) { o.resourceNameFunc = f }}
 }
 
 // ServingModeCallbackFunc is the callback that users can register to get

--- a/xds/server_options.go
+++ b/xds/server_options.go
@@ -44,22 +44,6 @@ func ServingModeCallback(cb ServingModeCallbackFunc) grpc.ServerOption {
 	return &serverOption{apply: func(o *serverOptions) { o.modeCallback = cb }}
 }
 
-// ResourceNameFunc returns a grpc.ServerOption which allows users to override
-// the LDS listener resource name that the xDS-enabled server subscribes to.
-// When set, this takes precedence over the
-// server_listener_resource_name_template in the bootstrap configuration.
-//
-// The provided function is called at Serve() time with the listener's address
-// and must return the full xDS listener resource name to watch.
-//
-// # Experimental
-//
-// Notice: This API is EXPERIMENTAL and may be changed or removed in a
-// later release.
-func ResourceNameFunc(f func(net.Addr) string) grpc.ServerOption {
-	return &serverOption{apply: func(o *serverOptions) { o.resourceNameFunc = f }}
-}
-
 // ServingModeCallbackFunc is the callback that users can register to get
 // notified about the server's serving mode changes. The callback is invoked
 // with the address of the listener and its new mode.

--- a/xds/server_options.go
+++ b/xds/server_options.go
@@ -28,9 +28,9 @@ import (
 )
 
 type serverOptions struct {
-	modeCallback         ServingModeCallbackFunc
-	clientPoolForTesting *xdsclient.Pool
-	resourceNameFunc     func(net.Addr) string
+	modeCallback                 ServingModeCallbackFunc
+	clientPoolForTesting         *xdsclient.Pool
+	overrideListenerResourceName func(net.Addr) string
 }
 
 type serverOption struct {

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -38,7 +38,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/credentials/tls/certprovider"
 	"google.golang.org/grpc/credentials/xds"
-	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
@@ -235,11 +234,17 @@ func (s) TestNewServer_Failure(t *testing.T) {
 // template is absent, and that its returned name is used for the LDS watch.
 func (s) TestServer_OverrideListenerResourceNameOverridesMissingTemplate(t *testing.T) {
 	const wantResourceName = "xdstp://foo/bar"
-	ldsResourceNameReceived := grpcsync.NewEvent()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	ldsResourceNamesCh := make(chan []string, 1)
 	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{
 		OnStreamRequest: func(_ int64, req *v3discoverypb.DiscoveryRequest) error {
-			if req.GetTypeUrl() == version.V3ListenerURL && cmp.Equal(req.GetResourceNames(), []string{wantResourceName}) {
-				ldsResourceNameReceived.Fire()
+			if req.GetTypeUrl() == version.V3ListenerURL {
+				select {
+				case ldsResourceNamesCh <- req.GetResourceNames():
+				case <-ctx.Done():
+				}
 			}
 			return nil
 		},
@@ -278,8 +283,6 @@ func (s) TestServer_OverrideListenerResourceNameOverridesMissingTemplate(t *test
 	}
 	go func() { _ = srv.Serve(lis) }()
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
 	// Verify that OverrideListenerResourceName receives the listener address.
 	select {
 	case gotAddr := <-lisAddrCh:
@@ -291,10 +294,15 @@ func (s) TestServer_OverrideListenerResourceNameOverridesMissingTemplate(t *test
 	}
 
 	// Verify that the LDS watch uses the resource name returned by the override.
+	var gotResourceNames []string
 	select {
-	case <-ldsResourceNameReceived.Done():
+	case gotResourceNames = <-ldsResourceNamesCh:
 	case <-ctx.Done():
-		t.Fatal("Timeout waiting for an LDS request with the overridden resource name")
+		t.Fatal("Timeout waiting for an LDS request")
+	}
+	wantResourceNames := []string{wantResourceName}
+	if !cmp.Equal(gotResourceNames, wantResourceNames) {
+		t.Fatalf("LDS watch registered for names %v, want %v", gotResourceNames, wantResourceNames)
 	}
 }
 

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -227,6 +227,36 @@ func (s) TestNewServer_Failure(t *testing.T) {
 	}
 }
 
+func (s) TestNewServer_ResourceNameFuncOverridesMissingTemplate(t *testing.T) {
+	xdsCreds, err := xds.NewServerCredentials(xds.ServerOptions{FallbackCreds: insecure.NewCredentials()})
+	if err != nil {
+		t.Fatalf("failed to create xds server credentials: %v", err)
+	}
+	bs, err := bootstrap.NewContentsForTesting(bootstrap.ConfigOptionsForTesting{
+		Servers: []byte(fmt.Sprintf(`[{
+			"server_uri": %q,
+			"channel_creds": [{"type": "insecure"}]
+		}]`, nonExistentManagementServer)),
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, uuid.New().String())),
+		CertificateProviders: map[string]json.RawMessage{
+			"cert-provider-instance": json.RawMessage("{}"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create bootstrap configuration: %v", err)
+	}
+
+	srv, err := NewGRPCServer(
+		grpc.Creds(xdsCreds),
+		ResourceNameFunc(func(_ net.Addr) string { return "xdstp://foo/bar" }),
+		BootstrapContentsForTesting(bs),
+	)
+	if err != nil {
+		t.Fatalf("NewGRPCServer() failed: %v", err)
+	}
+	srv.Stop()
+}
+
 func (s) TestRegisterService(t *testing.T) {
 	fs := newFakeGRPCServer()
 

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -42,6 +42,7 @@ import (
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
 	"google.golang.org/grpc/internal/xds/bootstrap"
+	internalserver "google.golang.org/grpc/internal/xds/server"
 	"google.golang.org/grpc/internal/xds/xdsclient"
 	"google.golang.org/grpc/internal/xds/xdsclient/xdsresource/version"
 
@@ -227,34 +228,92 @@ func (s) TestNewServer_Failure(t *testing.T) {
 	}
 }
 
-func (s) TestNewServer_ResourceNameFuncOverridesMissingTemplate(t *testing.T) {
-	xdsCreds, err := xds.NewServerCredentials(xds.ServerOptions{FallbackCreds: insecure.NewCredentials()})
-	if err != nil {
-		t.Fatalf("failed to create xds server credentials: %v", err)
-	}
+func (s) TestServer_ResourceNameFuncOverridesMissingTemplate(t *testing.T) {
+	const wantResourceName = "xdstp://foo/bar"
+	ldsRequestCh := make(chan []string, 1)
+	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{
+		OnStreamRequest: func(_ int64, req *v3discoverypb.DiscoveryRequest) error {
+			if req.GetTypeUrl() == version.V3ListenerURL {
+				select {
+				case ldsRequestCh <- req.GetResourceNames():
+				default:
+				}
+			}
+			return nil
+		},
+	})
+
 	bs, err := bootstrap.NewContentsForTesting(bootstrap.ConfigOptionsForTesting{
 		Servers: []byte(fmt.Sprintf(`[{
 			"server_uri": %q,
 			"channel_creds": [{"type": "insecure"}]
-		}]`, nonExistentManagementServer)),
+		}]`, mgmtServer.Address)),
 		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, uuid.New().String())),
-		CertificateProviders: map[string]json.RawMessage{
-			"cert-provider-instance": json.RawMessage("{}"),
-		},
 	})
 	if err != nil {
 		t.Fatalf("Failed to create bootstrap configuration: %v", err)
 	}
 
+	fs := newFakeGRPCServer()
+	origNewGRPCServer := newGRPCServer
+	newGRPCServer = func(...grpc.ServerOption) grpcServer { return fs }
+	defer func() { newGRPCServer = origNewGRPCServer }()
+
+	addrCh := make(chan net.Addr, 1)
 	srv, err := NewGRPCServer(
-		grpc.Creds(xdsCreds),
-		ResourceNameFunc(func(_ net.Addr) string { return "xdstp://foo/bar" }),
+		internalserver.ResourceNameFunc(func(addr net.Addr) string {
+			addrCh <- addr
+			return wantResourceName
+		}),
 		BootstrapContentsForTesting(bs),
 	)
 	if err != nil {
 		t.Fatalf("NewGRPCServer() failed: %v", err)
 	}
+	stopped := false
+	defer func() {
+		if !stopped {
+			srv.Stop()
+		}
+	}()
+
+	lis, err := testutils.LocalTCPListener()
+	if err != nil {
+		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
+	}
+	serveErrCh := make(chan error, 1)
+	go func() { serveErrCh <- srv.Serve(lis) }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	select {
+	case gotAddr := <-addrCh:
+		if gotAddr.String() != lis.Addr().String() {
+			t.Fatalf("ResourceNameFunc() called with address %q, want %q", gotAddr, lis.Addr())
+		}
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for ResourceNameFunc to be called")
+	}
+
+	select {
+	case gotNames := <-ldsRequestCh:
+		if diff := cmp.Diff([]string{wantResourceName}, gotNames); diff != "" {
+			t.Fatalf("LDS resource names mismatch (-want +got):\n%s", diff)
+		}
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for an LDS request")
+	}
+
 	srv.Stop()
+	stopped = true
+	select {
+	case err := <-serveErrCh:
+		if err != nil {
+			t.Fatalf("Serve() returned error: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for Serve() to return")
+	}
 }
 
 func (s) TestRegisterService(t *testing.T) {

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -238,8 +238,7 @@ func (s) TestServer_OverrideListenerResourceNameOverridesMissingTemplate(t *test
 	ldsResourceNameReceived := grpcsync.NewEvent()
 	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{
 		OnStreamRequest: func(_ int64, req *v3discoverypb.DiscoveryRequest) error {
-			if req.GetTypeUrl() == version.V3ListenerURL &&
-				cmp.Equal(req.GetResourceNames(), []string{wantResourceName}) {
+			if req.GetTypeUrl() == version.V3ListenerURL && cmp.Equal(req.GetResourceNames(), []string{wantResourceName}) {
 				ldsResourceNameReceived.Fire()
 			}
 			return nil
@@ -262,36 +261,28 @@ func (s) TestServer_OverrideListenerResourceNameOverridesMissingTemplate(t *test
 	newGRPCServer = func(...grpc.ServerOption) grpcServer { return fs }
 	defer func() { newGRPCServer = origNewGRPCServer }()
 
-	addrCh := make(chan net.Addr, 1)
-	srv, err := NewGRPCServer(
-		internalserver.OverrideListenerResourceName(func(addr net.Addr) string {
-			addrCh <- addr
-			return wantResourceName
-		}),
-		BootstrapContentsForTesting(bs),
-	)
+	lisAddrCh := make(chan net.Addr, 1)
+	resourceNameOpt := internalserver.OverrideListenerResourceName(func(addr net.Addr) string {
+		lisAddrCh <- addr
+		return wantResourceName
+	})
+	srv, err := NewGRPCServer(resourceNameOpt, BootstrapContentsForTesting(bs))
 	if err != nil {
 		t.Fatalf("NewGRPCServer() failed: %v", err)
 	}
-	stopped := false
-	defer func() {
-		if !stopped {
-			srv.Stop()
-		}
-	}()
+	defer srv.Stop()
 
 	lis, err := testutils.LocalTCPListener()
 	if err != nil {
 		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
 	}
-	serveErrCh := make(chan error, 1)
-	go func() { serveErrCh <- srv.Serve(lis) }()
+	go func() { _ = srv.Serve(lis) }()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	// Verify that OverrideListenerResourceName receives the listener address.
 	select {
-	case gotAddr := <-addrCh:
+	case gotAddr := <-lisAddrCh:
 		if gotAddr.String() != lis.Addr().String() {
 			t.Fatalf("OverrideListenerResourceName() called with address %q, want %q", gotAddr, lis.Addr())
 		}
@@ -304,18 +295,6 @@ func (s) TestServer_OverrideListenerResourceNameOverridesMissingTemplate(t *test
 	case <-ldsResourceNameReceived.Done():
 	case <-ctx.Done():
 		t.Fatal("Timeout waiting for an LDS request with the overridden resource name")
-	}
-
-	srv.Stop()
-	stopped = true
-	// Verify that Serve returns after the server is stopped.
-	select {
-	case err := <-serveErrCh:
-		if err != nil {
-			t.Fatalf("Serve() returned error: %v", err)
-		}
-	case <-ctx.Done():
-		t.Fatal("Timeout waiting for Serve() to return")
 	}
 }
 

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -38,6 +38,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/credentials/tls/certprovider"
 	"google.golang.org/grpc/credentials/xds"
+	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
@@ -228,16 +229,18 @@ func (s) TestNewServer_Failure(t *testing.T) {
 	}
 }
 
-func (s) TestServer_ResourceNameFuncOverridesMissingTemplate(t *testing.T) {
+// TestServer_OverrideListenerResourceNameOverridesMissingTemplate verifies
+// that an internal listener resource name override takes precedence over
+// server_listener_resource_name_template from bootstrap, including when the
+// template is absent, and that its returned name is used for the LDS watch.
+func (s) TestServer_OverrideListenerResourceNameOverridesMissingTemplate(t *testing.T) {
 	const wantResourceName = "xdstp://foo/bar"
-	ldsRequestCh := make(chan []string, 1)
+	ldsResourceNameReceived := grpcsync.NewEvent()
 	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{
 		OnStreamRequest: func(_ int64, req *v3discoverypb.DiscoveryRequest) error {
-			if req.GetTypeUrl() == version.V3ListenerURL {
-				select {
-				case ldsRequestCh <- req.GetResourceNames():
-				default:
-				}
+			if req.GetTypeUrl() == version.V3ListenerURL &&
+				cmp.Equal(req.GetResourceNames(), []string{wantResourceName}) {
+				ldsResourceNameReceived.Fire()
 			}
 			return nil
 		},
@@ -261,7 +264,7 @@ func (s) TestServer_ResourceNameFuncOverridesMissingTemplate(t *testing.T) {
 
 	addrCh := make(chan net.Addr, 1)
 	srv, err := NewGRPCServer(
-		internalserver.ResourceNameFunc(func(addr net.Addr) string {
+		internalserver.OverrideListenerResourceName(func(addr net.Addr) string {
 			addrCh <- addr
 			return wantResourceName
 		}),
@@ -286,26 +289,26 @@ func (s) TestServer_ResourceNameFuncOverridesMissingTemplate(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
+	// Verify that OverrideListenerResourceName receives the listener address.
 	select {
 	case gotAddr := <-addrCh:
 		if gotAddr.String() != lis.Addr().String() {
-			t.Fatalf("ResourceNameFunc() called with address %q, want %q", gotAddr, lis.Addr())
+			t.Fatalf("OverrideListenerResourceName() called with address %q, want %q", gotAddr, lis.Addr())
 		}
 	case <-ctx.Done():
-		t.Fatal("Timeout waiting for ResourceNameFunc to be called")
+		t.Fatal("Timeout waiting for OverrideListenerResourceName to be called")
 	}
 
+	// Verify that the LDS watch uses the resource name returned by the override.
 	select {
-	case gotNames := <-ldsRequestCh:
-		if diff := cmp.Diff([]string{wantResourceName}, gotNames); diff != "" {
-			t.Fatalf("LDS resource names mismatch (-want +got):\n%s", diff)
-		}
+	case <-ldsResourceNameReceived.Done():
 	case <-ctx.Done():
-		t.Fatal("Timeout waiting for an LDS request")
+		t.Fatal("Timeout waiting for an LDS request with the overridden resource name")
 	}
 
 	srv.Stop()
 	stopped = true
+	// Verify that Serve returns after the server is stopped.
 	select {
 	case err := <-serveErrCh:
 		if err != nil {


### PR DESCRIPTION
Adds an internal `ResourceNameFunc` server option that allows override the LDS listener resource name.

RELEASE NOTES: none