### PR TITLE
credentials/sts: do not follow redirects during token exchange

### DIFF
--- a/credentials/sts/sts.go
+++ b/credentials/sts/sts.go
@@ -195,6 +195,13 @@ type httpDoer interface {
 
 func makeHTTPClient(roots *x509.CertPool) httpDoer {
 	return &http.Client{
+		// The token exchange request carries the subject token (and an optional
+		// actor token) in its body. Following a redirect replays that body to
+		// the redirect target, so refuse to follow redirects and let sendRequest
+		// surface the 3xx as a non-2xx status instead.
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 		Timeout: stsRequestTimeout,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{

--- a/credentials/sts/sts_test.go
+++ b/credentials/sts/sts_test.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/http/httputil"
 	"strings"
 	"testing"
@@ -700,6 +701,42 @@ func (s) TestSendRequest(t *testing.T) {
 				t.Errorf("sendRequest(%v) = %v, wantErr: %v", req, err, test.wantErr)
 			}
 		})
+	}
+}
+
+func (s) TestSendRequestDoesNotFollowRedirects(t *testing.T) {
+	// Stands in for a redirect target that must never receive the token
+	// exchange request. It records the body of any request it does get.
+	leaked := make(chan string, 1)
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		select {
+		case leaked <- string(body):
+		default:
+		}
+	}))
+	defer redirectTarget.Close()
+
+	// The configured token exchange endpoint redirects the POST, whose body
+	// carries the subject token, to another host.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirectTarget.URL, http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL, bytes.NewBufferString(`{"subject_token":"secret"}`))
+	if err != nil {
+		t.Fatalf("http.NewRequest() failed: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	if _, err := sendRequest(makeHTTPClient(nil), req); err == nil {
+		t.Error("sendRequest() succeeded across a redirect; want a non-nil error")
+	}
+	select {
+	case body := <-leaked:
+		t.Errorf("redirect target received request body %q; the subject token must not be replayed to another host", body)
+	default:
 	}
 }
 

--- a/credentials/sts/sts_test.go
+++ b/credentials/sts/sts_test.go
@@ -735,7 +735,7 @@ func (s) TestSendRequestDoesNotFollowRedirects(t *testing.T) {
 	}
 	select {
 	case body := <-leaked:
-		t.Errorf("redirect target received request body %q; the subject token must not be replayed to another host", body)
+		t.Errorf("Redirect target received request body %q; the subject token must not be replayed to another host", body)
 	default:
 	}
 }


### PR DESCRIPTION
The token exchange request in credentials/sts sends the subject token (and an optional actor token) in the POST body, but makeHTTPClient sets no CheckRedirect, so the client follows redirects with the default policy. constructRequest hands the body to http.NewRequestWithContext as a bytes.Buffer, which makes net/http set Request.GetBody, so a 307 or 308 reply from the token endpoint replays the body to the redirect target, and a cross-host redirect only drops the Authorization and Cookie headers, not the body. A malicious or compromised token endpoint, or a MITM since validateOptions still allows a plaintext http URI, can aim that redirect at any host and collect the subject token.

Set CheckRedirect on the client so redirects are never followed. sendRequest already turns any non-2xx into an error, so a 3xx now fails the exchange cleanly instead of resending the credential. Putting the policy on the client the package builds keeps every caller covered without adding a redirect knob to Options. Added a test that redirects the exchange to a second server and checks it never receives the body.

RELEASE NOTES:
- credentials/sts: Disallow HTTP redirects in the credentials implementation, to prevent leaking tokens