### PR TITLE
xds: lowercase RDS route header matcher names before matching

### DIFF
--- a/internal/xds/xdsclient/xdsresource/unmarshal_rds.go
+++ b/internal/xds/xdsclient/xdsresource/unmarshal_rds.go
@@ -301,8 +301,7 @@ func routesProtoToSlice(routes []*v3routepb.Route, csps map[string]clusterspecif
 			}
 			// The metadata the matchers run against always has lowercase keys,
 			// so a name that contains an uppercase character matches no header
-			// and the route holding it never fires. Lowercase the name, as
-			// Envoy and the RBAC filter do.
+			// and the route holding it never fires.
 			header.Name = strings.ToLower(h.GetName())
 			invert := h.GetInvertMatch()
 			header.InvertMatch = &invert

--- a/internal/xds/xdsclient/xdsresource/unmarshal_rds.go
+++ b/internal/xds/xdsclient/xdsresource/unmarshal_rds.go
@@ -299,7 +299,11 @@ func routesProtoToSlice(routes []*v3routepb.Route, csps map[string]clusterspecif
 				}
 				header.StringMatch = &sm
 			}
-			header.Name = h.GetName()
+			// The metadata the matchers run against always has lowercase keys,
+			// so a name that contains an uppercase character matches no header
+			// and the route holding it never fires. Lowercase the name, as
+			// Envoy and the RBAC filter do.
+			header.Name = strings.ToLower(h.GetName())
 			invert := h.GetInvertMatch()
 			header.InvertMatch = &invert
 			route.Headers = append(route.Headers, &header)

--- a/internal/xds/xdsclient/xdsresource/unmarshal_rds_test.go
+++ b/internal/xds/xdsclient/xdsresource/unmarshal_rds_test.go
@@ -37,7 +37,6 @@ import (
 	"google.golang.org/grpc/internal/xds/httpfilter"
 	"google.golang.org/grpc/internal/xds/matcher"
 	"google.golang.org/grpc/internal/xds/xdsclient/xdsresource/version"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -1781,41 +1780,6 @@ func (s) TestRoutesProtoToSlice(t *testing.T) {
 				t.Fatalf("routesProtoToSlice() returned unexpected diff (-got +want):\n%s", diff)
 			}
 		})
-	}
-}
-
-// TestRoutesProtoToSliceHeaderMatcherNameCase verifies that a route whose
-// header matcher name is not lowercase still matches an RPC carrying that
-// header. Metadata keys are always lowercase, so the name has to be
-// normalized when the route configuration is parsed.
-func (s) TestRoutesProtoToSliceHeaderMatcherNameCase(t *testing.T) {
-	routes := []*v3routepb.Route{{
-		Match: &v3routepb.RouteMatch{
-			PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"},
-			Headers: []*v3routepb.HeaderMatcher{{
-				Name:                 "X-Role",
-				HeaderMatchSpecifier: &v3routepb.HeaderMatcher_ExactMatch{ExactMatch: "admin"},
-			}},
-		},
-		Action: &v3routepb.Route_Route{
-			Route: &v3routepb.RouteAction{ClusterSpecifier: &v3routepb.RouteAction_Cluster{Cluster: clusterName}},
-		},
-	}}
-
-	got, _, err := routesProtoToSlice(routes, nil, nil, nil)
-	if err != nil {
-		t.Fatalf("routesProtoToSlice() failed: %v", err)
-	}
-	if len(got) != 1 || len(got[0].Headers) != 1 {
-		t.Fatalf("routesProtoToSlice() = %v, want one route holding one header matcher", got)
-	}
-	if gotName, wantName := got[0].Headers[0].Name, "x-role"; gotName != wantName {
-		t.Errorf("Parsed header matcher name = %q, want %q", gotName, wantName)
-	}
-
-	md := metadata.Pairs("x-role", "admin")
-	if !RouteToMatcher(got[0]).Match("/some.Service/Method", md) {
-		t.Errorf("RouteToMatcher(...).Match(%v) = false, want true", md)
 	}
 }
 

