### PR TITLE
server: remove code to suppress duplicate writing of status

### DIFF
--- a/server.go
+++ b/server.go
@@ -1390,7 +1390,7 @@ func (s *Server) processRPC(ctx context.Context, stream *transport.ServerStream,
 		ss.decompressorV1 = encoding.GetCompressor(rc)
 		if ss.decompressorV1 == nil {
 			st := status.Newf(codes.Unimplemented, "grpc: Decompressor is not installed for grpc-encoding %q", rc)
-			ss.writeStatus(st)
+			ss.s.WriteStatus(st)
 			return st.Err()
 		}
 	}
@@ -1473,7 +1473,7 @@ func (s *Server) processRPC(ctx context.Context, stream *transport.ServerStream,
 				binlog.Log(ctx, st)
 			}
 		}
-		if err := ss.writeStatus(appStatus); err != nil {
+		if err := ss.s.WriteStatus(appStatus); err != nil {
 			channelz.Warningf(logger, s.channelz, "grpc: Server.processRPC failed to write status: %v", err)
 		}
 		return appErr
@@ -1492,7 +1492,7 @@ func (s *Server) processRPC(ctx context.Context, stream *transport.ServerStream,
 			binlog.Log(ctx, st)
 		}
 	}
-	if err := ss.writeStatus(statusOK); err != nil {
+	if err := ss.s.WriteStatus(statusOK); err != nil {
 		channelz.Warningf(logger, s.channelz, "grpc: Server.processRPC failed to write status: %v", err)
 	}
 	return err

--- a/server_test.go
+++ b/server_test.go
@@ -24,8 +24,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -233,45 +231,5 @@ func BenchmarkChainStreamInterceptor(b *testing.B) {
 				}
 			}
 		})
-	}
-}
-
-// Test verifies that writeStatus writes the status exactly once.
-func (s) TestServerStream_WriteStatus_Concurrency(t *testing.T) {
-	// To avoid setting up a heavy transport layer, this test leaves
-	// serverStream.s as nil. The first goroutine to successfully CAS will
-	// attempt to call WriteStatus on the nil stream, triggering a panic. This
-	// serves as our signal that the CAS check was bypassed. All subsequent or
-	// concurrent calls must fail the CAS and return without panicking.
-	ss := &serverStream{}
-
-	const numGoroutines = 100
-	var panicCount, successCount atomic.Int32
-	start := make(chan struct{})
-	var wg sync.WaitGroup
-	for range numGoroutines {
-		wg.Go(func() {
-			<-start // synchronize start
-
-			defer func() {
-				if r := recover(); r != nil {
-					panicCount.Add(1)
-				}
-			}()
-
-			if err := ss.writeStatus(nil); err == nil {
-				successCount.Add(1)
-			}
-		})
-	}
-
-	close(start) // start all goroutines
-	wg.Wait()
-
-	if panicCount.Load() != 1 {
-		t.Fatalf("Got %d panics, want exactly 1", panicCount.Load())
-	}
-	if successCount.Load() != numGoroutines-1 {
-		t.Fatalf("Got %d successful calls, want %d", successCount.Load(), numGoroutines-1)
 	}
 }

--- a/stream.go
+++ b/stream.go
@@ -28,7 +28,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"google.golang.org/grpc/balancer"
@@ -1732,8 +1731,6 @@ type serverStream struct {
 	// synchronized.
 	serverHeaderBinlogged bool
 
-	statusWritten atomic.Bool // True if status has been written to the transport.
-
 	mu sync.Mutex // protects trInfo.tr after the service handler runs.
 }
 
@@ -1782,16 +1779,6 @@ func (ss *serverStream) SetTrailer(md metadata.MD) {
 	ss.s.SetTrailer(md)
 }
 
-// writeStatus sends the status of a stream to the client. It uses an atomic
-// CAS to guarantee that the status is written to the transport exactly once,
-// even if called concurrently.
-func (ss *serverStream) writeStatus(st *status.Status) error {
-	if !ss.statusWritten.CompareAndSwap(false, true) {
-		return nil
-	}
-	return ss.s.WriteStatus(st)
-}
-
 func (ss *serverStream) SendMsg(m any) (err error) {
 	defer func() {
 		if ss.trInfo != nil {
@@ -1808,7 +1795,7 @@ func (ss *serverStream) SendMsg(m any) (err error) {
 		}
 		if err != nil && err != io.EOF {
 			st, _ := status.FromError(toRPCErr(err))
-			ss.writeStatus(st)
+			ss.s.WriteStatus(st)
 			// Non-user specified status was sent out. This should be an error
 			// case (as a server side Cancel maybe).
 			//
@@ -1891,7 +1878,7 @@ func (ss *serverStream) RecvMsg(m any) (err error) {
 		}
 		if err != nil && err != io.EOF {
 			st, _ := status.FromError(toRPCErr(err))
-			ss.writeStatus(st)
+			ss.s.WriteStatus(st)
 			// Non-user specified status was sent out. This should be an error
 			// case (as a server side Cancel maybe).
 			//


### PR DESCRIPTION
Follow-up from https://github.com/grpc/grpc-go/pull/9309.

The transport currently handles duplicate status write suppression. There is no need to add a further check in the gRPC layer without having an explicit reason for it. Maybe there is some edge case that requires it. So, removing it.

RELEASE NOTES: none