### PR TITLE
extproc: fix TestObservabilityMidStreamFailDeny race

### DIFF
--- a/internal/xds/httpfilter/extproc/ext_proc_ext_test.go
+++ b/internal/xds/httpfilter/extproc/ext_proc_ext_test.go
@@ -4135,12 +4135,15 @@ func (s) TestObservabilityMidStreamFailDeny(t *testing.T) {
 		t.Fatalf("FullDuplexCall() failed: %v", err)
 	}
 
-	const numMessages = 10
 	var gotErr error
-	// Send and recv 10 messages and verify that the RPC fails with correct error.
-	for i := 0; i < numMessages; i++ {
+	// Continuously send and recv messages until the RPC fails with correct error
+	// or the test context times out.
+	for {
+		if ctx.Err() != nil {
+			t.Fatalf("Timed out waiting for stream to fail from processor disconnect: %v", ctx.Err())
+		}
 		req := &testpb.StreamingOutputCallRequest{
-			Payload: &testpb.Payload{Body: []byte(fmt.Sprintf("msg-%d", i))},
+			Payload: &testpb.Payload{Body: []byte("msg")},
 		}
 		if err := stream.Send(req); err != nil {
 			gotErr = err
@@ -4152,8 +4155,11 @@ func (s) TestObservabilityMidStreamFailDeny(t *testing.T) {
 		}
 	}
 
+	if ctx.Err() != nil {
+		t.Fatalf("Timed out waiting for stream to fail from processor disconnect: %v", ctx.Err())
+	}
 	if gotErr == nil {
-		t.Fatalf("Expected error from processor stream failure, got none after %d messages", numMessages)
+		t.Fatalf("Expected error from processor stream failure, got none")
 	}
 	if code := status.Code(gotErr); code != codes.Internal {
 		t.Fatalf("Stream returned status code %v (error: %v), want %v", code, gotErr, codes.Internal)


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/9289

This PR changes `TestObservabilityMidStreamFailDeny` to send and recv message until it gets an error. The test was failing because send and recv call directly in dataplane stream without waiting for error from proc stream. Error from proc stream is received async in `recvAndDiscardResponses` loop. SO it can happen that 10 send and recv happen very fast before the proc server send error frame.

RELEASE NOTES: None

#ext-proc-a93
