### PR TITLE
balancer/ringhash: fix flaky TestRingHash_RequestHashKeyConnecting

### DIFF
--- a/balancer/ringhash/ringhash_e2e_test.go
+++ b/balancer/ringhash/ringhash_e2e_test.go
@@ -27,7 +27,7 @@ import (
 	"net"
 	"slices"
 	"strconv"
-	"sync"
+	"strings"
 	"testing"
 	"time"
 
@@ -2807,9 +2807,10 @@ func (s) TestRingHash_RequestHashKeyRandom(t *testing.T) {
 }
 
 // Tests that when a request hash key is set in the balancer configuration via
-// service config, and the header is not set in the outgoing request (random
-// behavior), then each RPC wakes up at most one SubChannel, and, if there are
-// SubChannels in Ready state, RPCs are routed to them.
+// service config, and the header is not set in the outgoing request, so the
+// picker uses a random hash, an RPC sent while an endpoint is already
+// connecting is queued instead of triggering a second connection attempt. Once
+// an endpoint reaches Ready, RPCs are routed to it.
 func (s) TestRingHash_RequestHashKeyConnecting(t *testing.T) {
 	testutils.SetEnvConfig(t, &envconfig.RingHashSetRequestHashKey, true)
 
@@ -2856,18 +2857,18 @@ func (s) TestRingHash_RequestHashKeyConnecting(t *testing.T) {
 		holds = append(holds, blockingDialer.Hold(backends[i]))
 	}
 
-	wg := sync.WaitGroup{}
-	wg.Add(1)
+	// Send 1 RPC and make sure this triggers exactly 1 connection attempt. The
+	// RPC stays blocked in the picker until that attempt is unblocked below.
+	errCh := make(chan error, 1)
 	go func() {
-		// Send 1 RPC and make sure this triggers at most 1 connection attempt.
 		_, err := client.EmptyCall(ctx, &testpb.Empty{})
-		if err != nil {
-			t.Errorf("EmptyCall(): got %v, want success", err)
-		}
-		wg.Done()
+		errCh <- err
 	}()
 
-	// Wait for at least one connection attempt.
+	// Wait for the first connection attempt to reach the dialer. pickfirst
+	// reports Connecting to the channel before calling SubConn.Connect(), so
+	// by the time the dialer is entered, ring_hash has already published a
+	// picker that knows an endpoint is connecting.
 	nConn := 0
 	for nConn == 0 {
 		if ctx.Err() != nil {
@@ -2880,42 +2881,59 @@ func (s) TestRingHash_RequestHashKeyConnecting(t *testing.T) {
 			}
 		}
 	}
-	if wantMaxConn := 1; nConn > wantMaxConn {
-		t.Fatalf("Got %d connection attempts, want at most %d", nConn, wantMaxConn)
+	if wantConn := 1; nConn != wantConn {
+		t.Fatalf("Got %d connection attempts, want %d", nConn, wantConn)
 	}
 
-	// Do a second RPC. Since there should already be a SubChannel in
-	// Connecting state, this should not trigger a connection attempt.
-	wg.Add(1)
-	go func() {
-		_, err := client.EmptyCall(ctx, &testpb.Empty{})
-		if err != nil {
-			t.Errorf("EmptyCall(): got %v, want success", err)
-		}
-		wg.Done()
-	}()
+	// Do a second RPC on this goroutine, so that its pick happens here instead
+	// of racing the assertions below. Since there is already an endpoint in
+	// Connecting state, the picker must queue the RPC rather than trigger
+	// another connection attempt, so the RPC fails with DeadlineExceeded.
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
+	_, err = client.EmptyCall(sCtx, &testpb.Empty{}, grpc.WaitForReady(true))
+	sCancel()
+	if got, want := status.Code(err), codes.DeadlineExceeded; got != want {
+		t.Fatalf("EmptyCall(): got code %v, want %v", got, want)
+	}
+	// Verify the RPC failed while blocked in the picker rather than before
+	// reaching it, otherwise the check below would not be testing anything.
+	if want := "while waiting for connections to become ready"; !strings.Contains(status.Convert(err).Message(), want) {
+		t.Fatalf("EmptyCall(): got error %q, want it to contain %q", status.Convert(err).Message(), want)
+	}
 
-	// Give extra time for more connections to be attempted.
-	time.Sleep(defaultTestShortTimeout)
-
-	var firstConnectedBackend string
+	// Count the connection attempts before unblocking any of them. Resuming a
+	// hold moves the channel to Ready, which lets the queued RPCs pick again
+	// and legitimately start one more connection attempt on an idle endpoint
+	// per gRFC A76, so this count is only meaningful while every attempt is
+	// still blocked.
 	nConn = 0
+	firstConnIdx := -1
 	for i, hold := range holds {
 		if hold.IsStarted() {
-			// Unblock the connection attempt. The SubChannel (and hence the
-			// channel) should transition to Ready. RPCs should succeed and
-			// be routed to this backend.
-			hold.Resume()
-			holds[i] = nil
-			firstConnectedBackend = backends[i]
 			nConn++
+			firstConnIdx = i
 		}
 	}
-	if wantMaxConn := 1; nConn > wantMaxConn {
-		t.Fatalf("Got %d connection attempts, want at most %d", nConn, wantMaxConn)
+	if wantConn := 1; nConn != wantConn {
+		t.Fatalf("Got %d connection attempts, want %d", nConn, wantConn)
 	}
+
+	// Unblock the connection attempt. The SubChannel (and hence the channel)
+	// should transition to Ready. RPCs should succeed and be routed to this
+	// backend.
+	firstConnectedBackend := backends[firstConnIdx]
+	holds[firstConnIdx].Resume()
+	holds[firstConnIdx] = nil
+
 	testutils.AwaitState(ctx, t, cc, connectivity.Ready)
-	wg.Wait() // Make sure we're done with the 2 previous RPCs.
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("EmptyCall(): got %v, want success", err)
+		}
+	case <-ctx.Done():
+		t.Fatal("Test timed out waiting for the first RPC to complete")
+	}
 
 	// Now send RPCs until we have at least one more connection attempt, that
 	// is, the random hash did not land on the same backend on every pick (the

--- a/balancer/ringhash/ringhash_e2e_test.go
+++ b/balancer/ringhash/ringhash_e2e_test.go
@@ -2829,7 +2829,6 @@ func (s) TestRingHash_RequestHashKeyConnecting(t *testing.T) {
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithResolvers(r),
 		grpc.WithDefaultServiceConfig(ringHashServiceConfig),
-		grpc.WithConnectParams(fastConnectParams),
 		grpc.WithContextDialer(blockingDialer.DialContext),
 	}
 	cc, err := grpc.NewClient(r.Scheme()+":///test.server", dopts...)
@@ -2889,7 +2888,13 @@ func (s) TestRingHash_RequestHashKeyConnecting(t *testing.T) {
 	// of racing the assertions below. Since there is already an endpoint in
 	// Connecting state, the picker must queue the RPC rather than trigger
 	// another connection attempt, so the RPC fails with DeadlineExceeded.
-	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
+	//
+	// The deadline must leave the RPC enough time to reach the picker on a
+	// loaded machine, otherwise it fails before the pick with a plain context
+	// error. It is not shared with the other tests because the RPC blocks for
+	// the whole duration on every run.
+	const secondRPCTimeout = 100 * time.Millisecond
+	sCtx, sCancel := context.WithTimeout(ctx, secondRPCTimeout)
 	_, err = client.EmptyCall(sCtx, &testpb.Empty{}, grpc.WaitForReady(true))
 	sCancel()
 	if got, want := status.Code(err), codes.DeadlineExceeded; got != want {


### PR DESCRIPTION
Fixes #9030

`TestRingHash_RequestHashKeyConnecting` counts connection attempts in the same loop that resumes the blocked one, so it can count an attempt that its own `Resume()` caused. Resuming makes the endpoint READY, ring_hash publishes a
picker with `hasEndpointInConnectingState` false, and the queued RPCs pick again and start a connection to one idle endpoint along the ring walk, which is what gRFC A76 asks for (picker.go:93-115). If the loop is still scanning when that
dial reaches the blocking dialer it counts that attempt and the test fails. Both failures linked from the issue show the second subchannel being created after the resume, never before it.

The fix orders the phase so the assertion cannot observe something the test itself caused:

1. First RPC in a goroutine, wait for a hold to be entered.
2. Count all 20 holds, want exactly 1.
3. Second RPC on the test goroutine, short deadline, `WaitForReady(true)`, want `DeadlineExceeded`.
4. Count all 20 holds again, want exactly 1.
5. Only then resume the single started hold.

Both counts precede any `Resume()`. Only two pickers can exist before that point and a pick against either cannot start a second connection attempt, so `at most 1` is tightened to `exactly 1` and the fixed 10ms sleep is removed. I proved this
with a throwaway instrument that forces the CI interleaving deterministically (current loop fails 100 of 100, this change 0 of 100), and also reproduced the flake organically under core pinning (current 2 of 300, this change 0 of 2000).
The CI log ordering, the picker state argument and the full numbers are in the first comment.

### Relation to #9079

#9079 split the counting loop from the resume loop and made the second RPC synchronous. Both are right and both are kept here. Its stated cause was that the second RPC could reach the picker before the balancer had recorded the endpoint
as connecting; I could not reproduce that and I do not think it can happen, for the reasons in the first comment. The `AwaitState(ctx, t, cc, connectivity.Connecting)` it added is not carried over, because `exitIdleMode` sets the channel to CONNECTING before the resolver is started (clientconn.go:402), so that wait is already satisfied while ring_hash has reported nothing.

#9079 was closed by its author saying the test has multiple race conditions that cannot all be fixed, and that other tests in this file are flaky too. I am not claiming otherwise. This addresses the one mechanism that both linked failures
show and that reproduces locally. I have not tried to make the file as a whole race free.

### Also in this diff

The one remaining background RPC reports through a buffered channel instead of calling `t.Errorf`, matching lines 1945-1964 of this file, since a `t.Fatalf` in the test goroutine could otherwise produce a log from the background goroutine after the test finished. The doc comment now describes what the test checks.

### One review point

The check that the second RPC blocked in the picker matches on the message substring from picker_wrapper.go:129. The idiom is used elsewhere in the repo (test/roundrobin_test.go:125), but the string belongs to another package. Nothing
in the fix depends on it, so it can be dropped if unwanted.

RELEASE NOTES: n/a
