### PR TITLE
stream: group bool fields at tail of serverStream, csAttempt, addrConnStream [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -746,10 +746,8 @@ type csAttempt struct {
 	parser          parser
 	pickResult      balancer.PickResult
 
-	finished        bool
-	decompressorV0  Decompressor
-	decompressorV1  encoding.Compressor
-	decompressorSet bool
+	decompressorV0 Decompressor
+	decompressorV1 encoding.Compressor
 
 	mu sync.Mutex // guards trInfo.tr
 	// trInfo may be nil (if EnableTracing is false).
@@ -760,10 +758,18 @@ type csAttempt struct {
 	statsHandler stats.Handler
 	beginTime    time.Time
 
-	// set for newStream errors that may be transparently retried
-	allowTransparentRetry bool
-	// set for pick errors that are returned as a status
-	drop bool
+	// Bool fields are grouped at the tail to eliminate the alignment padding
+	// that would otherwise follow each bool when the next field is pointer- or
+	// int-sized. See https://github.com/grpc/grpc-go/issues/9280 for benchmarks.
+	// Add new bool fields here, not inline above.
+
+	// Not guarded by mu.
+	decompressorSet bool
+
+	// Guarded by mu.
+	finished               bool
+	allowTransparentRetry  bool
+	drop                   bool
 }
 
 func (cs *clientStream) commitAttemptLocked() {
@@ -1491,19 +1497,28 @@ type addrConnStream struct {
 	callInfo         *callInfo
 	transport        transport.ClientTransport
 	ctx              context.Context
-	sentLast         bool
-	receivedFirstMsg bool
 	desc             *StreamDesc
 	codec            baseCodec
 	sendCompressorV0 Compressor
 	sendCompressorV1 encoding.Compressor
-	decompressorSet  bool
 	decompressorV0   Decompressor
 	decompressorV1   encoding.Compressor
 	parser           parser
 
 	// mu guards finished and is held for the entire finish method.
-	mu       sync.Mutex
+	mu sync.Mutex
+
+	// Bool fields are grouped at the tail to eliminate the alignment padding
+	// that would otherwise follow each bool when the next field is pointer- or
+	// int-sized. See https://github.com/grpc/grpc-go/issues/9280 for benchmarks.
+	// Add new bool fields here, not inline above.
+
+	// Not guarded by mu.
+	sentLast         bool
+	receivedFirstMsg bool
+	decompressorSet  bool
+
+	// Guarded by mu.
 	finished bool
 }
 
@@ -1719,8 +1734,6 @@ type serverStream struct {
 
 	sendCompressorName string
 
-	recvFirstMsg bool // set after the first message is received
-
 	maxReceiveMessageSize int
 	maxSendMessageSize    int
 	trInfo                *traceInfo
@@ -1728,6 +1741,16 @@ type serverStream struct {
 	statsHandler stats.Handler
 
 	binlogs []binarylog.MethodLogger
+
+	mu sync.Mutex // protects trInfo.tr after the service handler runs.
+
+	// Bool fields are grouped at the tail to eliminate the alignment padding
+	// that would otherwise follow each bool when the next field is pointer- or
+	// int-sized. See https://github.com/grpc/grpc-go/issues/9280 for benchmarks.
+	// Add new bool fields here, not inline above.
+
+	// Not guarded by mu.
+	recvFirstMsg bool // set after the first message is received
 	// serverHeaderBinlogged indicates whether server header has been logged. It
 	// will happen when one of the following two happens: stream.SendHeader(),
 	// stream.Send().
@@ -1735,8 +1758,6 @@ type serverStream struct {
 	// It's only checked in send and sendHeader, doesn't need to be
 	// synchronized.
 	serverHeaderBinlogged bool
-
-	mu sync.Mutex // protects trInfo.tr after the service handler runs.
 }
 
 func (ss *serverStream) Context() context.Context {

--- a/stream_test.go
+++ b/stream_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unsafe"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -233,5 +234,32 @@ func (s) TestDefaultStreamInterceptor(t *testing.T) {
 	}
 	if !iStream.closeSend {
 		t.Fatal("CloseSend not called after SendMsg on non-client-streaming RPC")
+	}
+}
+
+// TestServerStreamSize verifies that serverStream's bool fields are grouped at
+// the tail of the struct to avoid alignment padding. If this test fails, add
+// new bool fields in the grouped section, not inline.
+func (s) TestServerStreamSize(t *testing.T) {
+	if sz := unsafe.Sizeof(serverStream{}); sz > 256 {
+		t.Fatalf("serverStream size = %d, want <= 256 (add new bool fields to the grouped section in stream.go)", sz)
+	}
+}
+
+// TestCsAttemptSize verifies that csAttempt's bool fields are grouped at the
+// tail of the struct to avoid alignment padding. If this test fails, add new
+// bool fields in the grouped section, not inline.
+func (s) TestCsAttemptSize(t *testing.T) {
+	if sz := unsafe.Sizeof(csAttempt{}); sz > 232 {
+		t.Fatalf("csAttempt size = %d, want <= 232 (add new bool fields to the grouped section in stream.go)", sz)
+	}
+}
+
+// TestAddrConnStreamSize verifies that addrConnStream's bool fields are grouped
+// at the tail of the struct to avoid alignment padding. If this test fails, add
+// new bool fields in the grouped section, not inline.
+func (s) TestAddrConnStreamSize(t *testing.T) {
+	if sz := unsafe.Sizeof(addrConnStream{}); sz > 256 {
+		t.Fatalf("addrConnStream size = %d, want <= 256 (add new bool fields to the grouped section in stream.go)", sz)
 	}
 }


### PR DESCRIPTION
Reorder `serverStream`, `csAttempt`, and `addrConnStream` fields so all bool fields are grouped at the tail of each struct. Add `(s).TestServerStreamSize`, `(s).TestCsAttemptSize`, and `(s).TestAddrConnStreamSize` to guard against regressions.

## Why

See #9347, #9348, #9349 for the complete struct layout analysis. The same pattern was fixed for `clientStream` in #9280/#9281.

Each struct had `bool` fields scattered among pointer- and interface-sized fields. Each bool was followed by 3–7 bytes of alignment padding before the next 4- or 8-byte-aligned field.

Additionally, `decompressorSet` at offset 160 in `csAttempt` shared a 64-byte cache line with `mu` at offset 164, causing false-sharing overhead on every `mu.Lock()` under concurrent load.

Grouping all bools at the tail packs them into contiguous bytes, eliminating the padding. Lock discipline is preserved: `// Not guarded by mu` and `// Guarded by mu` sections reflect the original access patterns.

## Changes

1. **serverStream** (fixes #9349): move `recvFirstMsg` and `serverHeaderBinlogged` to the tail, after `mu`.
2. **csAttempt** (fixes #9347): move `finished`, `decompressorSet`, `allowTransparentRetry`, `drop` to the tail, after `mu`.
3. **addrConnStream** (fixes #9348): move `sentLast`, `receivedFirstMsg`, `decompressorSet`, `finished` to the tail, after `mu`.
4. **stream_test.go**: add size guard tests for all three structs.

## Code clarity

A comment in each struct explains the layout rationale and points to #9280. The size guard tests give a clear error message directing future contributors to add new bool fields in the grouped section.

Closes #9347, #9348, #9349.

RELEASE NOTES:
* core: reorder `serverStream`, `csAttempt`, `addrConnStream` bool fields to reduce struct size and eliminate false sharing between bool fields and `sync.Mutex`. (grpc/grpc-go#9347, grpc/grpc-go#9348, grpc/grpc-go#9349)