--- a/internal/xds/xdsclient/xdsresource/unmarshal_rds_test.go
+++ b/internal/xds/xdsclient/xdsresource/unmarshal_rds_test.go
@@ -37,6 +37,7 @@ import (
 	"google.golang.org/grpc/internal/xds/httpfilter"
 	"google.golang.org/grpc/internal/xds/matcher"
 	"google.golang.org/grpc/internal/xds/xdsclient/xdsresource/version"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -1344,6 +1345,32 @@ func (s) TestRoutesProtoToSlice(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "header specifier with a name that is not lowercase",
+			routes: []*v3routepb.Route{{
+				Match: &v3routepb.RouteMatch{
+					PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/a/"},
+					Headers: []*v3routepb.HeaderMatcher{{
+						Name:                 "X-Role",
+						HeaderMatchSpecifier: &v3routepb.HeaderMatcher_ExactMatch{ExactMatch: "tv"},
+					}},
+				},
+				Action: &v3routepb.Route_Route{
+					Route: &v3routepb.RouteAction{ClusterSpecifier: &v3routepb.RouteAction_Cluster{Cluster: clusterName}},
+				},
+			}},
+			wantRoutes: []*Route{{
+				Prefix: newStringP("/a/"),
+				Headers: []*HeaderMatcher{{
+					Name:        "x-role",
+					InvertMatch: newBoolP(false),
+					StringMatch: &sm,
+				}},
+				WeightedClusters: []WeightedCluster{{Name: clusterName, Weight: 1}},
+				ActionType:       RouteActionRoute,
+			}},
+			wantErr: false,
+		},
+		{
 			name: "suffix_match header specifier",
 			routes: []*v3routepb.Route{{
 				Match: &v3routepb.RouteMatch{
@@ -1754,6 +1781,41 @@ func (s) TestRoutesProtoToSlice(t *testing.T) {
 				t.Fatalf("routesProtoToSlice() returned unexpected diff (-got +want):\n%s", diff)
 			}
 		})
+	}
+}
+
+// TestRoutesProtoToSliceHeaderMatcherNameCase verifies that a route whose
+// header matcher name is not lowercase still matches an RPC carrying that
+// header. Metadata keys are always lowercase, so the name has to be
+// normalized when the route configuration is parsed.
+func (s) TestRoutesProtoToSliceHeaderMatcherNameCase(t *testing.T) {
+	routes := []*v3routepb.Route{{
+		Match: &v3routepb.RouteMatch{
+			PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"},
+			Headers: []*v3routepb.HeaderMatcher{{
+				Name:                 "X-Role",
+				HeaderMatchSpecifier: &v3routepb.HeaderMatcher_ExactMatch{ExactMatch: "admin"},
+			}},
+		},
+		Action: &v3routepb.Route_Route{
+			Route: &v3routepb.RouteAction{ClusterSpecifier: &v3routepb.RouteAction_Cluster{Cluster: clusterName}},
+		},
+	}}
+
+	got, _, err := routesProtoToSlice(routes, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("routesProtoToSlice() failed: %v", err)
+	}
+	if len(got) != 1 || len(got[0].Headers) != 1 {
+		t.Fatalf("routesProtoToSlice() = %v, want one route holding one header matcher", got)
+	}
+	if gotName, wantName := got[0].Headers[0].Name, "x-role"; gotName != wantName {
+		t.Errorf("Parsed header matcher name = %q, want %q", gotName, wantName)
+	}
+
+	md := metadata.Pairs("x-role", "admin")
+	if !RouteToMatcher(got[0]).Match("/some.Service/Method", md) {
+		t.Errorf("RouteToMatcher(...).Match(%v) = false, want true", md)
 	}
 }
 


### PR DESCRIPTION
Fixes #9352

xDS RDS route header matchers store the header name verbatim from the config in `routesProtoToSlice`:

```go
header.Name = h.GetName()
```

The matcher engine looks that name up against `metadata.MD`, whose keys are always lowercase, so a matcher configured with a mixed-case name such as `X-Role` matches no header and the route never fires.

This is the last consumer of that matcher engine that does not normalize the name. The RBAC HTTP filter started lowercasing it at parse time in #9332 (`normalizeHeaderMatcher`), and `authz/rbac_translator.go` does the same on the non-xDS path. Envoy stores `HeaderMatcher.name` in a `Http::LowerCaseString`, so this is valid config that works on other proxies.

The fix lowercases the name where the route header matcher is built, matching the sibling paths. Added a table test covering a mixed-case name against lowercased metadata, and asserting the parsed matcher stores the lowercased name; it fails on `master` and passes with the change.

RELEASE NOTES:
* xds: fix RDS route header matchers with non-lowercase names never matching
