### PR TITLE
authz: reject duplicate rule names in authorization policy

### DIFF
--- a/authz/rbac_translator.go
+++ b/authz/rbac_translator.go
@@ -278,6 +278,9 @@ func parseRules(rules []rule, prefixName string) (map[string]*v3rbacpb.Policy, e
 			return nil, fmt.Errorf("%d: %v", i, err)
 		}
 		policyName := prefixName + "_" + rule.Name
+		if _, ok := policies[policyName]; ok {
+			return nil, fmt.Errorf(`%d: "name" %q is duplicated`, i, rule.Name)
+		}
 		policies[policyName] = &v3rbacpb.Policy{
 			Principals:  []*v3rbacpb.Principal{parsePeer(rule.Source)},
 			Permissions: []*v3rbacpb.Permission{permission},

--- a/authz/rbac_translator_test.go
+++ b/authz/rbac_translator_test.go
@@ -948,6 +948,30 @@ func TestTranslatePolicy(t *testing.T) {
 			}`,
 			wantErr: `"allow_rules" 0: "headers" 0: unsupported "key" :method`,
 		},
+		"duplicate deny rule name": {
+			authzPolicy: `{
+				"name": "authz",
+				"deny_rules": [
+					{"name": "block", "request": {"paths": ["/admin.Admin/*"]}},
+					{"name": "block", "request": {"paths": ["/debug.Debug/*"]}}
+				],
+				"allow_rules": [{
+					"name": "allow_policy_1",
+					"request": {"paths": ["*"]}
+				}]
+			}`,
+			wantErr: `"deny_rules" 1: "name" "block" is duplicated`,
+		},
+		"duplicate allow rule name": {
+			authzPolicy: `{
+				"name": "authz",
+				"allow_rules": [
+					{"name": "allow_policy_1", "request": {"paths": ["/foo.Foo/*"]}},
+					{"name": "allow_policy_1", "request": {"paths": ["/bar.Bar/*"]}}
+				]
+			}`,
+			wantErr: `"allow_rules" 1: "name" "allow_policy_1" is duplicated`,
+		},
 		"bad audit condition": {
 			authzPolicy: `{
 				"name": "authz",


### PR DESCRIPTION
parseRules builds its map[string]*Policy keyed on the rule name, but two rules in the same list that share a name collapse to one entry: the second overwrites the first. For deny_rules that is fail-open, a deny the operator wrote is dropped and matching RPCs fall through to the allow policy, while translatePolicy still returns success and the file watcher logs a normal reload, so the lost rule is invisible downstream.

Reject a repeated name in parseRules, which is the last point that still has the rule list before it becomes a map. Both the deny and allow lists go through this function, so one check covers both, and an ambiguous policy is refused instead of silently discarding a rule.