### PR TITLE
extproc : wait for async RPC to complete in test

### DIFF
--- a/internal/xds/httpfilter/extproc/ext_proc.go
+++ b/internal/xds/httpfilter/extproc/ext_proc.go
@@ -435,7 +435,7 @@ func (i *clientInterceptor) NewStream(ctx context.Context, ri resolver.RPCInfo, 
 		// NewStream might return an error directly, and it is the caller's
 		// responsibility to handle cleanup if NewStream fails or returns an error.
 		i.procClient.Decrement()
-		return csCommon.handleInitError(fmt.Errorf("failed to create a stream to external processor: %v", err), newStream, opts...)
+		return csCommon.handleInitError(err, newStream, opts...)
 	}
 
 	// Observability mode.
@@ -465,7 +465,7 @@ func (i *clientInterceptor) NewStream(ctx context.Context, ri resolver.RPCInfo, 
 		// headers to the external processor server.
 		if i.config.processingModes.requestHeaderMode == modeSend {
 			if err = ocs.sendToProcessor(ocs.requestHeaders(outgoingMD, added)); err != nil {
-				return ocs.handleInitError(fmt.Errorf("failed to send client headers to external processor server: %v", err), newStream, opts...)
+				return ocs.handleInitError(err, newStream, opts...)
 			}
 		}
 

--- a/internal/xds/httpfilter/extproc/ext_proc.go
+++ b/internal/xds/httpfilter/extproc/ext_proc.go
@@ -21,6 +21,7 @@ package extproc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -429,7 +430,7 @@ func (i *clientInterceptor) NewStream(ctx context.Context, ri resolver.RPCInfo, 
 	if csCommon.procStream, err = procClient.Process(procCtx, grpc.OnFinish(func(error) {
 		i.procClient.Decrement()
 	})); err != nil {
-		return csCommon.handleInitError(err, newStream, opts...)
+		return csCommon.handleInitError(fmt.Errorf("failed to create a stream to external processor: %w", err), newStream, opts...)
 	}
 
 	// Observability mode.
@@ -459,7 +460,7 @@ func (i *clientInterceptor) NewStream(ctx context.Context, ri resolver.RPCInfo, 
 		// headers to the external processor server.
 		if i.config.processingModes.requestHeaderMode == modeSend {
 			if err = ocs.sendToProcessor(ocs.requestHeaders(outgoingMD, added)); err != nil {
-				return ocs.handleInitError(err, newStream, opts...)
+				return ocs.handleInitError(fmt.Errorf("failed to send client headers to external processor server: %w", err), newStream, opts...)
 			}
 		}
 
@@ -491,7 +492,7 @@ func (i *clientInterceptor) NewStream(ctx context.Context, ri resolver.RPCInfo, 
 			if err == io.EOF {
 				_, err = cs.procStream.Recv()
 			}
-			return cs.handleInitError(err, newStream, opts...)
+			return cs.handleInitError(fmt.Errorf("failed to send client headers to external processor server: %w", err), newStream, opts...)
 		}
 	} else {
 		if err = cs.createDataplaneStream(cs.ctx, newStream, opts); err != nil {
@@ -555,10 +556,14 @@ func (cs *commonStream) recordMetric(handle *estats.Float64HistoHandle, duration
 // processor stream in NewStream. In deny mode, it returns an internal error. In
 // allow mode, it bypasses the external processor and creates and returns the
 // dataplane stream directly.
+//
+// The error passed into handleInitError is a wrapped error and must not be
+// returned directly to the caller to avoid exposing it as part of the public
+// API.
 func (cs *commonStream) handleInitError(err error, newStream func(context.Context, ...grpc.CallOption) (grpc.ClientStream, error), opts ...grpc.CallOption) (grpc.ClientStream, error) {
 	cs.procCancel()
 
-	if err != io.EOF && !cs.config.failureModeAllow {
+	if !errors.Is(err, io.EOF) && !cs.config.failureModeAllow {
 		cs.cancel()
 		return nil, status.Errorf(codes.Internal, "extproc: %v", err)
 	}

--- a/internal/xds/httpfilter/extproc/ext_proc_ext_test.go
+++ b/internal/xds/httpfilter/extproc/ext_proc_ext_test.go
@@ -5033,12 +5033,12 @@ func (s) TestExtProcChannelRetention_XDSConfigUpdate(t *testing.T) {
 
 			client := testgrpc.NewTestServiceClient(cc)
 
+			errChan := make(chan error, 1)
 			// Make the first RPC using extproc server 1 in a background goroutine.
 			// The RPC remains in flight because the backend is blocked on blockChan.
 			go func() {
-				if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
-					t.Errorf("First EmptyCall() failed: %v", err)
-				}
+				_, err := client.EmptyCall(ctx, &testpb.Empty{})
+				errChan <- err
 			}()
 
 			<-enteredChan
@@ -5071,6 +5071,15 @@ func (s) TestExtProcChannelRetention_XDSConfigUpdate(t *testing.T) {
 			// Unblock the first RPC so that it completes and invokes OnFinish.
 			close(blockChan)
 
+			// Wait for the first RPC to complete.
+			select {
+			case err := <-errChan:
+				if err != nil {
+					t.Errorf("First EmptyCall() failed: %v", err)
+				}
+			case <-time.After(defaultTestTimeout):
+				t.Fatalf("Timeout waiting for first RPC to complete")
+			}
 			// Verify that proc channel 1 is now closed.
 			select {
 			case addr := <-closeChan:


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/9310

This PR has the following changes: 
1. Waits for the RPC in TestExtProcChannelRetention_XDSConfigUpdate to complete before checking interceptor close. The test was flaking because the test was ending and the background RPC's was not complete and context was being cancelled.
2. Pass direct errors to error handling functions instead of wrapping them to ensure correct stream bypass or failure.

RELEASE NOTES: None