### PR TITLE
xds: pass correct context metadata in client and server route matching.

### DIFF
--- a/internal/xds/resolver/serviceconfig.go
+++ b/internal/xds/resolver/serviceconfig.go
@@ -176,9 +176,20 @@ func annotateErrorWithNodeID(err error, nodeID string) error {
 
 func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RPCConfig, error) {
 	var rt *route
+	md, _ := metadata.FromOutgoingContext(rpcInfo.Context)
+	if extraMD, ok := grpcutil.ExtraMetadata(rpcInfo.Context); ok {
+		md = metadata.Join(md, extraMD)
+		// Remove all binary headers. They are hard to match with. May need
+		// to add back if asked by users.
+		for k := range md {
+			if strings.HasSuffix(k, "-bin") {
+				delete(md, k)
+			}
+		}
+	}
 	// Loop through routes in order and select first match.
 	for _, r := range cs.routes {
-		if r.m.Match(rpcInfo) {
+		if r.m.Match(rpcInfo.Method, md) {
 			rt = &r
 			break
 		}

--- a/internal/xds/server/routing.go
+++ b/internal/xds/server/routing.go
@@ -26,7 +26,6 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	iresolver "google.golang.org/grpc/internal/resolver"
 	"google.golang.org/grpc/internal/transport"
 	"google.golang.org/grpc/internal/xds/xdsclient/xdsresource"
 	"google.golang.org/grpc/metadata"
@@ -73,12 +72,8 @@ func RouteAndProcess(ctx context.Context) error {
 	}
 
 	var rwi *routeWithInterceptors
-	rpcInfo := iresolver.RPCInfo{
-		Context: ctx,
-		Method:  mn,
-	}
 	for _, r := range vh.routes {
-		if r.matcher.Match(rpcInfo) {
+		if r.matcher.Match(mn, md) {
 			// "NonForwardingAction is expected for all Routes used on
 			// server-side; a route with an inappropriate action causes RPCs
 			// matching that route to fail with UNAVAILABLE." - A36

--- a/internal/xds/xdsclient/xdsresource/matcher.go
+++ b/internal/xds/xdsclient/xdsresource/matcher.go
@@ -22,8 +22,6 @@ import (
 	rand "math/rand/v2"
 	"strings"
 
-	"google.golang.org/grpc/internal/grpcutil"
-	iresolver "google.golang.org/grpc/internal/resolver"
 	"google.golang.org/grpc/internal/xds/matcher"
 	"google.golang.org/grpc/metadata"
 )
@@ -84,27 +82,11 @@ func newCompositeMatcher(pm pathMatcher, hms []matcher.HeaderMatcher, fm *fracti
 }
 
 // Match returns true if all matchers return true.
-func (a *CompositeMatcher) Match(info iresolver.RPCInfo) bool {
-	if a.pm != nil && !a.pm.match(info.Method) {
+func (a *CompositeMatcher) Match(method string, md metadata.MD) bool {
+	if a.pm != nil && !a.pm.match(method) {
 		return false
 	}
 
-	// Call headerMatchers even if md is nil, because routes may match
-	// non-presence of some headers.
-	var md metadata.MD
-	if info.Context != nil {
-		md, _ = metadata.FromOutgoingContext(info.Context)
-		if extraMD, ok := grpcutil.ExtraMetadata(info.Context); ok {
-			md = metadata.Join(md, extraMD)
-			// Remove all binary headers. They are hard to match with. May need
-			// to add back if asked by users.
-			for k := range md {
-				if strings.HasSuffix(k, "-bin") {
-					delete(md, k)
-				}
-			}
-		}
-	}
 	for _, m := range a.hms {
 		if !m.Match(md) {
 			return false

--- a/internal/xds/xdsclient/xdsresource/matcher_test.go
+++ b/internal/xds/xdsclient/xdsresource/matcher_test.go
@@ -20,6 +20,7 @@ package xdsresource
 import (
 	"context"
 	rand "math/rand/v2"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -41,7 +42,7 @@ func (s) TestAndMatcherMatch(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "both match",
+			name: "both_match",
 			pm:   newPathExactMatcher("/a/b", false),
 			hm:   matcher.NewHeaderExactMatcher("th", "tv", false),
 			info: iresolver.RPCInfo{
@@ -51,7 +52,7 @@ func (s) TestAndMatcherMatch(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "both match with path case insensitive",
+			name: "both_match_with_path_case_insensitive",
 			pm:   newPathExactMatcher("/A/B", true),
 			hm:   matcher.NewHeaderExactMatcher("th", "tv", false),
 			info: iresolver.RPCInfo{
@@ -61,7 +62,7 @@ func (s) TestAndMatcherMatch(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "only one match",
+			name: "only_one_match",
 			pm:   newPathExactMatcher("/a/b", false),
 			hm:   matcher.NewHeaderExactMatcher("th", "tv", false),
 			info: iresolver.RPCInfo{
@@ -71,7 +72,7 @@ func (s) TestAndMatcherMatch(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "both not match",
+			name: "both_not match",
 			pm:   newPathExactMatcher("/z/y", false),
 			hm:   matcher.NewHeaderExactMatcher("th", "abc", false),
 			info: iresolver.RPCInfo{
@@ -81,7 +82,7 @@ func (s) TestAndMatcherMatch(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "fake header",
+			name: "fake_header",
 			pm:   newPathPrefixMatcher("/", false),
 			hm:   matcher.NewHeaderExactMatcher("content-type", "fake", false),
 			info: iresolver.RPCInfo{
@@ -93,7 +94,7 @@ func (s) TestAndMatcherMatch(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "binary header",
+			name: "binary_header",
 			pm:   newPathPrefixMatcher("/", false),
 			hm:   matcher.NewHeaderPresentMatcher("t-bin", true, false),
 			info: iresolver.RPCInfo{
@@ -110,7 +111,16 @@ func (s) TestAndMatcherMatch(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := newCompositeMatcher(tt.pm, []matcher.HeaderMatcher{tt.hm}, nil)
-			if got := a.Match(tt.info); got != tt.want {
+			md, _ := metadata.FromOutgoingContext(tt.info.Context)
+			if extraMD, ok := grpcutil.ExtraMetadata(tt.info.Context); ok {
+				md = metadata.Join(md, extraMD)
+				for k := range md {
+					if strings.HasSuffix(k, "-bin") {
+						delete(md, k)
+					}
+				}
+			}
+			if got := a.Match(tt.info.Method, md); got != tt.want {
 				t.Errorf("match() = %v, want %v", got, tt.want)
 			}
 		})

--- a/test/xds/xds_client_integration_test.go
+++ b/test/xds/xds_client_integration_test.go
@@ -32,6 +32,8 @@ import (
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
 	"google.golang.org/grpc/internal/testutils/xds/e2e/setup"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 
 	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	v3endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -146,4 +148,97 @@ func (s) TestClient_ConcurrentRPC(t *testing.T) {
 		})
 	}
 	wg.Wait()
+}
+
+// Test verifies that client-side xDS routing strictly evaluates
+// OutgoingContext metadata and ignores IncomingContext metadata. This
+// prevents incoming headers on a server handler context from leaking
+// into and contaminating outgoing client routing decisions.
+func (s) TestClientSideXDS_RouteMatching_IgnoreIncomingMetadata(t *testing.T) {
+	managementServer, nodeID, _, xdsResolver := setup.ManagementServerAndResolver(t)
+
+	serverA := stubserver.StartTestService(t, nil)
+	defer serverA.Stop()
+	serverB := stubserver.StartTestService(t, nil)
+	defer serverB.Stop()
+
+	const (
+		serviceName     = "my-service-client"
+		routeConfigName = "route-" + serviceName
+		clusterA        = "cluster-A-" + serviceName
+		clusterB        = "cluster-B-" + serviceName
+		headerName      = "x-route-target"
+		headerValue     = "cluster-a"
+	)
+
+	resources := e2e.UpdateOptions{
+		NodeID:    nodeID,
+		Listeners: []*v3listenerpb.Listener{e2e.DefaultClientListener(serviceName, routeConfigName)},
+		Routes: []*v3routepb.RouteConfiguration{{
+			Name: routeConfigName,
+			VirtualHosts: []*v3routepb.VirtualHost{{
+				Domains: []string{serviceName},
+				Routes: []*v3routepb.Route{
+					{
+						Match: &v3routepb.RouteMatch{
+							PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/grpc.testing.TestService/EmptyCall"},
+							Headers: []*v3routepb.HeaderMatcher{{
+								Name: headerName,
+								HeaderMatchSpecifier: &v3routepb.HeaderMatcher_ExactMatch{
+									ExactMatch: headerValue,
+								},
+							}},
+						},
+						Action: &v3routepb.Route_Route{Route: &v3routepb.RouteAction{
+							ClusterSpecifier: &v3routepb.RouteAction_Cluster{Cluster: clusterA},
+						}},
+					},
+					{
+						Match: &v3routepb.RouteMatch{
+							PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/grpc.testing.TestService/EmptyCall"},
+						},
+						Action: &v3routepb.Route_Route{Route: &v3routepb.RouteAction{
+							ClusterSpecifier: &v3routepb.RouteAction_Cluster{Cluster: clusterB},
+						}},
+					},
+				},
+			}},
+		}},
+		Clusters: []*v3clusterpb.Cluster{
+			e2e.DefaultCluster(clusterA, clusterA, e2e.SecurityLevelNone),
+			e2e.DefaultCluster(clusterB, clusterB, e2e.SecurityLevelNone),
+		},
+		Endpoints: []*v3endpointpb.ClusterLoadAssignment{
+			e2e.DefaultEndpoint(clusterA, "localhost", []uint32{testutils.ParsePort(t, serverA.Address)}),
+			e2e.DefaultEndpoint(clusterB, "localhost", []uint32{testutils.ParsePort(t, serverB.Address)}),
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if err := managementServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(xdsResolver))
+	if err != nil {
+		t.Fatalf("grpc.NewClient() failed: %v", err)
+	}
+	defer cc.Close()
+
+	client := testgrpc.NewTestServiceClient(cc)
+
+	// Simulate an intermediary server that receives an incoming RPC containing
+	// the header "x-route-target: cluster-a" in its IncomingContext, and then
+	// initiates an outgoing client RPC using that same context without setting
+	// any OutgoingContext metadata. Client-side routing  must strictly evaluate
+	// OutgoingContext (which is empty) and select Route 2.
+	incomingCtx := metadata.NewIncomingContext(ctx, metadata.Pairs(headerName, headerValue))
+	var p peer.Peer
+	if _, err := client.EmptyCall(incomingCtx, &testpb.Empty{}, grpc.Peer(&p)); err != nil {
+		t.Fatalf("EmptyCall() failed: %v", err)
+	}
+	if p.Addr.String() != serverB.Address {
+		t.Fatalf("Unexpected client routing to peer %s, want fallback Route 2 (clusterB at %s)", p.Addr.String(), serverB.Address)
+	}
 }

--- a/test/xds/xds_server_rbac_test.go
+++ b/test/xds/xds_server_rbac_test.go
@@ -39,6 +39,7 @@ import (
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
 	"google.golang.org/grpc/internal/testutils/xds/e2e/setup"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/xds"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -1010,4 +1011,145 @@ func createXDSTypedStruct(t *testing.T, in map[string]any, name string) *anypb.A
 		t.Fatalf("createXDSTypedStruct failed during anypb.New: %v", err)
 	}
 	return customConfig
+}
+
+// Test verifies server-side route matching against incoming metadata.
+// It focuses on a single Exact matcher to confirm restrictive per-route
+// RBAC policy selection, while explicitly testing resistance to context
+// conflation (Conflicting Contexts regression).
+func (s) TestServerSideXDS_RBACRouteHeaderMatchers(t *testing.T) {
+	const serviceName = "my-service-regression"
+	managementServer, nodeID, bootstrapContents, xdsResolver := setup.ManagementServerAndResolver(t)
+
+	// Inject conflicting OutgoingContext on the server to verify it is ignored
+	// by routing.
+	opt := grpc.UnaryInterceptor(func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		// This simulates leakage or presence of OutgoingContext on the server.
+		ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("x-route", "client-target"))
+		return handler(ctx, req)
+	})
+
+	lis, stopServer := setupGRPCServer(t, bootstrapContents, opt)
+	defer stopServer()
+
+	host, port, err := hostPortFromListener(lis)
+	if err != nil {
+		t.Fatalf("Failed to retrieve host and port of server: %v", err)
+	}
+	resources := e2e.DefaultClientResources(e2e.ResourceParams{
+		DialTarget: serviceName,
+		NodeID:     nodeID,
+		Host:       host,
+		Port:       port,
+		SecLevel:   e2e.SecurityLevelNone,
+	})
+
+	// Setup a route with an Exact Matcher.
+	matcher := &v3routepb.HeaderMatcher{
+		Name: "x-route",
+		HeaderMatchSpecifier: &v3routepb.HeaderMatcher_ExactMatch{
+			ExactMatch: "server-target",
+		},
+	}
+
+	vhs := []*v3routepb.VirtualHost{{
+		Domains: []string{"*"},
+		Routes: []*v3routepb.Route{
+			{
+				Match: &v3routepb.RouteMatch{
+					PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/grpc.testing.TestService/EmptyCall"},
+					Headers:       []*v3routepb.HeaderMatcher{matcher},
+				},
+				Action: &v3routepb.Route_NonForwardingAction{},
+				TypedPerFilterConfig: map[string]*anypb.Any{
+					"rbac": testutils.MarshalAny(t, &rpb.RBACPerRoute{Rbac: &rpb.RBAC{Rules: &v3rbacpb.RBAC{
+						Action: v3rbacpb.RBAC_DENY,
+						Policies: map[string]*v3rbacpb.Policy{
+							"deny-all": {
+								Permissions: []*v3rbacpb.Permission{{Rule: &v3rbacpb.Permission_Any{Any: true}}},
+								Principals:  []*v3rbacpb.Principal{{Identifier: &v3rbacpb.Principal_Any{Any: true}}},
+							},
+						},
+					}}}),
+				},
+			},
+			{
+				Match: &v3routepb.RouteMatch{
+					PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/grpc.testing.TestService/EmptyCall"},
+				},
+				Action: &v3routepb.Route_NonForwardingAction{},
+			},
+		},
+	}}
+
+	inboundLis := &v3listenerpb.Listener{
+		Name: fmt.Sprintf(e2e.ServerListenerResourceNameTemplate, net.JoinHostPort(host, strconv.Itoa(int(port)))),
+		Address: &v3corepb.Address{
+			Address: &v3corepb.Address_SocketAddress{
+				SocketAddress: &v3corepb.SocketAddress{
+					Address: host,
+					PortSpecifier: &v3corepb.SocketAddress_PortValue{
+						PortValue: port,
+					},
+				},
+			},
+		},
+		DefaultFilterChain: &v3listenerpb.FilterChain{Filters: []*v3listenerpb.Filter{{
+			Name: "hcm",
+			ConfigType: &v3listenerpb.Filter_TypedConfig{
+				TypedConfig: testutils.MarshalAny(t, &v3httppb.HttpConnectionManager{
+					HttpFilters: []*v3httppb.HttpFilter{
+						e2e.HTTPFilter("rbac", &rpb.RBAC{Rules: &v3rbacpb.RBAC{
+							Action: v3rbacpb.RBAC_ALLOW,
+							Policies: map[string]*v3rbacpb.Policy{
+								"allow-all": {
+									Permissions: []*v3rbacpb.Permission{{Rule: &v3rbacpb.Permission_Any{Any: true}}},
+									Principals:  []*v3rbacpb.Principal{{Identifier: &v3rbacpb.Principal_Any{Any: true}}},
+								},
+							},
+						}}),
+						e2e.RouterHTTPFilter,
+					},
+					RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
+						RouteConfig: &v3routepb.RouteConfiguration{
+							Name:         "routeName",
+							VirtualHosts: vhs,
+						},
+					},
+				}),
+			},
+		}}},
+	}
+	resources.Listeners = append(resources.Listeners, inboundLis)
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if err := managementServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(xdsResolver))
+	if err != nil {
+		t.Fatalf("grpc.NewClient() failed: %v", err)
+	}
+	defer cc.Close()
+
+	client := testgrpc.NewTestServiceClient(cc)
+
+	// Make an RPC with metadata matching the header matcher. We pass
+	// "server-target" in OutgoingContext (client side). This becomes
+	// IncomingContext on server-side. If the server routing matches
+	// based on IncomingContext ("server-target") and ignores
+	// OutgoingContext ("client-target" injected by interceptor),
+	// it goes to Route 1 (Deny).
+	matchCtx := metadata.NewOutgoingContext(ctx, metadata.Pairs("x-route", "server-target"))
+	if _, err := client.EmptyCall(matchCtx, &testpb.Empty{}, grpc.WaitForReady(true)); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("EmptyCall() failed with status code %v, want PermissionDenied", status.Code(err))
+	}
+
+	// Make an RPC with no metadata. This verifies that requests missing
+	// the matching header cleanly fall through.
+	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); status.Code(err) != codes.OK {
+		t.Fatalf("EmptyCall() failed with status code %v, want OK", status.Code(err))
+	}
 }


### PR DESCRIPTION
Server-side xDS route matching ignores incoming request metadata when evaluating route header matchers. 

Previously, `xdsresource.CompositeMatcher.Match(info iresolver.RPCInfo)` internally extracted header metadata from `info.Context` via `metadata.FromOutgoingContext(info.Context)`.  This PR fixed it by evaluating the correct metadata before calling `Match` and pass it in the parameters.

#### Key Changes:
- **`internal/xds/xdsclient/xdsresource/matcher.go`**: Refactored `CompositeMatcher.Match(info iresolver.RPCInfo)` to `Match(method string, md metadata.MD) bool`, decoupling route matching from `RPCInfo` and context metadata extraction.
- **`internal/xds/resolver/serviceconfig.go`**: Extracted outgoing metadata (`metadata.FromOutgoingContext` + `grpcutil.ExtraMetadata`, stripping `-bin` headers) inside `configSelector.SelectConfig` and explicitly passed it to `r.m.Match(rpcInfo.Method, md)`.
- **`internal/xds/server/routing.go`**: Updated `RouteAndProcess` to pass the RPC's incoming metadata (`md`, extracted via `metadata.FromIncomingContext(ctx)`) directly to `r.matcher.Match(mn, md)`.

RELEASE NOTES: N/A