### PR TITLE
xds: guard against a missing :authority in the server routing interceptor

### DIFF
--- a/internal/xds/server/routing.go
+++ b/internal/xds/server/routing.go
@@ -61,12 +61,16 @@ func RouteAndProcess(ctx context.Context) error {
 	if !ok {
 		return errors.New("missing metadata in incoming context")
 	}
-	// A41 added logic to the core grpc implementation to guarantee that once
-	// the RPC gets to this point, there will be a single, unambiguous authority
-	// present in the header map.
-	authority := md.Get(":authority")
-	// authority[0] is safe because of the guarantee mentioned above.
-	vh := findBestMatchingVirtualHostServer(authority[0], rc.vhs)
+	// A41 renames a "host" header to ":authority" when ":authority" is absent,
+	// but a request that carries neither is still dispatched with no authority
+	// present (see the transport's handleData path), so this slice can be empty.
+	// Treat a missing authority as the empty string rather than indexing blindly,
+	// which would panic and take down the server.
+	var authority string
+	if a := md.Get(":authority"); len(a) > 0 {
+		authority = a[0]
+	}
+	vh := findBestMatchingVirtualHostServer(authority, rc.vhs)
 	if vh == nil {
 		return rc.statusErrWithNodeID(codes.Unavailable, "the incoming RPC did not match a configured Virtual Host")
 	}

--- a/internal/xds/server/routing_test.go
+++ b/internal/xds/server/routing_test.go
@@ -19,9 +19,15 @@
 package server
 
 import (
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/internal/transport"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 func (s) TestMatchTypeForDomain(t *testing.T) {
@@ -105,5 +111,45 @@ func (s) TestFindBestMatchingVirtualHost(t *testing.T) {
 				t.Errorf("findBestMatchingVirtualHostServer() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// stubServerTransportStream is a minimal ServerTransportStream so that
+// grpc.Method(ctx) returns a method name inside RouteAndProcess.
+type stubServerTransportStream struct {
+	method string
+}
+
+func (s *stubServerTransportStream) Method() string               { return s.method }
+func (s *stubServerTransportStream) SetHeader(metadata.MD) error  { return nil }
+func (s *stubServerTransportStream) SendHeader(metadata.MD) error { return nil }
+func (s *stubServerTransportStream) SetTrailer(metadata.MD) error { return nil }
+
+// TestRouteAndProcessMissingAuthority verifies that a request whose metadata
+// carries no ":authority" header (which the transport permits when neither
+// ":authority" nor "host" is present) does not panic the server. Before the
+// fix, RouteAndProcess indexed md.Get(":authority")[0] on an empty slice and
+// crashed the whole process.
+func (s) TestRouteAndProcessMissingAuthority(t *testing.T) {
+	urc := &atomic.Pointer[usableRouteConfiguration]{}
+	urc.Store(&usableRouteConfiguration{
+		vhs: []virtualHostWithInterceptors{{
+			domains: []string{"example.com"},
+			routes:  []routeWithInterceptors{},
+		}},
+	})
+	cw := &connWrapper{urc: urc}
+
+	ctx := transport.SetConnection(t.Context(), cw)
+	ctx = grpc.NewContextWithServerTransportStream(ctx, &stubServerTransportStream{method: "/foo.Service/Method"})
+	// Metadata with no ":authority" key — the case the transport allows through.
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{})
+
+	// Must not panic. No virtual host matches an empty authority, so we expect
+	// the "did not match a configured Virtual Host" Unavailable error rather
+	// than a crash.
+	err := RouteAndProcess(ctx)
+	if status.Code(err) != codes.Unavailable {
+		t.Errorf("RouteAndProcess() with no :authority = %v; want an Unavailable status (and no panic)", err)
 	}
 }


### PR DESCRIPTION
Fixes #9354

`RouteAndProcess` indexed `md.Get(":authority")[0]` on the assumption, stated in the comment there, that A41 guarantees a single `:authority` is always present by that point.

That guarantee has a gap. The transport only renames `host` → `:authority` when `host` is present (`internal/transport/http2_server.go`); a request that omits **both** `:authority` and `host` is still dispatched with no authority — the transport comment even notes "no eventual :authority header is a valid RPC". So `md.Get(":authority")` returns an empty slice and `authority[0]` panics. With no `recover` between `RouteAndProcess` and the serving goroutine, a single such request crashes the server.

This guards the index and treats a missing authority as the empty string, so it falls through to the normal "did not match a configured Virtual Host" path instead of crashing. I swept `internal/xds/server/` for other unconditional first-element indexes on request metadata; this was the only one.

Added a regression test that drives `RouteAndProcess` with metadata that has no `:authority`; it panics on `master` and passes with this change.

This was reported to Google OSS VRP first (tracker 551288012); they reviewed it and directed that it be fixed here on GitHub rather than via the security list.

RELEASE NOTES:
* xds: fix a crash in server-side xDS routing when a request omits the `:authority` header
