### PR TITLE
server: unify handling of unary and streaming RPCs

### DIFF
--- a/encoding/compressor_test.go
+++ b/encoding/compressor_test.go
@@ -237,3 +237,45 @@ func (s) TestDecompressionExceedsMaxMessageSize(t *testing.T) {
 		t.Errorf("Client.UnaryCall(%+v) returned status %v, want %v", req, got, want)
 	}
 }
+
+// Test verifies that decompression failures (after stream establishment) are
+// handled gracefully without duplicate status writes.
+func (s) TestStreamingDecompressionExceedsMaxMessageSize(t *testing.T) {
+	const messageLen = 100
+	regFn := internal.RegisterCompressorForTesting.(func(encoding.Compressor) func())
+	compressor := &fakeCompressor{decompressedMessageSize: messageLen}
+	unreg := regFn(compressor)
+	defer unreg()
+
+	ss := &stubserver.StubServer{
+		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+			for {
+				if _, err := stream.Recv(); err != nil {
+					return err
+				}
+			}
+		},
+	}
+	if err := ss.Start([]grpc.ServerOption{grpc.MaxRecvMsgSize(messageLen - 1)}); err != nil {
+		t.Fatalf("Error starting endpoint server: %v", err)
+	}
+	defer ss.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	stream, err := ss.Client.FullDuplexCall(ctx, grpc.UseCompressor(compressor.Name()))
+	if err != nil {
+		t.Fatalf("FullDuplexCall failed: %v", err)
+	}
+
+	// Send message that will result in decompression failure on the server
+	// because it exceeds the max message size.
+	if err := stream.Send(&testpb.StreamingOutputCallRequest{Payload: &testpb.Payload{Body: []byte("payload")}}); err != nil {
+		t.Fatalf("Send() failed: %v", err)
+	}
+
+	// We expect the stream to fail with ResourceExhausted on Recv.
+	if _, err = stream.Recv(); status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("stream.Recv() returned status %v, want %v", status.Code(err), codes.ResourceExhausted)
+	}
+}

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -112,8 +112,6 @@ func (c *errProtoCodec) Name() string {
 // Tests the case where encoding fails on the server. Verifies that there is
 // no panic and that the encoding error is propagated to the client.
 func (s) TestEncodeDoesntPanicOnServer(t *testing.T) {
-	grpctest.ExpectError("grpc: server failed to encode response")
-
 	// Create a codec that errors when encoding messages.
 	encodingErr := errors.New("encoding failed")
 	ec := &errProtoCodec{name: t.Name(), encodingErr: encodingErr}
@@ -173,7 +171,7 @@ func (s) TestDecodeDoesntPanicOnServer(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	_, err := backend1.Client.EmptyCall(ctx, &testpb.Empty{})
-	if err == nil || !strings.Contains(err.Error(), decodingErr.Error()) || !strings.Contains(err.Error(), "grpc: error unmarshalling request") {
+	if err == nil || !strings.Contains(err.Error(), decodingErr.Error()) || !strings.Contains(err.Error(), "grpc: failed to unmarshal the received message") {
 		t.Fatalf("RPC failed with error: %v, want: %v", err, decodingErr)
 	}
 

--- a/gcp/observability/logging_test.go
+++ b/gcp/observability/logging_test.go
@@ -432,7 +432,7 @@ func (s) TestServerRPCEventsLogAll(t *testing.T) {
 			Authority:   ss.Address,
 			SequenceID:  4,
 			Payload: payload{
-				Message: []uint8{},
+				Message: nil,
 			},
 		},
 		{

--- a/server.go
+++ b/server.go
@@ -117,10 +117,8 @@ type ServiceDesc struct {
 // serviceInfo wraps information about a service. It is very similar to
 // ServiceDesc and is constructed from it for internal purposes.
 type serviceInfo struct {
-	// Contains the implementation for the methods in this service.
-	serviceImpl any
-	methods     map[string]*MethodDesc
-	streams     map[string]*StreamDesc
+	serviceImpl any                    // Implementation for the methods in this service.
+	streams     map[string]*StreamDesc // Streaming descriptors and wrapped unary descriptors for this service.
 	mdata       any
 }
 
@@ -790,17 +788,21 @@ func (s *Server) register(sd *ServiceDesc, ss any) {
 	}
 	info := &serviceInfo{
 		serviceImpl: ss,
-		methods:     make(map[string]*MethodDesc),
 		streams:     make(map[string]*StreamDesc),
 		mdata:       sd.Metadata,
-	}
-	for i := range sd.Methods {
-		d := &sd.Methods[i]
-		info.methods[d.MethodName] = d
 	}
 	for i := range sd.Streams {
 		d := &sd.Streams[i]
 		info.streams[d.StreamName] = d
+	}
+	for i := range sd.Methods {
+		d := &sd.Methods[i]
+		info.streams[d.MethodName] = &StreamDesc{
+			StreamName:    d.MethodName,
+			Handler:       s.wrapUnaryHandler(d),
+			ServerStreams: false,
+			ClientStreams: false,
+		}
 	}
 	s.services[sd.ServiceName] = info
 }
@@ -827,20 +829,26 @@ type ServiceInfo struct {
 func (s *Server) GetServiceInfo() map[string]ServiceInfo {
 	ret := make(map[string]ServiceInfo)
 	for n, srv := range s.services {
-		methods := make([]MethodInfo, 0, len(srv.methods)+len(srv.streams))
-		for m := range srv.methods {
-			methods = append(methods, MethodInfo{
-				Name:           m,
-				IsClientStream: false,
-				IsServerStream: false,
-			})
-		}
+		methods := make([]MethodInfo, 0, len(srv.streams))
+		// Iterate over unary methods first to maintain backward compatibility of order.
 		for m, d := range srv.streams {
-			methods = append(methods, MethodInfo{
-				Name:           m,
-				IsClientStream: d.ClientStreams,
-				IsServerStream: d.ServerStreams,
-			})
+			if !d.ClientStreams && !d.ServerStreams {
+				methods = append(methods, MethodInfo{
+					Name:           m,
+					IsClientStream: false,
+					IsServerStream: false,
+				})
+			}
+		}
+		// Iterate over streaming methods.
+		for m, d := range srv.streams {
+			if d.ClientStreams || d.ServerStreams {
+				methods = append(methods, MethodInfo{
+					Name:           m,
+					IsClientStream: d.ClientStreams,
+					IsServerStream: d.ServerStreams,
+				})
+			}
 		}
 
 		ret[n] = ServiceInfo{
@@ -1185,42 +1193,6 @@ func (s *Server) incrCallsFailed() {
 	s.channelz.ServerMetrics.CallsFailed.Add(1)
 }
 
-func (s *Server) sendResponse(ctx context.Context, stream *transport.ServerStream, msg any, cp Compressor, opts *transport.WriteOptions, comp encoding.Compressor) error {
-	data, err := encode(s.getCodec(stream.ContentSubtype()), msg)
-	if err != nil {
-		channelz.Error(logger, s.channelz, "grpc: server failed to encode response: ", err)
-		return err
-	}
-
-	compData, pf, err := compress(data, cp, comp, s.opts.bufferPool)
-	if err != nil {
-		data.Free()
-		channelz.Error(logger, s.channelz, "grpc: server failed to compress response: ", err)
-		return err
-	}
-
-	hdr, payload := msgHeader(data, compData, pf)
-
-	defer func() {
-		compData.Free()
-		data.Free()
-		// payload does not need to be freed here, it is either data or compData, both of
-		// which are already freed.
-	}()
-
-	dataLen := data.Len()
-	payloadLen := payload.Len()
-	// TODO(dfawley): should we be checking len(data) instead?
-	if payloadLen > s.opts.maxSendMessageSize {
-		return status.Errorf(codes.ResourceExhausted, "grpc: trying to send message larger than max (%d vs. %d)", payloadLen, s.opts.maxSendMessageSize)
-	}
-	err = stream.Write(hdr, payload, opts)
-	if err == nil && s.statsHandler != nil {
-		s.statsHandler.HandleRPC(ctx, outPayload(false, msg, dataLen, payloadLen, time.Now()))
-	}
-	return err
-}
-
 // chainUnaryServerInterceptors chains all unary server interceptors into one.
 func chainUnaryServerInterceptors(s *Server) {
 	// Prepend opts.unaryInt to the chaining interceptors if it exists, since unaryInt will
@@ -1255,300 +1227,6 @@ func getChainUnaryHandler(interceptors []UnaryServerInterceptor, curr int, info 
 	return func(ctx context.Context, req any) (any, error) {
 		return interceptors[curr+1](ctx, req, info, getChainUnaryHandler(interceptors, curr+1, info, finalHandler))
 	}
-}
-
-func (s *Server) processUnaryRPC(ctx context.Context, stream *transport.ServerStream, info *serviceInfo, md *MethodDesc, trInfo *traceInfo) (err error) {
-	sh := s.statsHandler
-	if sh != nil || trInfo != nil || channelz.IsOn() {
-		if channelz.IsOn() {
-			s.incrCallsStarted()
-		}
-		var statsBegin *stats.Begin
-		if sh != nil {
-			statsBegin = &stats.Begin{
-				BeginTime:      time.Now(),
-				IsClientStream: false,
-				IsServerStream: false,
-			}
-			sh.HandleRPC(ctx, statsBegin)
-		}
-		if trInfo != nil {
-			trInfo.tr.LazyLog(&trInfo.firstLine, false)
-		}
-		// The deferred error handling for tracing, stats handler and channelz are
-		// combined into one function to reduce stack usage -- a defer takes ~56-64
-		// bytes on the stack, so overflowing the stack will require a stack
-		// re-allocation, which is expensive.
-		//
-		// To maintain behavior similar to separate deferred statements, statements
-		// should be executed in the reverse order. That is, tracing first, stats
-		// handler second, and channelz last. Note that panics *within* defers will
-		// lead to different behavior, but that's an acceptable compromise; that
-		// would be undefined behavior territory anyway.
-		defer func() {
-			if trInfo != nil {
-				if err != nil && err != io.EOF {
-					trInfo.tr.LazyLog(&fmtStringer{"%v", []any{err}}, true)
-					trInfo.tr.SetError()
-				}
-				trInfo.tr.Finish()
-			}
-
-			if sh != nil {
-				end := &stats.End{
-					BeginTime: statsBegin.BeginTime,
-					EndTime:   time.Now(),
-				}
-				if err != nil && err != io.EOF {
-					end.Error = toRPCErr(err)
-				}
-				sh.HandleRPC(ctx, end)
-			}
-
-			if channelz.IsOn() {
-				if err != nil && err != io.EOF {
-					s.incrCallsFailed()
-				} else {
-					s.incrCallsSucceeded()
-				}
-			}
-		}()
-	}
-	var binlogs []binarylog.MethodLogger
-	if ml := binarylog.GetMethodLogger(stream.Method()); ml != nil {
-		binlogs = append(binlogs, ml)
-	}
-	if s.opts.binaryLogger != nil {
-		if ml := s.opts.binaryLogger.GetMethodLogger(stream.Method()); ml != nil {
-			binlogs = append(binlogs, ml)
-		}
-	}
-	if len(binlogs) != 0 {
-		md, _ := metadata.FromIncomingContext(ctx)
-		logEntry := &binarylog.ClientHeader{
-			Header:     md,
-			MethodName: stream.Method(),
-			PeerAddr:   nil,
-		}
-		if deadline, ok := ctx.Deadline(); ok {
-			logEntry.Timeout = time.Until(deadline)
-			if logEntry.Timeout < 0 {
-				logEntry.Timeout = 0
-			}
-		}
-		if a := md[":authority"]; len(a) > 0 {
-			logEntry.Authority = a[0]
-		}
-		if peer, ok := peer.FromContext(ctx); ok {
-			logEntry.PeerAddr = peer.Addr
-		}
-		for _, binlog := range binlogs {
-			binlog.Log(ctx, logEntry)
-		}
-	}
-
-	// comp and cp are used for compression.  decomp and dc are used for
-	// decompression.  If comp and decomp are both set, they are the same;
-	// however they are kept separate to ensure that at most one of the
-	// compressor/decompressor variable pairs are set for use later.
-	var comp, decomp encoding.Compressor
-	var cp Compressor
-	var dc Decompressor
-	var sendCompressorName string
-
-	// If dc is set and matches the stream's compression, use it.  Otherwise, try
-	// to find a matching registered compressor for decomp.
-	if rc := stream.RecvCompress(); s.opts.dc != nil && s.opts.dc.Type() == rc {
-		dc = s.opts.dc
-	} else if rc != "" && rc != encoding.Identity {
-		decomp = encoding.GetCompressor(rc)
-		if decomp == nil {
-			st := status.Newf(codes.Unimplemented, "grpc: Decompressor is not installed for grpc-encoding %q", rc)
-			stream.WriteStatus(st)
-			return st.Err()
-		}
-	}
-
-	// If cp is set, use it.  Otherwise, attempt to compress the response using
-	// the incoming message compression method.
-	//
-	// NOTE: this needs to be ahead of all handling, https://github.com/grpc/grpc-go/issues/686.
-	if s.opts.cp != nil {
-		cp = s.opts.cp
-		sendCompressorName = cp.Type()
-	} else if rc := stream.RecvCompress(); rc != "" && rc != encoding.Identity {
-		// Legacy compressor not specified; attempt to respond with same encoding.
-		comp = encoding.GetCompressor(rc)
-		if comp != nil {
-			sendCompressorName = comp.Name()
-		}
-	}
-
-	if sendCompressorName != "" {
-		if err := stream.SetSendCompress(sendCompressorName); err != nil {
-			return status.Errorf(codes.Internal, "grpc: failed to set send compressor: %v", err)
-		}
-	}
-
-	var payInfo *payloadInfo
-	if sh != nil || len(binlogs) != 0 {
-		payInfo = &payloadInfo{}
-		defer payInfo.free()
-	}
-
-	d, err := recvAndDecompress(&parser{r: stream, bufferPool: s.opts.bufferPool}, stream, dc, s.opts.maxReceiveMessageSize, payInfo, decomp, true)
-	if err != nil {
-		if e := stream.WriteStatus(status.Convert(err)); e != nil {
-			channelz.Warningf(logger, s.channelz, "grpc: Server.processUnaryRPC failed to write status: %v", e)
-		}
-		return err
-	}
-	freed := false
-	dataFree := func() {
-		if !freed {
-			d.Free()
-			freed = true
-		}
-	}
-	defer dataFree()
-	df := func(v any) error {
-		defer dataFree()
-		if err := s.getCodec(stream.ContentSubtype()).Unmarshal(d, v); err != nil {
-			return status.Errorf(codes.Internal, "grpc: error unmarshalling request: %v", err)
-		}
-
-		if sh != nil {
-			sh.HandleRPC(ctx, &stats.InPayload{
-				RecvTime:         time.Now(),
-				Payload:          v,
-				Length:           d.Len(),
-				WireLength:       payInfo.compressedLength + headerLen,
-				CompressedLength: payInfo.compressedLength,
-			})
-		}
-		if len(binlogs) != 0 {
-			cm := &binarylog.ClientMessage{
-				Message: d.Materialize(),
-			}
-			for _, binlog := range binlogs {
-				binlog.Log(ctx, cm)
-			}
-		}
-		if trInfo != nil {
-			trInfo.tr.LazyLog(&payload{sent: false, msg: v}, true)
-		}
-		return nil
-	}
-	ctx = NewContextWithServerTransportStream(ctx, stream)
-	reply, appErr := md.Handler(info.serviceImpl, ctx, df, s.opts.unaryInt)
-	if appErr != nil {
-		appStatus, ok := status.FromError(appErr)
-		if !ok {
-			// Convert non-status application error to a status error with code
-			// Unknown, but handle context errors specifically.
-			appStatus = status.FromContextError(appErr)
-			appErr = appStatus.Err()
-		}
-		if trInfo != nil {
-			trInfo.tr.LazyLog(stringer(appStatus.Message()), true)
-			trInfo.tr.SetError()
-		}
-		if e := stream.WriteStatus(appStatus); e != nil {
-			channelz.Warningf(logger, s.channelz, "grpc: Server.processUnaryRPC failed to write status: %v", e)
-		}
-		if len(binlogs) != 0 {
-			if h, _ := stream.Header(); h.Len() > 0 {
-				// Only log serverHeader if there was header. Otherwise it can
-				// be trailer only.
-				sh := &binarylog.ServerHeader{
-					Header: h,
-				}
-				for _, binlog := range binlogs {
-					binlog.Log(ctx, sh)
-				}
-			}
-			st := &binarylog.ServerTrailer{
-				Trailer: stream.Trailer(),
-				Err:     appErr,
-			}
-			for _, binlog := range binlogs {
-				binlog.Log(ctx, st)
-			}
-		}
-		return appErr
-	}
-	if trInfo != nil {
-		trInfo.tr.LazyLog(stringer("OK"), false)
-	}
-	opts := &transport.WriteOptions{Last: true}
-
-	// Server handler could have set new compressor by calling SetSendCompressor.
-	// In case it is set, we need to use it for compressing outbound message.
-	if stream.SendCompress() != sendCompressorName {
-		comp = encoding.GetCompressor(stream.SendCompress())
-	}
-	if err := s.sendResponse(ctx, stream, reply, cp, opts, comp); err != nil {
-		if err == io.EOF {
-			// The entire stream is done (for unary RPC only).
-			return err
-		}
-		if sts, ok := status.FromError(err); ok {
-			if e := stream.WriteStatus(sts); e != nil {
-				channelz.Warningf(logger, s.channelz, "grpc: Server.processUnaryRPC failed to write status: %v", e)
-			}
-		} else {
-			switch st := err.(type) {
-			case transport.ConnectionError:
-				// Nothing to do here.
-			default:
-				panic(fmt.Sprintf("grpc: Unexpected error (%T) from sendResponse: %v", st, st))
-			}
-		}
-		if len(binlogs) != 0 {
-			h, _ := stream.Header()
-			sh := &binarylog.ServerHeader{
-				Header: h,
-			}
-			st := &binarylog.ServerTrailer{
-				Trailer: stream.Trailer(),
-				Err:     appErr,
-			}
-			for _, binlog := range binlogs {
-				binlog.Log(ctx, sh)
-				binlog.Log(ctx, st)
-			}
-		}
-		return err
-	}
-	if len(binlogs) != 0 {
-		h, _ := stream.Header()
-		sh := &binarylog.ServerHeader{
-			Header: h,
-		}
-		sm := &binarylog.ServerMessage{
-			Message: reply,
-		}
-		for _, binlog := range binlogs {
-			binlog.Log(ctx, sh)
-			binlog.Log(ctx, sm)
-		}
-	}
-	if trInfo != nil {
-		trInfo.tr.LazyLog(&payload{sent: true, msg: reply}, true)
-	}
-	// TODO: Should we be logging if writing status failed here, like above?
-	// Should the logging be in WriteStatus?  Should we ignore the WriteStatus
-	// error or allow the stats handler to see it?
-	if len(binlogs) != 0 {
-		st := &binarylog.ServerTrailer{
-			Trailer: stream.Trailer(),
-			Err:     appErr,
-		}
-		for _, binlog := range binlogs {
-			binlog.Log(ctx, st)
-		}
-	}
-	return stream.WriteStatus(statusOK)
 }
 
 // chainStreamServerInterceptors chains all stream server interceptors into one.
@@ -1587,7 +1265,21 @@ func getChainStreamHandler(interceptors []StreamServerInterceptor, curr int, inf
 	}
 }
 
-func (s *Server) processStreamingRPC(ctx context.Context, stream *transport.ServerStream, info *serviceInfo, sd *StreamDesc, trInfo *traceInfo) (err error) {
+// wrapUnaryHandler converts a standard Unary Method Descriptor into a
+// StreamHandler, allowing Unary RPCs to be processed via the same unified
+// pipeline as Streaming RPCs.
+func (s *Server) wrapUnaryHandler(md *MethodDesc) StreamHandler {
+	return func(srv any, stream ServerStream) error {
+		df := func(v any) error { return stream.RecvMsg(v) }
+		reply, err := md.Handler(srv, stream.Context(), df, s.opts.unaryInt)
+		if err != nil {
+			return err
+		}
+		return stream.SendMsg(reply)
+	}
+}
+
+func (s *Server) processRPC(ctx context.Context, stream *transport.ServerStream, info *serviceInfo, sd *StreamDesc, trInfo *traceInfo) (err error) {
 	if channelz.IsOn() {
 		s.incrCallsStarted()
 	}
@@ -1615,7 +1307,16 @@ func (s *Server) processStreamingRPC(ctx context.Context, stream *transport.Serv
 	}
 
 	if sh != nil || trInfo != nil || channelz.IsOn() {
-		// See comment in processUnaryRPC on defers.
+		// The deferred error handling for tracing, stats handler and channelz are
+		// combined into one function to reduce stack usage -- a defer takes ~56-64
+		// bytes on the stack, so overflowing the stack will require a stack
+		// re-allocation, which is expensive.
+		//
+		// To maintain behavior similar to separate deferred statements, statements
+		// should be executed in the reverse order. That is, tracing first, stats
+		// handler second, and channelz last. Note that panics *within* defers will
+		// lead to different behavior, but that's an acceptable compromise; that
+		// would be undefined behavior territory anyway.
 		defer func() {
 			if trInfo != nil {
 				ss.mu.Lock()
@@ -1689,7 +1390,7 @@ func (s *Server) processStreamingRPC(ctx context.Context, stream *transport.Serv
 		ss.decompressorV1 = encoding.GetCompressor(rc)
 		if ss.decompressorV1 == nil {
 			st := status.Newf(codes.Unimplemented, "grpc: Decompressor is not installed for grpc-encoding %q", rc)
-			ss.s.WriteStatus(st)
+			ss.writeStatus(st)
 			return st.Err()
 		}
 	}
@@ -1725,7 +1426,10 @@ func (s *Server) processStreamingRPC(ctx context.Context, stream *transport.Serv
 	if info != nil {
 		server = info.serviceImpl
 	}
-	if s.opts.streamInt == nil {
+	if s.opts.streamInt == nil || (!sd.ClientStreams && !sd.ServerStreams) {
+		// If there is no stream interceptor, or if this is a unary RPC, call
+		// the handler directly. The wrapped unary handler will call the unary
+		// interceptor if it exists.
 		appErr = sd.Handler(server, ss)
 	} else {
 		info := &StreamServerInfo{
@@ -1750,6 +1454,17 @@ func (s *Server) processStreamingRPC(ctx context.Context, stream *transport.Serv
 			ss.mu.Unlock()
 		}
 		if len(ss.binlogs) != 0 {
+			if !ss.serverHeaderBinlogged {
+				if h, _ := ss.s.Header(); h.Len() > 0 {
+					sh := &binarylog.ServerHeader{
+						Header: h,
+					}
+					ss.serverHeaderBinlogged = true
+					for _, binlog := range ss.binlogs {
+						binlog.Log(ctx, sh)
+					}
+				}
+			}
 			st := &binarylog.ServerTrailer{
 				Trailer: ss.s.Trailer(),
 				Err:     appErr,
@@ -1758,8 +1473,9 @@ func (s *Server) processStreamingRPC(ctx context.Context, stream *transport.Serv
 				binlog.Log(ctx, st)
 			}
 		}
-		ss.s.WriteStatus(appStatus)
-		// TODO: Should we log an error from WriteStatus here and below?
+		if err := ss.writeStatus(appStatus); err != nil {
+			channelz.Warningf(logger, s.channelz, "grpc: Server.processRPC failed to write status: %v", err)
+		}
 		return appErr
 	}
 	if trInfo != nil {
@@ -1776,7 +1492,10 @@ func (s *Server) processStreamingRPC(ctx context.Context, stream *transport.Serv
 			binlog.Log(ctx, st)
 		}
 	}
-	return ss.s.WriteStatus(statusOK)
+	if err := ss.writeStatus(statusOK); err != nil {
+		channelz.Warningf(logger, s.channelz, "grpc: Server.processRPC failed to write status: %v", err)
+	}
+	return err
 }
 
 func (s *Server) handleMalformedMethodName(stream *transport.ServerStream, ti *traceInfo) {
@@ -1854,18 +1573,14 @@ func (s *Server) handleStream(t transport.ServerTransport, stream *transport.Ser
 
 	srv, knownService := s.services[service]
 	if knownService {
-		if md, ok := srv.methods[method]; ok {
-			s.processUnaryRPC(ctx, stream, srv, md, ti)
-			return
-		}
 		if sd, ok := srv.streams[method]; ok {
-			s.processStreamingRPC(ctx, stream, srv, sd, ti)
+			s.processRPC(ctx, stream, srv, sd, ti)
 			return
 		}
 	}
 	// Unknown service, or known server unknown method.
 	if unknownDesc := s.opts.unknownStreamDesc; unknownDesc != nil {
-		s.processStreamingRPC(ctx, stream, nil, unknownDesc, ti)
+		s.processRPC(ctx, stream, nil, unknownDesc, ti)
 		return
 	}
 	var errDesc string
@@ -2069,9 +1784,6 @@ func (s *Server) isRegisteredMethod(serviceMethod string) bool {
 	method := serviceMethod[pos+1:]
 	srv, knownService := s.services[service]
 	if knownService {
-		if _, ok := srv.methods[method]; ok {
-			return true
-		}
 		if _, ok := srv.streams[method]; ok {
 			return true
 		}

--- a/server_test.go
+++ b/server_test.go
@@ -24,6 +24,8 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -231,5 +233,45 @@ func BenchmarkChainStreamInterceptor(b *testing.B) {
 				}
 			}
 		})
+	}
+}
+
+// Test verifies that writeStatus writes the status exactly once.
+func (s) TestServerStream_WriteStatus_Concurrency(t *testing.T) {
+	// To avoid setting up a heavy transport layer, this test leaves
+	// serverStream.s as nil. The first goroutine to successfully CAS will
+	// attempt to call WriteStatus on the nil stream, triggering a panic. This
+	// serves as our signal that the CAS check was bypassed. All subsequent or
+	// concurrent calls must fail the CAS and return without panicking.
+	ss := &serverStream{}
+
+	const numGoroutines = 100
+	var panicCount, successCount atomic.Int32
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range numGoroutines {
+		wg.Go(func() {
+			<-start // synchronize start
+
+			defer func() {
+				if r := recover(); r != nil {
+					panicCount.Add(1)
+				}
+			}()
+
+			if err := ss.writeStatus(nil); err == nil {
+				successCount.Add(1)
+			}
+		})
+	}
+
+	close(start) // start all goroutines
+	wg.Wait()
+
+	if panicCount.Load() != 1 {
+		t.Fatalf("Got %d panics, want exactly 1", panicCount.Load())
+	}
+	if successCount.Load() != numGoroutines-1 {
+		t.Fatalf("Got %d successful calls, want %d", successCount.Load(), numGoroutines-1)
 	}
 }

--- a/stream.go
+++ b/stream.go
@@ -1891,10 +1891,7 @@ func (ss *serverStream) RecvMsg(m any) (err error) {
 		}
 		if err != nil && err != io.EOF {
 			st, _ := status.FromError(toRPCErr(err))
-			if ss.desc.ClientStreams || ss.desc.ServerStreams {
-				// For unary RPCs, status is written from processRPC.
-				ss.writeStatus(st)
-			}
+			ss.writeStatus(st)
 			// Non-user specified status was sent out. This should be an error
 			// case (as a server side Cancel maybe).
 			//

--- a/stream.go
+++ b/stream.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"google.golang.org/grpc/balancer"
@@ -1731,6 +1732,8 @@ type serverStream struct {
 	// synchronized.
 	serverHeaderBinlogged bool
 
+	statusWritten atomic.Bool // True if status has been written to the transport.
+
 	mu sync.Mutex // protects trInfo.tr after the service handler runs.
 }
 
@@ -1779,6 +1782,16 @@ func (ss *serverStream) SetTrailer(md metadata.MD) {
 	ss.s.SetTrailer(md)
 }
 
+// writeStatus sends the status of a stream to the client. It uses an atomic
+// CAS to guarantee that the status is written to the transport exactly once,
+// even if called concurrently.
+func (ss *serverStream) writeStatus(st *status.Status) error {
+	if !ss.statusWritten.CompareAndSwap(false, true) {
+		return nil
+	}
+	return ss.s.WriteStatus(st)
+}
+
 func (ss *serverStream) SendMsg(m any) (err error) {
 	defer func() {
 		if ss.trInfo != nil {
@@ -1795,7 +1808,7 @@ func (ss *serverStream) SendMsg(m any) (err error) {
 		}
 		if err != nil && err != io.EOF {
 			st, _ := status.FromError(toRPCErr(err))
-			ss.s.WriteStatus(st)
+			ss.writeStatus(st)
 			// Non-user specified status was sent out. This should be an error
 			// case (as a server side Cancel maybe).
 			//
@@ -1878,7 +1891,10 @@ func (ss *serverStream) RecvMsg(m any) (err error) {
 		}
 		if err != nil && err != io.EOF {
 			st, _ := status.FromError(toRPCErr(err))
-			ss.s.WriteStatus(st)
+			if ss.desc.ClientStreams || ss.desc.ServerStreams {
+				// For unary RPCs, status is written from processRPC.
+				ss.writeStatus(st)
+			}
 			// Non-user specified status was sent out. This should be an error
 			// case (as a server side Cancel maybe).
 			//

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -4659,7 +4659,7 @@ func (s) TestInvalidStreamIDSmallerThanPrevious(t *testing.T) {
 
 func testClientRequestBodyErrorCloseAfterLength(t *testing.T, e env) {
 	te := newTest(t, e)
-	te.declareLogNoise("Server.processUnaryRPC failed to write status")
+	te.declareLogNoise("Server.processRPC failed to write status")
 	ts := &funcServer{unaryCall: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 		errUnexpectedCall := errors.New("unexpected call func server method")
 		t.Error(errUnexpectedCall)
@@ -6238,7 +6238,7 @@ func testLargeTimeout(t *testing.T, e env) {
 	for i, maxTimeout := range timeouts {
 		func() {
 			te := newTest(t, e)
-			te.declareLogNoise("Server.processUnaryRPC failed to write status")
+			te.declareLogNoise("Server.processRPC failed to write status")
 
 			ts := &funcServer{
 				unaryCall: func(ctx context.Context, _ *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -425,3 +425,62 @@ func (s) TestChainStreamServerInterceptor(t *testing.T) {
 		t.Fatalf("callCounts[3] should be 1, but got=%d", callCounts[3].Load())
 	}
 }
+
+// Test verifies that only unary interceptors are invoked for unary RPCs and
+// only streaming interceptors are invoked for streaming RPCs.
+func (s) TestInterceptorSegregation(t *testing.T) {
+	var unaryCalled, streamCalled atomic.Bool
+
+	unaryInt := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		unaryCalled.Store(true)
+		return handler(ctx, req)
+	}
+	streamInt := func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		streamCalled.Store(true)
+		return handler(srv, ss)
+	}
+	sopts := []grpc.ServerOption{grpc.UnaryInterceptor(unaryInt), grpc.StreamInterceptor(streamInt)}
+	ss := &stubserver.StubServer{
+		UnaryCallF: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+			return &testpb.SimpleResponse{}, nil
+		},
+		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+			return nil
+		},
+	}
+	if err := ss.Start(sopts); err != nil {
+		t.Fatalf("Error starting endpoint server: %v", err)
+	}
+	defer ss.Stop()
+
+	// Make a unary RPC and ensure that only the unary interceptor was invoked.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := ss.Client.UnaryCall(ctx, &testpb.SimpleRequest{}); err != nil {
+		t.Fatalf("ss.Client.UnaryCall failed: %v", err)
+	}
+	if !unaryCalled.Load() {
+		t.Error("Unary interceptor was not called for Unary RPC")
+	}
+	if streamCalled.Load() {
+		t.Error("Stream interceptor was called for Unary RPC")
+	}
+
+	// Make a streaming RPC and ensure that only the streaming interceptor was
+	// invoked.
+	unaryCalled.Store(false)
+	streamCalled.Store(false)
+	stream, err := ss.Client.FullDuplexCall(ctx)
+	if err != nil {
+		t.Fatalf("ss.Client.FullDuplexCall failed: %v", err)
+	}
+	if _, err := stream.Recv(); err != io.EOF {
+		t.Fatalf("stream.Recv() returned %v, want io.EOF", err)
+	}
+	if unaryCalled.Load() {
+		t.Error("Unary interceptor was called for Streaming RPC")
+	}
+	if !streamCalled.Load() {
+		t.Error("Stream interceptor was not called for Streaming RPC")
+	}
+}

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -431,11 +431,11 @@ func (s) TestChainStreamServerInterceptor(t *testing.T) {
 func (s) TestInterceptorSegregation(t *testing.T) {
 	var unaryCalled, streamCalled atomic.Bool
 
-	unaryInt := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	unaryInt := func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		unaryCalled.Store(true)
 		return handler(ctx, req)
 	}
-	streamInt := func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	streamInt := func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		streamCalled.Store(true)
 		return handler(srv, ss)
 	}
@@ -444,7 +444,7 @@ func (s) TestInterceptorSegregation(t *testing.T) {
 		UnaryCallF: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return &testpb.SimpleResponse{}, nil
 		},
-		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+		FullDuplexCallF: func(testgrpc.TestService_FullDuplexCallServer) error {
 			return nil
 		},
 	}


### PR DESCRIPTION
This change unifies the processing for unary and streaming RPCs on the gRPC-Go server. By treating all RPCs fundamentally as streams internally, this change simplifies the codebase and eliminates duplicate logic.

Summary of changes:
* Merged `processUnaryRPC` and `processStreamingRPC` into a single `processRPC` method by wrapping unary handlers as stream handlers.
* Removed the methods map from `serviceInfo`, storing all descriptors in the streams map.
* Ensured interceptor segregation is maintained so that unary interceptors only run for unary RPCs and stream interceptors only run for streaming RPCs.
* Introduced thread-safe, exactly-once status writing in `serverStream` using an atomic boolean to prevent duplicate status writes.
* Added tests to verify interceptor segregation and concurrent status writing behavior.

RELEASE NOTES: none