### PR TITLE
interop: implement client_compressed_unary and server_compressed_unary tests

### DIFF
--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -88,6 +88,8 @@ var (
 		`Configure different test cases. Valid options are:
         empty_unary : empty (zero bytes) request and response;
         large_unary : single request and (large) response;
+        client_compressed_unary : single request and (large) response, verifying client-side request compression;
+        server_compressed_unary : single request and (large) response, verifying server-side response compression;
         client_streaming : request streaming with single response;
         server_streaming : single request with response streaming;
         ping_pong : full-duplex streaming;
@@ -299,6 +301,12 @@ func main() {
 	case "large_unary":
 		interop.DoLargeUnaryCall(ctx, tc)
 		logger.Infoln("LargeUnaryCall done")
+	case "client_compressed_unary":
+		interop.DoClientCompressedUnaryCall(ctx, tc)
+		logger.Infoln("ClientCompressedUnaryCall done")
+	case "server_compressed_unary":
+		interop.DoServerCompressedUnaryCall(ctx, tc)
+		logger.Infoln("ServerCompressedUnaryCall done")
 	case "client_streaming":
 		interop.DoClientStreaming(ctx, tc)
 		logger.Infoln("ClientStreaming done")

--- a/interop/compression_test.go
+++ b/interop/compression_test.go
@@ -1,0 +1,94 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package interop
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/internal/stubserver"
+	testpb "google.golang.org/grpc/interop/grpc_testing"
+	"google.golang.org/grpc/status"
+)
+
+func startCompressionTestServer(t *testing.T) *stubserver.StubServer {
+	t.Helper()
+
+	ts := NewTestServer()
+	stub := &stubserver.StubServer{
+		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+			return ts.UnaryCall(ctx, in)
+		},
+	}
+	if err := stub.StartServer(); err != nil {
+		t.Fatalf("Error starting server: %v", err)
+	}
+	t.Cleanup(stub.Stop)
+
+	if err := stub.StartClient(); err != nil {
+		t.Fatalf("Error starting client: %v", err)
+	}
+	return stub
+}
+
+// TestClientCompressedUnaryCall runs the client_compressed_unary interop
+// test case end-to-end: it verifies the server rejects a probe request
+// whose ExpectCompressed flag doesn't match the actual wire compression,
+// and accepts correctly compressed and uncompressed requests.
+func (s) TestClientCompressedUnaryCall(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	stub := startCompressionTestServer(t)
+	DoClientCompressedUnaryCall(ctx, stub.Client)
+}
+
+// TestServerCompressedUnaryCall runs the server_compressed_unary interop
+// test case end-to-end: it verifies the server accepts requests asking for
+// both a compressed and an uncompressed response.
+func (s) TestServerCompressedUnaryCall(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	stub := startCompressionTestServer(t)
+	DoServerCompressedUnaryCall(ctx, stub.Client)
+}
+
+// TestUnaryCall_ExpectCompressedMismatch verifies that UnaryCall rejects a
+// request whose ExpectCompressed flag doesn't match the compression
+// actually used on the wire, directly asserting the INVALID_ARGUMENT status
+// rather than relying on DoClientCompressedUnaryCall's own checks.
+func (s) TestUnaryCall_ExpectCompressedMismatch(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	stub := startCompressionTestServer(t)
+
+	req := &testpb.SimpleRequest{
+		ResponseType:     testpb.PayloadType_COMPRESSABLE,
+		ResponseSize:     1,
+		ExpectCompressed: &testpb.BoolValue{Value: true},
+	}
+	_, err := stub.Client.UnaryCall(ctx, req, grpc.UseCompressor("identity"))
+	if got, want := status.Code(err), codes.InvalidArgument; got != want {
+		t.Fatalf("UnaryCall with mismatched ExpectCompressed got code %v, want %v", got, want)
+	}
+}

--- a/interop/compression_test.go
+++ b/interop/compression_test.go
@@ -20,16 +20,18 @@ package interop
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/internal/stubserver"
 	testpb "google.golang.org/grpc/interop/grpc_testing"
+	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 )
 
-func startCompressionTestServer(t *testing.T) *stubserver.StubServer {
+func startCompressionTestServer(t *testing.T, dopts ...grpc.DialOption) *stubserver.StubServer {
 	t.Helper()
 
 	ts := NewTestServer()
@@ -38,14 +40,10 @@ func startCompressionTestServer(t *testing.T) *stubserver.StubServer {
 			return ts.UnaryCall(ctx, in)
 		},
 	}
-	if err := stub.StartServer(); err != nil {
+	if err := stub.Start(nil, dopts...); err != nil {
 		t.Fatalf("Error starting server: %v", err)
 	}
 	t.Cleanup(stub.Stop)
-
-	if err := stub.StartClient(); err != nil {
-		t.Fatalf("Error starting client: %v", err)
-	}
 	return stub
 }
 
@@ -72,6 +70,47 @@ func (s) TestServerCompressedUnaryCall(t *testing.T) {
 	DoServerCompressedUnaryCall(ctx, stub.Client)
 }
 
+// TestServerCompressedUnaryCall_WireCompression verifies, via a
+// stats.Handler observing InPayload on the client, that
+// response_compressed actually controls whether the response is
+// compressed on the wire: response_compressed=true must shrink
+// CompressedLength below Length, and response_compressed=false must leave
+// them equal.
+func (s) TestServerCompressedUnaryCall_WireCompression(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	rec := &inPayloadRecorder{}
+	stub := startCompressionTestServer(t, grpc.WithStatsHandler(rec))
+
+	pl := ClientNewPayload(testpb.PayloadType_COMPRESSABLE, largeReqSize)
+	for _, compressed := range []bool{true, false} {
+		rec.reset()
+		req := &testpb.SimpleRequest{
+			ResponseType:       testpb.PayloadType_COMPRESSABLE,
+			ResponseSize:       int32(largeRespSize),
+			ResponseCompressed: &testpb.BoolValue{Value: compressed},
+			Payload:            pl,
+		}
+		reply, err := stub.Client.UnaryCall(ctx, req)
+		if err != nil {
+			t.Fatalf("UnaryCall(response_compressed=%v) failed: %v", compressed, err)
+		}
+		checkLargePayload(reply.GetPayload())
+
+		p := rec.get()
+		if p == nil {
+			t.Fatalf("response_compressed=%v: no InPayload observed", compressed)
+		}
+		if compressed && p.CompressedLength >= p.Length {
+			t.Fatalf("response_compressed=true: got CompressedLength=%d, Length=%d; want CompressedLength < Length", p.CompressedLength, p.Length)
+		}
+		if !compressed && p.CompressedLength != p.Length {
+			t.Fatalf("response_compressed=false: got CompressedLength=%d, Length=%d; want equal", p.CompressedLength, p.Length)
+		}
+	}
+}
+
 // TestUnaryCall_ExpectCompressedMismatch verifies that UnaryCall rejects a
 // request whose ExpectCompressed flag doesn't match the compression
 // actually used on the wire, directly asserting the INVALID_ARGUMENT status
@@ -91,4 +130,42 @@ func (s) TestUnaryCall_ExpectCompressedMismatch(t *testing.T) {
 	if got, want := status.Code(err), codes.InvalidArgument; got != want {
 		t.Fatalf("UnaryCall with mismatched ExpectCompressed got code %v, want %v", got, want)
 	}
+}
+
+// inPayloadRecorder is a stats.Handler that records the most recently
+// observed stats.InPayload, used to assert on wire-level compression from
+// outside the RPC (see TestServerCompressedUnaryCall_WireCompression).
+type inPayloadRecorder struct {
+	mu   sync.Mutex
+	last *stats.InPayload
+}
+
+func (r *inPayloadRecorder) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+	return ctx
+}
+
+func (r *inPayloadRecorder) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+func (r *inPayloadRecorder) HandleConn(context.Context, stats.ConnStats) {}
+
+func (r *inPayloadRecorder) HandleRPC(_ context.Context, rs stats.RPCStats) {
+	if p, ok := rs.(*stats.InPayload); ok {
+		r.mu.Lock()
+		r.last = p
+		r.mu.Unlock()
+	}
+}
+
+func (r *inPayloadRecorder) reset() {
+	r.mu.Lock()
+	r.last = nil
+	r.mu.Unlock()
+}
+
+func (r *inPayloadRecorder) get() *stats.InPayload {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.last
 }

--- a/interop/interop_test.sh
+++ b/interop/interop_test.sh
@@ -78,6 +78,8 @@ withTimeout () {
 CASES=(
   "empty_unary"
   "large_unary"
+  "client_compressed_unary"
+  "server_compressed_unary"
   "client_streaming"
   "server_streaming"
   "ping_pong"

--- a/interop/test_utils.go
+++ b/interop/test_utils.go
@@ -828,6 +828,21 @@ func recvCompressUsed(ctx context.Context) bool {
 }
 
 func (s *testServer) UnaryCall(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+	if ec := in.GetExpectCompressed(); ec != nil && ec.GetValue() != recvCompressUsed(ctx) {
+		return nil, status.Errorf(codes.InvalidArgument, "request expected_compressed=%v did not match actual compression on the wire", ec.GetValue())
+	}
+	// SetSendCompressor must be called before headers are sent, so this has
+	// to happen before the SendHeader call below (triggered by
+	// initialMetadataKey).
+	if rc := in.GetResponseCompressed(); rc != nil {
+		name := encoding.Identity
+		if rc.GetValue() {
+			name = gzip.Name
+		}
+		if err := grpc.SetSendCompressor(ctx, name); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to set send compressor %q: %v", name, err)
+		}
+	}
 	st := in.GetResponseStatus()
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
 		if initialMetadata, ok := md[initialMetadataKey]; ok {
@@ -841,18 +856,6 @@ func (s *testServer) UnaryCall(ctx context.Context, in *testpb.SimpleRequest) (*
 	}
 	if st != nil && st.Code != 0 {
 		return nil, status.Error(codes.Code(st.Code), st.Message)
-	}
-	if ec := in.GetExpectCompressed(); ec != nil && ec.GetValue() != recvCompressUsed(ctx) {
-		return nil, status.Errorf(codes.InvalidArgument, "request expected_compressed=%v did not match actual compression on the wire", ec.GetValue())
-	}
-	if rc := in.GetResponseCompressed(); rc != nil {
-		name := encoding.Identity
-		if rc.GetValue() {
-			name = gzip.Name
-		}
-		if err := grpc.SetSendCompressor(ctx, name); err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to set send compressor %q: %v", name, err)
-		}
 	}
 	pl, err := serverNewPayload(in.GetResponseType(), in.GetResponseSize())
 	if err != nil {

--- a/interop/test_utils.go
+++ b/interop/test_utils.go
@@ -101,11 +101,7 @@ func DoLargeUnaryCall(ctx context.Context, tc testgrpc.TestServiceClient, args .
 	if err != nil {
 		logger.Fatal("/TestService/UnaryCall RPC failed: ", err)
 	}
-	t := reply.GetPayload().GetType()
-	s := len(reply.GetPayload().GetBody())
-	if t != testpb.PayloadType_COMPRESSABLE || s != largeRespSize {
-		logger.Fatalf("Got the reply with type %d len %d; want %d, %d", t, s, testpb.PayloadType_COMPRESSABLE, largeRespSize)
-	}
+	checkLargePayload(reply.GetPayload())
 }
 
 // DoClientCompressedUnaryCall performs a unary RPC with a compressed request
@@ -154,12 +150,10 @@ func DoClientCompressedUnaryCall(ctx context.Context, tc testgrpc.TestServiceCli
 }
 
 // DoServerCompressedUnaryCall verifies the server can be told whether to
-// compress its unary response.
-//
-// Note: this does not verify the actual wire-level compressed flag on the
-// response, since gRPC-Go does not expose a public, per-RPC API on the
-// client side to inspect it (see the discussion on #8662). Both calls are
-// verified to succeed and return the expected payload.
+// compress its unary response. Both calls are verified to succeed and
+// return the expected payload; verifying the actual wire-level compression
+// requires a stats.Handler (see compression_test.go), since that isn't
+// observable from a plain TestServiceClient.
 func DoServerCompressedUnaryCall(ctx context.Context, tc testgrpc.TestServiceClient, args ...grpc.CallOption) {
 	pl := ClientNewPayload(testpb.PayloadType_COMPRESSABLE, largeReqSize)
 
@@ -818,18 +812,24 @@ func serverNewPayload(t testpb.PayloadType, size int32) (*testpb.Payload, error)
 
 // recvCompressUsed reports whether the request associated with ctx was
 // actually received compressed on the wire.
-func recvCompressUsed(ctx context.Context) bool {
+func recvCompressUsed(ctx context.Context) (bool, error) {
 	stream, ok := grpc.ServerTransportStreamFromContext(ctx).(*transport.ServerStream)
 	if !ok || stream == nil {
-		return false
+		return false, fmt.Errorf("failed to fetch the stream from the given context")
 	}
 	c := stream.RecvCompress()
-	return c != "" && c != encoding.Identity
+	return c != "" && c != encoding.Identity, nil
 }
 
 func (s *testServer) UnaryCall(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
-	if ec := in.GetExpectCompressed(); ec != nil && ec.GetValue() != recvCompressUsed(ctx) {
-		return nil, status.Errorf(codes.InvalidArgument, "request expected_compressed=%v did not match actual compression on the wire", ec.GetValue())
+	if ec := in.GetExpectCompressed(); ec != nil {
+		used, err := recvCompressUsed(ctx)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to determine received compression: %v", err)
+		}
+		if ec.GetValue() != used {
+			return nil, status.Errorf(codes.InvalidArgument, "request expected_compressed=%v did not match actual compression on the wire", ec.GetValue())
+		}
 	}
 	// SetSendCompressor must be called before headers are sent, so this has
 	// to happen before the SendHeader call below (triggered by

--- a/interop/test_utils.go
+++ b/interop/test_utils.go
@@ -36,7 +36,10 @@ import (
 	"golang.org/x/oauth2/google"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/encoding"
+	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/internal/transport"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/orca"
 	"google.golang.org/grpc/status"
@@ -100,6 +103,95 @@ func DoLargeUnaryCall(ctx context.Context, tc testgrpc.TestServiceClient, args .
 	}
 	t := reply.GetPayload().GetType()
 	s := len(reply.GetPayload().GetBody())
+	if t != testpb.PayloadType_COMPRESSABLE || s != largeRespSize {
+		logger.Fatalf("Got the reply with type %d len %d; want %d, %d", t, s, testpb.PayloadType_COMPRESSABLE, largeRespSize)
+	}
+}
+
+// DoClientCompressedUnaryCall performs a unary RPC with a compressed request
+// and verifies the server rejects a request whose ExpectCompressed flag
+// doesn't match how the message was actually sent on the wire.
+func DoClientCompressedUnaryCall(ctx context.Context, tc testgrpc.TestServiceClient, args ...grpc.CallOption) {
+	pl := ClientNewPayload(testpb.PayloadType_COMPRESSABLE, largeReqSize)
+
+	// Probe: claim the message will be compressed while actually sending it
+	// uncompressed. The server must detect the mismatch and reject it.
+	probeReq := &testpb.SimpleRequest{
+		ResponseType:     testpb.PayloadType_COMPRESSABLE,
+		ResponseSize:     int32(largeRespSize),
+		ExpectCompressed: &testpb.BoolValue{Value: true},
+		Payload:          pl,
+	}
+	if _, err := tc.UnaryCall(ctx, probeReq, append(args, grpc.UseCompressor(encoding.Identity))...); status.Code(err) != codes.InvalidArgument {
+		logger.Fatalf("/TestService/UnaryCall probe RPC got error %v; want code %v", err, codes.InvalidArgument)
+	}
+
+	// Compressed request, matching the ExpectCompressed flag.
+	compressedReq := &testpb.SimpleRequest{
+		ResponseType:     testpb.PayloadType_COMPRESSABLE,
+		ResponseSize:     int32(largeRespSize),
+		ExpectCompressed: &testpb.BoolValue{Value: true},
+		Payload:          pl,
+	}
+	compressedReply, err := tc.UnaryCall(ctx, compressedReq, append(args, grpc.UseCompressor(gzip.Name))...)
+	if err != nil {
+		logger.Fatal("/TestService/UnaryCall compressed RPC failed: ", err)
+	}
+	checkLargePayload(compressedReply.GetPayload())
+
+	// Uncompressed request, matching the ExpectCompressed flag.
+	uncompressedReq := &testpb.SimpleRequest{
+		ResponseType:     testpb.PayloadType_COMPRESSABLE,
+		ResponseSize:     int32(largeRespSize),
+		ExpectCompressed: &testpb.BoolValue{Value: false},
+		Payload:          pl,
+	}
+	uncompressedReply, err := tc.UnaryCall(ctx, uncompressedReq, append(args, grpc.UseCompressor(encoding.Identity))...)
+	if err != nil {
+		logger.Fatal("/TestService/UnaryCall uncompressed RPC failed: ", err)
+	}
+	checkLargePayload(uncompressedReply.GetPayload())
+}
+
+// DoServerCompressedUnaryCall verifies the server can be told whether to
+// compress its unary response.
+//
+// Note: this does not verify the actual wire-level compressed flag on the
+// response, since gRPC-Go does not expose a public, per-RPC API on the
+// client side to inspect it (see the discussion on #8662). Both calls are
+// verified to succeed and return the expected payload.
+func DoServerCompressedUnaryCall(ctx context.Context, tc testgrpc.TestServiceClient, args ...grpc.CallOption) {
+	pl := ClientNewPayload(testpb.PayloadType_COMPRESSABLE, largeReqSize)
+
+	compressedReq := &testpb.SimpleRequest{
+		ResponseType:       testpb.PayloadType_COMPRESSABLE,
+		ResponseSize:       int32(largeRespSize),
+		ResponseCompressed: &testpb.BoolValue{Value: true},
+		Payload:            pl,
+	}
+	compressedReply, err := tc.UnaryCall(ctx, compressedReq, args...)
+	if err != nil {
+		logger.Fatal("/TestService/UnaryCall response_compressed=true RPC failed: ", err)
+	}
+	checkLargePayload(compressedReply.GetPayload())
+
+	uncompressedReq := &testpb.SimpleRequest{
+		ResponseType:       testpb.PayloadType_COMPRESSABLE,
+		ResponseSize:       int32(largeRespSize),
+		ResponseCompressed: &testpb.BoolValue{Value: false},
+		Payload:            pl,
+	}
+	uncompressedReply, err := tc.UnaryCall(ctx, uncompressedReq, args...)
+	if err != nil {
+		logger.Fatal("/TestService/UnaryCall response_compressed=false RPC failed: ", err)
+	}
+	checkLargePayload(uncompressedReply.GetPayload())
+}
+
+// checkLargePayload verifies p is a COMPRESSABLE payload of largeRespSize bytes.
+func checkLargePayload(p *testpb.Payload) {
+	t := p.GetType()
+	s := len(p.GetBody())
 	if t != testpb.PayloadType_COMPRESSABLE || s != largeRespSize {
 		logger.Fatalf("Got the reply with type %d len %d; want %d, %d", t, s, testpb.PayloadType_COMPRESSABLE, largeRespSize)
 	}
@@ -724,6 +816,17 @@ func serverNewPayload(t testpb.PayloadType, size int32) (*testpb.Payload, error)
 	}, nil
 }
 
+// recvCompressUsed reports whether the request associated with ctx was
+// actually received compressed on the wire.
+func recvCompressUsed(ctx context.Context) bool {
+	stream, ok := grpc.ServerTransportStreamFromContext(ctx).(*transport.ServerStream)
+	if !ok || stream == nil {
+		return false
+	}
+	c := stream.RecvCompress()
+	return c != "" && c != encoding.Identity
+}
+
 func (s *testServer) UnaryCall(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 	st := in.GetResponseStatus()
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
@@ -738,6 +841,18 @@ func (s *testServer) UnaryCall(ctx context.Context, in *testpb.SimpleRequest) (*
 	}
 	if st != nil && st.Code != 0 {
 		return nil, status.Error(codes.Code(st.Code), st.Message)
+	}
+	if ec := in.GetExpectCompressed(); ec != nil && ec.GetValue() != recvCompressUsed(ctx) {
+		return nil, status.Errorf(codes.InvalidArgument, "request expected_compressed=%v did not match actual compression on the wire", ec.GetValue())
+	}
+	if rc := in.GetResponseCompressed(); rc != nil {
+		name := encoding.Identity
+		if rc.GetValue() {
+			name = gzip.Name
+		}
+		if err := grpc.SetSendCompressor(ctx, name); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to set send compressor %q: %v", name, err)
+		}
 	}
 	pl, err := serverNewPayload(in.GetResponseType(), in.GetResponseSize())
 	if err != nil {


### PR DESCRIPTION
Updates #1357

## What this PR does

Adds the two unary compression interop tests from the interop test specification:

* `client_compressed_unary`
* `server_compressed_unary`

`DoClientCompressedUnaryCall` covers the expected request-side behavior: an uncompressed request with `expect_compressed=true` is rejected with `INVALID_ARGUMENT`, while correctly compressed and uncompressed requests succeed with the expected response.

`DoServerCompressedUnaryCall` verifies that the server honors the `response_compressed` setting when sending the response, and that both calls succeed with the expected payload. `TestServerCompressedUnaryCall_WireCompression` in `compression_test.go` separately verifies the actual wire-level compression, using a `stats.Handler` on the client to compare `CompressedLength` against `Length` on the received response.

On the server side, `UnaryCall` now checks the request's actual compression via `RecvCompress` and applies the requested response compressor with `SetSendCompressor`. `recvCompressUsed` returns `(bool, error)`, matching `SetSendCompressor`'s style, and `UnaryCall` surfaces `codes.Internal` if the stream can't be fetched from the context.

The streaming compression cases are intentionally not included here. They require changing compression on individual messages within a stream, which isn't currently supported by the public API. That work is being tracked in #8662.

## Testing

* `go test -cpu 1,4 -timeout 7m ./interop/...`
* `go test -cpu 1,4 -timeout 7m -race ./interop/...`
* `./interop/interop_test.sh`
* Manual end-to-end runs of both new test cases
* `./scripts/vet.sh`

All passed locally.

RELEASE NOTES:
* interop: Add `client_compressed_unary` and `server_compressed_unary` test cases
