### PR TITLE
endpointsharding: decouple locking, and simplify ChildState API

### DIFF
--- a/balancer/endpointsharding/endpointsharding.go
+++ b/balancer/endpointsharding/endpointsharding.go
@@ -241,7 +241,8 @@ func (es *endpointSharding) allowUpdatesFromChildren() {
 
 // updateStateLocked updates this component's state. It sends the aggregated
 // state, and a picker with round robin behavior with all the child states
-// present if needed.
+// present if needed. This method must only be called when inhibitChildUpdates
+// is false.
 //
 // Caller must hold es.mu.
 func (es *endpointSharding) updateStateLocked() {

--- a/balancer/endpointsharding/endpointsharding.go
+++ b/balancer/endpointsharding/endpointsharding.go
@@ -82,12 +82,31 @@ type endpointSharding struct {
 	esOpts       Options
 	childBuilder ChildBuilderFunc
 
-	// mu is used to guarantee mutual exclusion between top-down methods (like
-	// UpdateClientConnState, ResolverError etc, which are already serialized) and
-	// calls from child balancers (like UpdateState) that can be called
-	// concurrently. This directly means that we should never call any methods on
-	// the child balancers while holding the mutex, because they can call
-	// UpdateState inline, leading to a deadlock.
+	// mu guards access to the below fields and guarantees mutual exclusion
+	// between top-down methods (like UpdateClientConnState, ResolverError etc,
+	// which are already serialized) and bottom-up methods (like UpdateState)
+	// that can be called concurrently.
+	//
+	// Lock ordering & deadlock prevention:
+	// Child callbacks (like UpdateState) acquire this mutex to push state updates
+	// to the parent. This establishes a strict lock ordering:
+	//   [endpointState.childMu] -> [endpointSharding.mu]
+	//
+	// To prevent deadlocks, we must never invert this order. Therefore, we must
+	// never call any methods on a child balancer while holding this mutex. If we
+	// did, and that child balancer invoked UpdateState synchronously, it would
+	// attempt to re-acquire this mutex, causing a deadlock.
+	//
+	// Concurrency:
+	// Top-down operations need to iterate over all children. To ensure a
+	// single, clean aggregated update at the end of such operations, we inhibit
+	// intermediate updates from children. We grab this mutex briefly to set
+	// `inhibitChildUpdates = true` and immediately release it. This allows us
+	// to perform the potentially slow, top-down child updates without holding
+	// any parent locks. Once finished, we grab the mutex again to unset the
+	// flag and push the final aggregated state. An update from a child during
+	// this time will *only* update the child state, and will not access the
+	// endpoints map or push an aggregated state to the parent.
 	mu                  sync.Mutex
 	endpoints           *resolver.EndpointMap[*endpointState]
 	inhibitChildUpdates bool
@@ -116,9 +135,7 @@ func rotateEndpoints(es []resolver.Endpoint) []resolver.Endpoint {
 //
 // Returns the first error found from a child, but fully processes the update.
 func (es *endpointSharding) UpdateClientConnState(state balancer.ClientConnState) error {
-	es.mu.Lock()
-	es.inhibitChildUpdates = true
-	es.mu.Unlock()
+	es.inhibitUpdatesFromChildren()
 
 	// Update/create child balancers for each endpoint in the update. Note that we
 	// don't hold the mutex here, but this is fine because inhibitChildUpdates is
@@ -137,16 +154,17 @@ func (es *endpointSharding) UpdateClientConnState(state balancer.ClientConnState
 		} else {
 			// Endpoint child does not exist, create a new one.
 			epState = &endpointState{
-				ClientConn: es.cc,
-				es:         es,
-				endpoint:   endpoint,
+				ClientConn:           es.cc,
+				parent:               es,
+				endpoint:             endpoint,
+				disableAutoReconnect: es.esOpts.DisableAutoReconnect,
 			}
 			epState.childLB = es.childBuilder(epState, es.bOpts)
 		}
 		// Update the endpoint state for the endpoint.
 		newEndpoints.Set(endpoint, epState)
 
-		if err := epState.childLB.UpdateClientConnState(balancer.ClientConnState{
+		if err := epState.updateClientConnState(balancer.ClientConnState{
 			BalancerConfig: state.BalancerConfig,
 			ResolverState: resolver.State{
 				Endpoints:  []resolver.Endpoint{endpoint},
@@ -161,17 +179,16 @@ func (es *endpointSharding) UpdateClientConnState(state balancer.ClientConnState
 	// Delete old children that are no longer present.
 	for e, child := range es.endpoints.All() {
 		if _, ok := newEndpoints.Get(e); !ok {
-			child.childLB.Close()
+			child.close()
 		}
 	}
 
-	// Update the endpoints to the new endpoints.
-	es.endpoints = newEndpoints
-	if es.endpoints.Len() == 0 {
+	if newEndpoints.Len() == 0 {
 		retErr = balancer.ErrBadResolverState
 	}
 
 	es.mu.Lock()
+	es.endpoints = newEndpoints
 	es.inhibitChildUpdates = false
 	es.updateStateLocked()
 	es.mu.Unlock()
@@ -183,18 +200,11 @@ func (es *endpointSharding) UpdateClientConnState(state balancer.ClientConnState
 // children and sends a single synchronous update of the childStates at the end
 // of the ResolverError operation.
 func (es *endpointSharding) ResolverError(err error) {
-	es.mu.Lock()
-	es.inhibitChildUpdates = true
-	es.mu.Unlock()
-
+	es.inhibitUpdatesFromChildren()
 	for _, child := range es.endpoints.All() {
-		child.childLB.ResolverError(err)
+		child.resolverError(err)
 	}
-
-	es.mu.Lock()
-	es.inhibitChildUpdates = false
-	es.updateStateLocked()
-	es.mu.Unlock()
+	es.allowUpdatesFromChildren()
 }
 
 func (es *endpointSharding) UpdateSubConnState(balancer.SubConn, balancer.SubConnState) {
@@ -202,20 +212,27 @@ func (es *endpointSharding) UpdateSubConnState(balancer.SubConn, balancer.SubCon
 }
 
 func (es *endpointSharding) Close() {
+	es.inhibitUpdatesFromChildren()
 	for _, child := range es.endpoints.All() {
-		child.childLB.Close()
+		child.close()
 	}
 }
 
 func (es *endpointSharding) ExitIdle() {
+	es.inhibitUpdatesFromChildren()
+	for _, child := range es.endpoints.All() {
+		child.exitIdle()
+	}
+	es.allowUpdatesFromChildren()
+}
+
+func (es *endpointSharding) inhibitUpdatesFromChildren() {
 	es.mu.Lock()
 	es.inhibitChildUpdates = true
 	es.mu.Unlock()
+}
 
-	for _, child := range es.endpoints.All() {
-		child.childLB.ExitIdle()
-	}
-
+func (es *endpointSharding) allowUpdatesFromChildren() {
 	es.mu.Lock()
 	es.inhibitChildUpdates = false
 	es.updateStateLocked()
@@ -235,7 +252,7 @@ func (es *endpointSharding) updateStateLocked() {
 		childState := ChildState{
 			Endpoint: epState.endpoint,
 			State:    epState.state,
-			ExitIdle: func() { go epState.childLB.ExitIdle() },
+			ExitIdle: func() { go epState.exitIdle() },
 		}
 		childStates = append(childStates, childState)
 		childPicker := childState.State.Picker
@@ -313,21 +330,55 @@ func ChildStatesFromPicker(picker balancer.Picker) []ChildState {
 type endpointState struct {
 	balancer.ClientConn // Embedded to intercept UpdateState
 
-	es       *endpointSharding // Parent endpointsharding balancer.
-	childLB  balancer.Balancer // Child balancer.
-	endpoint resolver.Endpoint // Endpoint of the child balancer.
-	state    balancer.State    // State of the child balancer.
+	parent               *endpointSharding // Parent endpointsharding balancer.
+	endpoint             resolver.Endpoint // Endpoint of the child balancer.
+	state                balancer.State    // State of the child balancer.
+	disableAutoReconnect bool              // Whether to disable auto reconnect for this child.
+
+	childMu sync.Mutex        // Guarantees mutual exclusion for Balancer API calls to the child balancer.
+	childLB balancer.Balancer // Child balancer.
+	closed  bool              // Tracks closure of the child balancer to ensure ExitIdle is not called after Close().
 }
 
 func (es *endpointState) UpdateState(state balancer.State) {
-	es.es.mu.Lock()
+	es.parent.mu.Lock()
 	es.state = state
-	if !es.es.inhibitChildUpdates {
-		es.es.updateStateLocked()
+	if !es.parent.inhibitChildUpdates {
+		es.parent.updateStateLocked()
 	}
-	es.es.mu.Unlock()
+	es.parent.mu.Unlock()
 
-	if state.ConnectivityState == connectivity.Idle && !es.es.esOpts.DisableAutoReconnect {
-		go es.childLB.ExitIdle()
+	if state.ConnectivityState == connectivity.Idle && !es.disableAutoReconnect {
+		go es.exitIdle()
 	}
+}
+
+func (es *endpointState) updateClientConnState(state balancer.ClientConnState) error {
+	es.childMu.Lock()
+	err := es.childLB.UpdateClientConnState(state)
+	es.childMu.Unlock()
+	return err
+}
+
+func (es *endpointState) resolverError(err error) {
+	es.childMu.Lock()
+	es.childLB.ResolverError(err)
+	es.childMu.Unlock()
+}
+
+func (es *endpointState) close() {
+	es.childMu.Lock()
+	if !es.closed {
+		es.closed = true
+		es.childLB.Close()
+	}
+	es.childMu.Unlock()
+}
+
+func (es *endpointState) exitIdle() {
+	es.childMu.Lock()
+	if !es.closed {
+		es.childLB.ExitIdle()
+	}
+	es.childMu.Unlock()
 }

--- a/balancer/endpointsharding/endpointsharding.go
+++ b/balancer/endpointsharding/endpointsharding.go
@@ -39,27 +39,14 @@ import (
 
 var randIntN = rand.IntN
 
-// ChildState is the balancer state of a child along with the endpoint which
-// identifies the child balancer.
+// ChildState is the state of a child balancer.
 type ChildState struct {
-	Endpoint resolver.Endpoint
-	State    balancer.State
-
-	// Balancer exposes only the ExitIdler interface of the child LB policy.
-	// Other methods of the child policy are called only by endpointsharding.
-	Balancer ExitIdler
+	Endpoint resolver.Endpoint // Endpoint of the child balancer.
+	State    balancer.State    // State of the child balancer.
+	ExitIdle func()            // Function to exit the child balancer from IDLE state.
 }
 
-// ExitIdler provides access to only the ExitIdle method of the child balancer.
-type ExitIdler interface {
-	// ExitIdle instructs the LB policy to reconnect to backends / exit the
-	// IDLE state, if appropriate and possible.  Note that SubConns that enter
-	// the IDLE state will not reconnect until SubConn.Connect is called.
-	ExitIdle()
-}
-
-// Options are the options to configure the behaviour of the
-// endpointsharding balancer.
+// Options configure the behaviour of the endpointsharding balancer.
 type Options struct {
 	// DisableAutoReconnect allows the balancer to keep child balancer in the
 	// IDLE state until they are explicitly triggered to exit using the
@@ -77,14 +64,13 @@ type ChildBuilderFunc func(cc balancer.ClientConn, opts balancer.BuildOptions) b
 // policies each owning a single endpoint. The endpointsharding balancer
 // forwards the LoadBalancingConfig in ClientConn state updates to its children.
 func NewBalancer(cc balancer.ClientConn, opts balancer.BuildOptions, childBuilder ChildBuilderFunc, esOpts Options) balancer.Balancer {
-	es := &endpointSharding{
+	return &endpointSharding{
 		cc:           cc,
 		bOpts:        opts,
 		esOpts:       esOpts,
 		childBuilder: childBuilder,
+		endpoints:    resolver.NewEndpointMap[*endpointState](),
 	}
-	es.children.Store(resolver.NewEndpointMap[*balancerWrapper]())
-	return es
 }
 
 // endpointSharding is a balancer that wraps child balancers. It creates a child
@@ -96,124 +82,119 @@ type endpointSharding struct {
 	esOpts       Options
 	childBuilder ChildBuilderFunc
 
-	// childMu synchronizes calls to any single child. It must be held for all
-	// calls into a child. To avoid deadlocks, do not acquire childMu while
-	// holding mu.
-	childMu  sync.Mutex
-	children atomic.Pointer[resolver.EndpointMap[*balancerWrapper]]
-
-	// inhibitChildUpdates is set during UpdateClientConnState/ResolverError
-	// calls (calls to children will each produce an update, only want one
-	// update).
-	inhibitChildUpdates atomic.Bool
-
-	// mu synchronizes access to the state stored in balancerWrappers in the
-	// children field. mu must not be held during calls into a child since
-	// synchronous calls back from the child may require taking mu, causing a
-	// deadlock. To avoid deadlocks, do not acquire childMu while holding mu.
-	mu sync.Mutex
+	// mu is used to guarantee mutual exclusion between top-down methods (like
+	// UpdateClientConnState, ResolverError etc, which are already serialized) and
+	// calls from child balancers (like UpdateState) that can be called
+	// concurrently. This directly means that we should never call any methods on
+	// the child balancers while holding the mutex, because they can call
+	// UpdateState inline, leading to a deadlock.
+	mu                  sync.Mutex
+	endpoints           *resolver.EndpointMap[*endpointState]
+	inhibitChildUpdates bool
 }
 
 // rotateEndpoints returns a slice of all the input endpoints rotated a random
 // amount.
 func rotateEndpoints(es []resolver.Endpoint) []resolver.Endpoint {
-	les := len(es)
-	if les == 0 {
+	n := len(es)
+	if n == 0 {
 		return es
 	}
-	r := randIntN(les)
+	r := randIntN(n)
+
 	// Make a copy to avoid mutating data beyond the end of es.
-	ret := make([]resolver.Endpoint, les)
+	ret := make([]resolver.Endpoint, n)
 	copy(ret, es[r:])
-	copy(ret[les-r:], es[:r])
+	copy(ret[n-r:], es[:r])
 	return ret
 }
 
 // UpdateClientConnState creates a child for new endpoints and deletes children
 // for endpoints that are no longer present. It also updates all the children,
 // and sends a single synchronous update of the childrens' aggregated state at
-// the end of the UpdateClientConnState operation. If any endpoint has no
-// addresses it will ignore that endpoint. Otherwise, returns first error found
-// from a child, but fully processes the new update.
+// the end of the UpdateClientConnState operation.
+//
+// Returns the first error found from a child, but fully processes the update.
 func (es *endpointSharding) UpdateClientConnState(state balancer.ClientConnState) error {
-	es.childMu.Lock()
-	defer es.childMu.Unlock()
+	es.mu.Lock()
+	es.inhibitChildUpdates = true
+	es.mu.Unlock()
 
-	es.inhibitChildUpdates.Store(true)
-	defer func() {
-		es.inhibitChildUpdates.Store(false)
-		es.updateState()
-	}()
-	var ret error
-
-	children := es.children.Load()
-	newChildren := resolver.NewEndpointMap[*balancerWrapper]()
-
-	// Update/Create new children.
+	// Update/create child balancers for each endpoint in the update. Note that we
+	// don't hold the mutex here, but this is fine because inhibitChildUpdates is
+	// true, and therefore UpdateState will not access es.endpoints.
+	var retErr error
+	newEndpoints := resolver.NewEndpointMap[*endpointState]()
 	for _, endpoint := range rotateEndpoints(state.ResolverState.Endpoints) {
-		if _, ok := newChildren.Get(endpoint); ok {
-			// Endpoint child was already created, continue to avoid duplicate
-			// update.
+		if _, ok := newEndpoints.Get(endpoint); ok {
+			// Skip duplicate endpoints.
 			continue
 		}
-		childBalancer, ok := children.Get(endpoint)
+		epState, ok := es.endpoints.Get(endpoint)
 		if ok {
-			// Endpoint attributes may have changed, update the stored endpoint.
-			es.mu.Lock()
-			childBalancer.childState.Endpoint = endpoint
-			es.mu.Unlock()
+			// Endpoint child already exists, update the stored endpoint.
+			epState.endpoint = endpoint
 		} else {
-			childBalancer = &balancerWrapper{
-				childState: ChildState{Endpoint: endpoint},
+			// Endpoint child does not exist, create a new one.
+			epState = &endpointState{
 				ClientConn: es.cc,
 				es:         es,
+				endpoint:   endpoint,
 			}
-			childBalancer.childState.Balancer = childBalancer
-			childBalancer.child = es.childBuilder(childBalancer, es.bOpts)
+			epState.childLB = es.childBuilder(epState, es.bOpts)
 		}
-		newChildren.Set(endpoint, childBalancer)
-		if err := childBalancer.updateClientConnStateLocked(balancer.ClientConnState{
+		// Update the endpoint state for the endpoint.
+		newEndpoints.Set(endpoint, epState)
+
+		if err := epState.childLB.UpdateClientConnState(balancer.ClientConnState{
 			BalancerConfig: state.BalancerConfig,
 			ResolverState: resolver.State{
 				Endpoints:  []resolver.Endpoint{endpoint},
 				Attributes: state.ResolverState.Attributes,
 			},
-		}); err != nil && ret == nil {
-			// Return first error found, and always commit full processing of
-			// updating children. If desired to process more specific errors
-			// across all endpoints, caller should make these specific
-			// validations, this is a current limitation for simplicity sake.
-			ret = err
+		}); err != nil && retErr == nil {
+			// Keep the first error found from any child.
+			retErr = err
 		}
 	}
+
 	// Delete old children that are no longer present.
-	for e, child := range children.All() {
-		if _, ok := newChildren.Get(e); !ok {
-			child.closeLocked()
+	for e, child := range es.endpoints.All() {
+		if _, ok := newEndpoints.Get(e); !ok {
+			child.childLB.Close()
 		}
 	}
-	es.children.Store(newChildren)
-	if newChildren.Len() == 0 {
-		return balancer.ErrBadResolverState
+
+	// Update the endpoints to the new endpoints.
+	es.endpoints = newEndpoints
+	if es.endpoints.Len() == 0 {
+		retErr = balancer.ErrBadResolverState
 	}
-	return ret
+
+	es.mu.Lock()
+	es.inhibitChildUpdates = false
+	es.updateStateLocked()
+	es.mu.Unlock()
+
+	return retErr
 }
 
 // ResolverError forwards the resolver error to all of the endpointSharding's
 // children and sends a single synchronous update of the childStates at the end
 // of the ResolverError operation.
 func (es *endpointSharding) ResolverError(err error) {
-	es.childMu.Lock()
-	defer es.childMu.Unlock()
-	es.inhibitChildUpdates.Store(true)
-	defer func() {
-		es.inhibitChildUpdates.Store(false)
-		es.updateState()
-	}()
-	children := es.children.Load()
-	for _, child := range children.All() {
-		child.resolverErrorLocked(err)
+	es.mu.Lock()
+	es.inhibitChildUpdates = true
+	es.mu.Unlock()
+
+	for _, child := range es.endpoints.All() {
+		child.childLB.ResolverError(err)
 	}
+
+	es.mu.Lock()
+	es.inhibitChildUpdates = false
+	es.updateStateLocked()
+	es.mu.Unlock()
 }
 
 func (es *endpointSharding) UpdateSubConnState(balancer.SubConn, balancer.SubConnState) {
@@ -221,41 +202,41 @@ func (es *endpointSharding) UpdateSubConnState(balancer.SubConn, balancer.SubCon
 }
 
 func (es *endpointSharding) Close() {
-	es.childMu.Lock()
-	defer es.childMu.Unlock()
-	children := es.children.Load()
-	for _, child := range children.All() {
-		child.closeLocked()
+	for _, child := range es.endpoints.All() {
+		child.childLB.Close()
 	}
 }
 
 func (es *endpointSharding) ExitIdle() {
-	es.childMu.Lock()
-	defer es.childMu.Unlock()
-	for _, bw := range es.children.Load().All() {
-		if !bw.isClosed {
-			bw.child.ExitIdle()
-		}
-	}
-}
+	es.mu.Lock()
+	es.inhibitChildUpdates = true
+	es.mu.Unlock()
 
-// updateState updates this component's state. It sends the aggregated state,
-// and a picker with round robin behavior with all the child states present if
-// needed.
-func (es *endpointSharding) updateState() {
-	if es.inhibitChildUpdates.Load() {
-		return
+	for _, child := range es.endpoints.All() {
+		child.childLB.ExitIdle()
 	}
-	var readyPickers, connectingPickers, idlePickers, transientFailurePickers []balancer.Picker
 
 	es.mu.Lock()
-	defer es.mu.Unlock()
+	es.inhibitChildUpdates = false
+	es.updateStateLocked()
+	es.mu.Unlock()
+}
 
-	children := es.children.Load()
-	childStates := make([]ChildState, 0, children.Len())
+// updateStateLocked updates this component's state. It sends the aggregated
+// state, and a picker with round robin behavior with all the child states
+// present if needed.
+//
+// Caller must hold es.mu.
+func (es *endpointSharding) updateStateLocked() {
+	var readyPickers, connectingPickers, idlePickers, transientFailurePickers []balancer.Picker
 
-	for _, child := range children.All() {
-		childState := child.childState
+	childStates := make([]ChildState, 0, es.endpoints.Len())
+	for _, epState := range es.endpoints.All() {
+		childState := ChildState{
+			Endpoint: epState.endpoint,
+			State:    epState.state,
+			ExitIdle: func() { go epState.childLB.ExitIdle() },
+		}
 		childStates = append(childStates, childState)
 		childPicker := childState.State.Picker
 		switch childState.State.ConnectivityState {
@@ -292,14 +273,14 @@ func (es *endpointSharding) updateState() {
 		aggState = connectivity.TransientFailure
 		pickers = []balancer.Picker{base.NewErrPicker(errors.New("no children to pick from"))}
 	} // No children (resolver error before valid update).
-	p := &pickerWithChildStates{
-		pickers:     pickers,
-		childStates: childStates,
-		next:        uint32(randIntN(len(pickers))),
-	}
+
 	es.cc.UpdateState(balancer.State{
 		ConnectivityState: aggState,
-		Picker:            p,
+		Picker: &pickerWithChildStates{
+			pickers:     pickers,
+			childStates: childStates,
+			next:        uint32(randIntN(len(pickers))),
+		},
 	})
 }
 
@@ -328,61 +309,25 @@ func ChildStatesFromPicker(picker balancer.Picker) []ChildState {
 	return p.childStates
 }
 
-// balancerWrapper is a wrapper of a balancer. It ID's a child balancer by
-// endpoint, and persists recent child balancer state.
-type balancerWrapper struct {
-	// The following fields are initialized at build time and read-only after
-	// that and therefore do not need to be guarded by a mutex.
+// endpointState is the internal state maintained for each endpoint.
+type endpointState struct {
+	balancer.ClientConn // Embedded to intercept UpdateState
 
-	// child contains the wrapped balancer. Access its methods only through
-	// methods on balancerWrapper to ensure proper synchronization
-	child               balancer.Balancer
-	balancer.ClientConn // embed to intercept UpdateState, doesn't deal with SubConns
-
-	es *endpointSharding
-
-	// Access to the following fields is guarded by es.mu.
-
-	childState ChildState
-	isClosed   bool
+	es       *endpointSharding // Parent endpointsharding balancer.
+	childLB  balancer.Balancer // Child balancer.
+	endpoint resolver.Endpoint // Endpoint of the child balancer.
+	state    balancer.State    // State of the child balancer.
 }
 
-func (bw *balancerWrapper) UpdateState(state balancer.State) {
-	bw.es.mu.Lock()
-	bw.childState.State = state
-	bw.es.mu.Unlock()
-	if state.ConnectivityState == connectivity.Idle && !bw.es.esOpts.DisableAutoReconnect {
-		bw.ExitIdle()
+func (es *endpointState) UpdateState(state balancer.State) {
+	es.es.mu.Lock()
+	es.state = state
+	if !es.es.inhibitChildUpdates {
+		es.es.updateStateLocked()
 	}
-	bw.es.updateState()
-}
+	es.es.mu.Unlock()
 
-// ExitIdle pings an IDLE child balancer to exit idle in a new goroutine to
-// avoid deadlocks due to synchronous balancer state updates.
-func (bw *balancerWrapper) ExitIdle() {
-	go func() {
-		bw.es.childMu.Lock()
-		if !bw.isClosed {
-			bw.child.ExitIdle()
-		}
-		bw.es.childMu.Unlock()
-	}()
-}
-
-// updateClientConnStateLocked delivers the ClientConnState to the child
-// balancer. Callers must hold the child mutex of the parent endpointsharding
-// balancer.
-func (bw *balancerWrapper) updateClientConnStateLocked(ccs balancer.ClientConnState) error {
-	return bw.child.UpdateClientConnState(ccs)
-}
-
-// closeLocked closes the child balancer. Callers must hold the child mutext of
-// the parent endpointsharding balancer.
-func (bw *balancerWrapper) closeLocked() {
-	bw.child.Close()
-	bw.isClosed = true
-}
-
-func (bw *balancerWrapper) resolverErrorLocked(err error) {
-	bw.child.ResolverError(err)
+	if state.ConnectivityState == connectivity.Idle && !es.es.esOpts.DisableAutoReconnect {
+		go es.childLB.ExitIdle()
+	}
 }

--- a/balancer/ringhash/picker.go
+++ b/balancer/ringhash/picker.go
@@ -107,7 +107,7 @@ func (p *picker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
 				// If the SubChannel is in idle state, initiate a connection but
 				// continue to check other pickers to see if there is one in
 				// ready state.
-				es.balancer.ExitIdle()
+				es.exitIdle()
 			}
 		}
 		if requestedConnection {

--- a/balancer/ringhash/picker_test.go
+++ b/balancer/ringhash/picker_test.go
@@ -65,14 +65,6 @@ func (p *fakeChildPicker) Pick(balancer.PickInfo) (balancer.PickResult, error) {
 	}
 }
 
-type fakeExitIdler struct {
-	sc *testutils.TestSubConn
-}
-
-func (ei *fakeExitIdler) ExitIdle() {
-	ei.sc.Connect()
-}
-
 func testRingAndEndpointStates(states []connectivity.State) (*ring, map[string]endpointState) {
 	var items []*ringEntry
 	epStates := map[string]endpointState{}
@@ -92,9 +84,7 @@ func testRingAndEndpointStates(states []connectivity.State) (*ring, map[string]e
 					subConn:           testSC,
 				},
 			},
-			balancer: &fakeExitIdler{
-				sc: testSC,
-			},
+			exitIdle: func() { testSC.Connect() },
 		}
 		epStates[testSC.String()] = epState
 	}

--- a/balancer/ringhash/ringhash.go
+++ b/balancer/ringhash/ringhash.go
@@ -142,10 +142,10 @@ func (b *ringhashBalancer) UpdateState(state balancer.State) {
 		es, ok := b.endpointStates.Get(endpoint)
 		if !ok {
 			es := &endpointState{
-				balancer: childState.Balancer,
 				hashKey:  hk,
 				weight:   newWeight,
 				state:    childState.State,
+				exitIdle: childState.ExitIdle,
 			}
 			b.endpointStates.Set(endpoint, es)
 			b.shouldRegenerateRing = true
@@ -261,26 +261,28 @@ func (b *ringhashBalancer) updatePickerLocked() {
 		// non-deterministic, the list of `endpointState`s must be sorted to
 		// ensure `ExitIdle` is called on the same child, preventing unnecessary
 		// connections.
-		var endpointStates = make([]*endpointState, 0, b.endpointStates.Len())
+		endpointStates := make([]*endpointState, 0, b.endpointStates.Len())
 		for _, s := range b.endpointStates.All() {
 			endpointStates = append(endpointStates, s)
 		}
 		sort.Slice(endpointStates, func(i, j int) bool {
 			return endpointStates[i].hashKey < endpointStates[j].hashKey
 		})
-		var idleBalancer endpointsharding.ExitIdler
+
+		// Store the function to ExitIdle on the first IDLE endpoint.
+		var requestConnection func()
 		for _, es := range endpointStates {
 			connState := es.state.ConnectivityState
 			if connState == connectivity.Connecting {
-				idleBalancer = nil
+				requestConnection = nil
 				break
 			}
-			if idleBalancer == nil && connState == connectivity.Idle {
-				idleBalancer = es.balancer
+			if requestConnection == nil && connState == connectivity.Idle {
+				requestConnection = es.exitIdle
 			}
 		}
-		if idleBalancer != nil {
-			idleBalancer.ExitIdle()
+		if requestConnection != nil {
+			requestConnection()
 		}
 	}
 
@@ -399,7 +401,7 @@ type endpointState struct {
 	// overridden, for example based on EDS endpoint metadata.
 	hashKey  string
 	weight   uint32
-	balancer endpointsharding.ExitIdler
+	exitIdle func()
 
 	// state is updated by the balancer while receiving resolver updates from
 	// the channel and picker updates from its children. Access to it is guarded

--- a/balancer/ringhash/ringhash.go
+++ b/balancer/ringhash/ringhash.go
@@ -270,19 +270,19 @@ func (b *ringhashBalancer) updatePickerLocked() {
 		})
 
 		// Store the function to ExitIdle on the first IDLE endpoint.
-		var requestConnection func()
+		var exitIdle func()
 		for _, es := range endpointStates {
 			connState := es.state.ConnectivityState
 			if connState == connectivity.Connecting {
-				requestConnection = nil
+				exitIdle = nil
 				break
 			}
-			if requestConnection == nil && connState == connectivity.Idle {
-				requestConnection = es.exitIdle
+			if exitIdle == nil && connState == connectivity.Idle {
+				exitIdle = es.exitIdle
 			}
 		}
-		if requestConnection != nil {
-			requestConnection()
+		if exitIdle != nil {
+			exitIdle()
 		}
 	}
 

--- a/balancer/ringhash/ringhash_test.go
+++ b/balancer/ringhash/ringhash_test.go
@@ -60,6 +60,8 @@ func setupTest(t *testing.T, endpoints []resolver.Endpoint) (*testutils.Balancer
 	if b == nil {
 		t.Fatalf("builder.Build(%s) failed and returned nil", Name)
 	}
+	t.Cleanup(func() { b.Close() })
+
 	if err := b.UpdateClientConnState(balancer.ClientConnState{
 		ResolverState:  resolver.State{Endpoints: endpoints},
 		BalancerConfig: testConfig,


### PR DESCRIPTION
This change refactors `balancer/endpointsharding` by having a two-level locking strategy: one for the state in the `endpointSharding` balancer and one for the state that is maintained for every endpoint. It continues to guarantee the mutual exclusion requirements of the `balancer.Balancer` API methods while keeping the code simple and deadlock-free.

Summary of Changes:
- Decoupled & Safe Locking Model:
  - Per-Child Isolation (`childMu`): Guarantees strict mutual exclusion for all `balancer.Balancer` API calls to a specific child balancer. This protects against races when `ExitIdle` is triggered asynchronously by the picker or auto-reconnection.
  - Parent Aggregation (`mu`): Protects the global endpoints map and aggregated state.
  - Deadlock Prevention: Establishes a strict lock hierarchy where parent locks are never held when calling into a child.
- Simplify the `ChildState` API:
  - Replaced the single-method `ExitIdler` interface with with a first-class function `ExitIdle func()`.
  - Removed `ExitIdler` from package `endpointsharding`.
  - Updated `balancer/ringhash` to consume the function callback directly.

RELEASE NOTES: none