### PR TITLE
stats: expose client authority in OutHeader

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -946,6 +946,7 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr, handler s
 			LocalAddr:   t.localAddr,
 			Compression: callHdr.SendCompress,
 			Header:      header,
+			Authority:   callHdr.Host,
 		})
 	}
 	if transportDrainRequired {

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -190,6 +190,9 @@ type OutHeader struct {
 	Compression string
 	// Header contains the header metadata sent.
 	Header metadata.MD
+	// Authority is the :authority pseudo-header sent for the RPC.
+	// It is valid only if Client is true.
+	Authority string
 
 	// The following fields are valid only if Client is true.
 	// FullMethod is the full RPC method string, i.e., /package.service/method.

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -297,6 +297,7 @@ type rpcConfig struct {
 	count    int  // Number of requests and responses for streaming RPCs.
 	success  bool // Whether the RPC should succeed or return error.
 	failfast bool
+	authority string // Authority override for the RPC.
 	callType rpcType // Type of RPC.
 }
 
@@ -315,7 +316,11 @@ func (te *test) doUnaryCall(c *rpcConfig) (*testpb.SimpleRequest, *testpb.Simple
 		req = &testpb.SimpleRequest{Payload: idToPayload(errorID)}
 	}
 
-	resp, err = tc.UnaryCall(metadata.NewOutgoingContext(tCtx, testMetadata), req, grpc.WaitForReady(!c.failfast))
+	callOpts := []grpc.CallOption{grpc.WaitForReady(!c.failfast)}
+	if c.authority != "" {
+		callOpts = append(callOpts, grpc.CallAuthority(c.authority))
+	}
+	resp, err = tc.UnaryCall(metadata.NewOutgoingContext(tCtx, testMetadata), req, callOpts...)
 	return req, resp, err
 }
 
@@ -427,6 +432,7 @@ type expectedData struct {
 	isServerStream bool
 	serverAddr     string
 	compression    string
+	authority      string
 	reqIdx         int
 	requests       []proto.Message
 	respIdx        int
@@ -619,6 +625,9 @@ func checkOutHeader(t *testing.T, d *gotData, e *expectedData) {
 		}
 		if st.RemoteAddr.String() != e.serverAddr {
 			t.Fatalf("st.RemoteAddr = %v, want %v", st.RemoteAddr, e.serverAddr)
+		}
+		if e.authority != "" && st.Authority != e.authority {
+			t.Fatalf("st.Authority = %s, want %s", st.Authority, e.authority)
 		}
 		// additional headers might be injected so instead of testing equality, test that all the
 		// expected headers keys have the expected header values.
@@ -1215,11 +1224,29 @@ func testClientStats(t *testing.T, tc *testConfig, cc *rpcConfig, checkFuncs map
 	h.mu.Lock()
 	checkConnStats(t, h.gotConn)
 	h.mu.Unlock()
+	expect.authority = cc.authority
 	checkClientStats(t, h.gotRPC, expect, checkFuncs)
 }
 
 func (s) TestClientStatsUnaryRPC(t *testing.T) {
 	testClientStats(t, &testConfig{compress: ""}, &rpcConfig{success: true, failfast: false, callType: unaryRPC}, map[int]*checkFuncWithCount{
+		begin:      {checkBegin, 1},
+		outHeader:  {checkOutHeader, 1},
+		outPayload: {checkOutPayload, 1},
+		inHeader:   {checkInHeader, 1},
+		inPayload:  {checkInPayload, 1},
+		inTrailer:  {checkInTrailer, 1},
+		end:        {checkEnd, 1},
+	})
+}
+
+func (s) TestClientStatsUnaryRPCAuthority(t *testing.T) {
+	testClientStats(t, &testConfig{compress: ""}, &rpcConfig{
+		success:   true,
+		failfast:  false,
+		authority: "authority-override.example.com",
+		callType:  unaryRPC,
+	}, map[int]*checkFuncWithCount{
 		begin:      {checkBegin, 1},
 		outHeader:  {checkOutHeader, 1},
 		outPayload: {checkOutPayload, 1},

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -626,8 +626,12 @@ func checkOutHeader(t *testing.T, d *gotData, e *expectedData) {
 		if st.RemoteAddr.String() != e.serverAddr {
 			t.Fatalf("st.RemoteAddr = %v, want %v", st.RemoteAddr, e.serverAddr)
 		}
-		if e.authority != "" && st.Authority != e.authority {
-			t.Fatalf("st.Authority = %s, want %s", st.Authority, e.authority)
+		wantAuthority := e.authority
+		if wantAuthority == "" {
+			wantAuthority = e.serverAddr
+		}
+		if st.Authority != wantAuthority {
+			t.Fatalf("st.Authority = %s, want %s", st.Authority, wantAuthority)
 		}
 		// additional headers might be injected so instead of testing equality, test that all the
 		// expected headers keys have the expected header values.

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -294,11 +294,11 @@ const (
 )
 
 type rpcConfig struct {
-	count    int  // Number of requests and responses for streaming RPCs.
-	success  bool // Whether the RPC should succeed or return error.
-	failfast bool
-	authority string // Authority override for the RPC.
-	callType rpcType // Type of RPC.
+	count     int  // Number of requests and responses for streaming RPCs.
+	success   bool // Whether the RPC should succeed or return error.
+	failfast  bool
+	authority string  // Authority override for the RPC.
+	callType  rpcType // Type of RPC.
 }
 
 func (te *test) doUnaryCall(c *rpcConfig) (*testpb.SimpleRequest, *testpb.SimpleResponse, error) {

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -1223,12 +1223,12 @@ func testClientStats(t *testing.T, tc *testConfig, cc *rpcConfig, checkFuncs map
 		err:            err,
 		isClientStream: isClientStream,
 		isServerStream: isServerStream,
+		authority:      cc.authority,
 	}
 
 	h.mu.Lock()
 	checkConnStats(t, h.gotConn)
 	h.mu.Unlock()
-	expect.authority = cc.authority
 	checkClientStats(t, h.gotRPC, expect, checkFuncs)
 }
 


### PR DESCRIPTION
Fixes #9235

Add the effective client authority to stats.OutHeader and populate it from callHdr.Host, as requested in the issue discussion. The change includes unary client stats regression coverage.

Tests:
mise exec go@1.26.5 -- gofmt -d stats/stats.go stats/stats_test.go internal/transport/http2_client.go
mise exec go@1.26.5 -- go test ./stats ./internal/transport

RELEASE NOTES:
* stats: Expose the effective client authority in client stats.OutHeader events.