### PR TITLE
extproc: increase timeout for TestStreamTimeoutBodyPhaseAllow and remove incorrect refcount decrement

### DIFF
--- a/internal/xds/httpfilter/extproc/ext_proc.go
+++ b/internal/xds/httpfilter/extproc/ext_proc.go
@@ -429,12 +429,6 @@ func (i *clientInterceptor) NewStream(ctx context.Context, ri resolver.RPCInfo, 
 	if csCommon.procStream, err = procClient.Process(procCtx, grpc.OnFinish(func(error) {
 		i.procClient.Decrement()
 	})); err != nil {
-		// Since Process failed to create the stream, its OnFinish callback will
-		// not be called, so we must manually decrement the procClient refcount.
-		// We do not invoke other registered OnFinish call options here because
-		// NewStream might return an error directly, and it is the caller's
-		// responsibility to handle cleanup if NewStream fails or returns an error.
-		i.procClient.Decrement()
 		return csCommon.handleInitError(fmt.Errorf("failed to create a stream to external processor: %v", err), newStream, opts...)
 	}
 

--- a/internal/xds/httpfilter/extproc/ext_proc_ext_test.go
+++ b/internal/xds/httpfilter/extproc/ext_proc_ext_test.go
@@ -3155,10 +3155,10 @@ func (s) TestStreamTimeoutBodyPhaseAllow(t *testing.T) {
 
 	extProcConfig := &v3procfilterpb.ExternalProcessor{
 		GrpcService: &v3corepb.GrpcService{
-			Timeout: durationpb.New(defaultTestShortTimeout),
+			Timeout: durationpb.New(100 * time.Millisecond),
 		},
 		ProcessingMode: &v3procfilterpb.ProcessingMode{
-			RequestHeaderMode: v3procfilterpb.ProcessingMode_SEND,
+			RequestHeaderMode: v3procfilterpb.ProcessingMode_SKIP,
 			RequestBodyMode:   v3procfilterpb.ProcessingMode_GRPC,
 		},
 		FailureModeAllow: true,

--- a/internal/xds/httpfilter/extproc/ext_proc_ext_test.go
+++ b/internal/xds/httpfilter/extproc/ext_proc_ext_test.go
@@ -3155,6 +3155,10 @@ func (s) TestStreamTimeoutBodyPhaseAllow(t *testing.T) {
 
 	extProcConfig := &v3procfilterpb.ExternalProcessor{
 		GrpcService: &v3corepb.GrpcService{
+			// Use 100ms instead of defaultTestShortTimeout (10ms) to protect against
+			// slow connections, for example where the processor RPC fails before the
+			// data plane stream is even connected, which would cause the test to fail
+			// in the header phase itself.
 			Timeout: durationpb.New(100 * time.Millisecond),
 		},
 		ProcessingMode: &v3procfilterpb.ProcessingMode{


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/9305

This PR : 
- Increases the timeout for TestStreamTimeoutBodyPhaseAllow
- Removes refcount decrement after rpc init returns error because that is already taken care by https://github.com/grpc/grpc-go/pull/9140

RELEASE NOTES: None