### PR TITLE
credentials/alts: preserve boundAccessToken in altsTC.Clone

### DIFF
--- a/credentials/alts/alts.go
+++ b/credentials/alts/alts.go
@@ -266,10 +266,11 @@ func (g *altsTC) Clone() credentials.TransportCredentials {
 		copy(accounts, g.accounts)
 	}
 	return &altsTC{
-		info:      &info,
-		side:      g.side,
-		hsAddress: g.hsAddress,
-		accounts:  accounts,
+		info:             &info,
+		side:             g.side,
+		hsAddress:        g.hsAddress,
+		accounts:         accounts,
+		boundAccessToken: g.boundAccessToken,
 	}
 }
 

--- a/credentials/alts/alts_test.go
+++ b/credentials/alts/alts_test.go
@@ -91,6 +91,7 @@ func (s) TestCloneClient(t *testing.T) {
 	opt := DefaultClientOptions()
 	opt.TargetServiceAccounts = []string{"not", "empty"}
 	c := NewClientCreds(opt)
+	c.(*altsTC).boundAccessToken = "bound-access-token"
 	c.OverrideServerName(wantServerName)
 	cc := c.Clone()
 	if got, want := cc.Info().ServerName, wantServerName; got != want {
@@ -115,6 +116,9 @@ func (s) TestCloneClient(t *testing.T) {
 	}
 	if !reflect.DeepEqual(ct.accounts, cct.accounts) {
 		t.Errorf("cc.accounts = %q, want %q", cct.accounts, ct.accounts)
+	}
+	if ct.boundAccessToken != cct.boundAccessToken {
+		t.Errorf("cc.boundAccessToken = %q, want %q", cct.boundAccessToken, ct.boundAccessToken)
 	}
 }
 


### PR DESCRIPTION
### Summary

`altsTC.Clone` does not copy `boundAccessToken`, so a cloned ALTS credential silently loses the token and performs its handshake without it.

### Detail

`boundAccessToken` was added to the `altsTC` struct in 00be1e13, "[alts] Add plumbing for the bound access token field in the ALTS Start". That commit added the field and consumed it in `ClientHandshake`:

```go
 type altsTC struct {
-	info      *credentials.ProtocolInfo
-	side      core.Side
-	accounts  []string
-	hsAddress string
+	info             *credentials.ProtocolInfo
+	side             core.Side
+	accounts         []string
+	hsAddress        string
+	boundAccessToken string
 }
...
+	opts.BoundAccessToken = g.boundAccessToken
```

but it did not update `Clone`, which still copies only the four original fields:

```go
func (g *altsTC) Clone() credentials.TransportCredentials {
	...
	return &altsTC{
		info:      &info,
		side:      g.side,
		hsAddress: g.hsAddress,
		accounts:  accounts,
	}
}
```

`Clone` is part of the exported `credentials.TransportCredentials` interface, and grpc-go calls it internally, for example when building the RLS control channel in `balancer/rls/control_channel.go`:

```go
credsOpt = grpc.WithTransportCredentials(bOpts.DialCreds.Clone())
```

so a clone taken there would hand the handshaker an empty `BoundAccessToken`.

To be upfront about reachability: there is currently no exported setter for `boundAccessToken`, so today it is only assigned in tests and the field is always empty in production. This is a latent bug in the plumbing rather than one users can hit right now, but it will bite as soon as a setter lands, and `Clone` dropping a field it should carry is wrong regardless.

### Change

One field added to the struct literal in `Clone`.

### Testing

`TestCloneClient` already asserts on `side`, `hsAddress` and `accounts`, so I extended it to cover `boundAccessToken` alongside them. Without the fix it fails:

```
alts_test.go:121: cc.boundAccessToken = "", want "bound-access-token"
```

With the fix, `go test ./credentials/alts/...` passes for the whole tree and `go vet ./credentials/alts/...` is clean.


RELEASE NOTES: none