### PR TITLE
transport: reduce server header decoding allocations

### DIFF
--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -643,7 +643,7 @@ func (t *http2Server) HandleStreams(ctx context.Context, handle func(*ServerStre
 	}()
 	for {
 		t.controlBuf.throttle()
-		frame, err := t.framer.readFrame()
+		frame, err := t.framer.readServerFrame()
 		atomic.StoreInt64(&t.lastRead, time.Now().UnixNano())
 		if err != nil {
 			if se, ok := err.(http2.StreamError); ok {

--- a/internal/transport/http2_server_header.go
+++ b/internal/transport/http2_server_header.go
@@ -1,0 +1,298 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package transport
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/net/http/httpguts"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+const serverDefaultMaxHeaderListSize = 16 << 20
+
+type serverHeaderDecoder struct {
+	decoder           *hpack.Decoder
+	maxHeaderListSize uint32
+	frame             http2.MetaHeadersFrame
+	remainSize        uint32
+	sawRegular        bool
+	invalid           error
+	emit              func(hpack.HeaderField)
+}
+
+func newServerHeaderDecoder(decoder *hpack.Decoder, maxHeaderListSize uint32) *serverHeaderDecoder {
+	if maxHeaderListSize == 0 {
+		maxHeaderListSize = serverDefaultMaxHeaderListSize
+	}
+	d := &serverHeaderDecoder{
+		decoder:           decoder,
+		maxHeaderListSize: maxHeaderListSize,
+	}
+	d.emit = d.emitField
+	return d
+}
+
+func (d *serverHeaderDecoder) reset(frame *http2.HeadersFrame) {
+	clear(d.frame.Fields)
+	d.frame.HeadersFrame = frame
+	d.frame.Fields = d.frame.Fields[:0]
+	d.frame.Truncated = false
+	d.remainSize = d.maxHeaderListSize
+	d.sawRegular = false
+	d.invalid = nil
+
+	d.decoder.SetEmitEnabled(true)
+	maxStringLength := int(d.maxHeaderListSize)
+	if maxStringLength < 0 {
+		maxStringLength = 0
+	}
+	d.decoder.SetMaxStringLength(maxStringLength)
+	d.decoder.SetEmitFunc(d.emit)
+}
+
+func (d *serverHeaderDecoder) emitField(field hpack.HeaderField) {
+	if !httpguts.ValidHeaderFieldValue(field.Value) {
+		d.invalid = fmt.Errorf(
+			"invalid header field value for %q",
+			field.Name,
+		)
+	}
+
+	if strings.HasPrefix(field.Name, ":") {
+		if d.sawRegular {
+			d.invalid = errors.New(
+				"pseudo header field after regular",
+			)
+		}
+	} else {
+		d.sawRegular = true
+		if !validServerWireHeaderFieldName(field.Name) {
+			d.invalid = fmt.Errorf(
+				"invalid header field name %q",
+				field.Name,
+			)
+		}
+	}
+
+	if d.invalid != nil {
+		d.decoder.SetEmitEnabled(false)
+		return
+	}
+
+	size := field.Size()
+	if size > d.remainSize {
+		d.decoder.SetEmitEnabled(false)
+		d.frame.Truncated = true
+		d.remainSize = 0
+		return
+	}
+
+	d.remainSize -= size
+	d.frame.Fields = append(d.frame.Fields, field)
+}
+
+func (d *serverHeaderDecoder) read(
+	f *framer,
+	header http2.FrameHeader,
+) (*http2.MetaHeadersFrame, error) {
+	metaDecoder := f.fr.ReadMetaHeaders
+	f.fr.ReadMetaHeaders = nil
+
+	frame, err := f.fr.ReadFrameForHeader(header)
+
+	f.fr.ReadMetaHeaders = metaDecoder
+
+	if err != nil {
+		f.errDetail = f.fr.ErrorDetail()
+		return nil, err
+	}
+
+	headers, ok := frame.(*http2.HeadersFrame)
+	if !ok {
+		return nil, fmt.Errorf(
+			"decoded %T, want *http2.HeadersFrame",
+			frame,
+		)
+	}
+
+	d.reset(headers)
+
+	var current interface {
+		HeaderBlockFragment() []byte
+		HeadersEnded() bool
+	} = headers
+
+	for {
+		fragment := current.HeaderBlockFragment()
+
+		if int64(len(fragment)) > int64(2*d.remainSize) {
+			return &d.frame,
+				http2.ConnectionError(http2.ErrCodeProtocol)
+		}
+
+		if d.invalid != nil {
+			return &d.frame,
+				http2.ConnectionError(http2.ErrCodeProtocol)
+		}
+
+		if _, err := d.decoder.Write(fragment); err != nil {
+			return &d.frame,
+				http2.ConnectionError(http2.ErrCodeCompression)
+		}
+
+		if current.HeadersEnded() {
+			break
+		}
+
+		next, err := f.fr.ReadFrame()
+		if err != nil {
+			f.errDetail = f.fr.ErrorDetail()
+			return nil, err
+		}
+
+		current = next.(*http2.ContinuationFrame)
+	}
+
+	if err := d.decoder.Close(); err != nil {
+		return &d.frame,
+			http2.ConnectionError(http2.ErrCodeCompression)
+	}
+
+	if d.invalid != nil {
+		f.errDetail = d.invalid
+		return nil, http2.StreamError{
+			StreamID: d.frame.StreamID,
+			Code:     http2.ErrCodeProtocol,
+			Cause:    d.invalid,
+		}
+	}
+
+	if err := checkServerPseudos(d.frame.Fields); err != nil {
+		f.errDetail = err
+		return nil, http2.StreamError{
+			StreamID: d.frame.StreamID,
+			Code:     http2.ErrCodeProtocol,
+			Cause:    err,
+		}
+	}
+
+	return &d.frame, nil
+}
+
+func (f *framer) readServerFrame() (any, error) {
+	f.errDetail = nil
+
+	header, err := f.fr.ReadFrameHeader()
+	if err != nil {
+		f.errDetail = f.fr.ErrorDetail()
+		return nil, err
+	}
+
+	if header.Type == http2.FrameData {
+		err = f.readDataFrame(header)
+		return &f.dataFrame, err
+	}
+
+	if header.Type == http2.FrameHeaders {
+		if f.serverHeader == nil {
+			f.serverHeader = newServerHeaderDecoder(
+				f.fr.ReadMetaHeaders,
+				f.fr.MaxHeaderListSize,
+			)
+		}
+		frame, err := f.serverHeader.read(f, header)
+		if err != nil {
+			return nil, err
+		}
+		return frame, nil
+	}
+
+	frame, err := f.fr.ReadFrameForHeader(header)
+	if err != nil {
+		f.errDetail = f.fr.ErrorDetail()
+		return nil, err
+	}
+
+	return frame, nil
+}
+
+func validServerWireHeaderFieldName(value string) bool {
+	if len(value) == 0 {
+		return false
+	}
+
+	for _, r := range value {
+		if !httpguts.IsTokenRune(r) ||
+			('A' <= r && r <= 'Z') {
+			return false
+		}
+	}
+
+	return true
+}
+
+func checkServerPseudos(fields []hpack.HeaderField) error {
+	var request bool
+	var response bool
+
+	for i, field := range fields {
+		if !field.IsPseudo() {
+			break
+		}
+
+		switch field.Name {
+		case ":method",
+			":path",
+			":scheme",
+			":authority",
+			":protocol":
+			request = true
+
+		case ":status":
+			response = true
+
+		default:
+			return fmt.Errorf(
+				"invalid pseudo-header %q",
+				field.Name,
+			)
+		}
+
+		for _, previous := range fields[:i] {
+			if field.Name == previous.Name {
+				return fmt.Errorf(
+					"duplicate pseudo-header %q",
+					field.Name,
+				)
+			}
+		}
+	}
+
+	if request && response {
+		return errors.New(
+			"mix of request and response pseudo headers",
+		)
+	}
+
+	return nil
+}

--- a/internal/transport/http2_server_header_read_bench_test.go
+++ b/internal/transport/http2_server_header_read_bench_test.go
@@ -1,0 +1,113 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package transport
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+	"google.golang.org/grpc/mem"
+)
+
+type headerBenchmarkConn struct {
+	bytes.Reader
+}
+
+func (*headerBenchmarkConn) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func encodedRequestHeaders(b *testing.B, metadataFields int) []byte {
+	b.Helper()
+
+	var block bytes.Buffer
+	encoder := hpack.NewEncoder(&block)
+
+	fields := []hpack.HeaderField{
+		{Name: ":method", Value: "POST", Sensitive: true},
+		{Name: ":scheme", Value: "https", Sensitive: true},
+		{Name: ":path", Value: "/service/method", Sensitive: true},
+		{Name: ":authority", Value: "localhost", Sensitive: true},
+		{Name: "content-type", Value: "application/grpc", Sensitive: true},
+		{Name: "te", Value: "trailers", Sensitive: true},
+	}
+
+	for i := 0; i < metadataFields; i++ {
+		fields = append(fields, hpack.HeaderField{
+			Name:      fmt.Sprintf("metadata-%02d", i),
+			Value:     "0123456789abcdef0123456789abcdef",
+			Sensitive: true,
+		})
+	}
+
+	for _, field := range fields {
+		if err := encoder.WriteField(field); err != nil {
+			b.Fatalf("failed to encode header field: %v", err)
+		}
+	}
+
+	var wire bytes.Buffer
+	writer := http2.NewFramer(&wire, nil)
+	if err := writer.WriteHeaders(http2.HeadersFrameParam{
+		StreamID:      1,
+		BlockFragment: block.Bytes(),
+		EndStream:     true,
+		EndHeaders:    true,
+	}); err != nil {
+		b.Fatalf("failed to encode HEADERS frame: %v", err)
+	}
+
+	return append([]byte(nil), wire.Bytes()...)
+}
+
+func BenchmarkReadServerHeaders(b *testing.B) {
+	for _, metadataFields := range []int{0, 4, 12, 48} {
+		b.Run(fmt.Sprintf("metadata_fields=%d", metadataFields), func(b *testing.B) {
+			wire := encodedRequestHeaders(b, metadataFields)
+			conn := &headerBenchmarkConn{}
+			framer := newFramer(
+				conn,
+				0,
+				0,
+				false,
+				defaultClientMaxHeaderListSize,
+				mem.DefaultBufferPool(),
+			)
+
+			b.ReportAllocs()
+			for b.Loop() {
+				conn.Reset(wire)
+				frame, err := framer.readServerFrame()
+				if err != nil {
+					b.Fatalf("readFrame() failed: %v", err)
+				}
+				headers, ok := frame.(*http2.MetaHeadersFrame)
+				if !ok {
+					b.Fatalf("readFrame() returned %T, want *http2.MetaHeadersFrame", frame)
+				}
+				if got, want := len(headers.Fields), metadataFields+6; got != want {
+					b.Fatalf("decoded %d fields, want %d", got, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/transport/http2_server_header_test.go
+++ b/internal/transport/http2_server_header_test.go
@@ -1,0 +1,519 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package transport
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+	"google.golang.org/grpc/mem"
+)
+
+type serverHeaderTestConn struct {
+	bytes.Reader
+}
+
+func (*serverHeaderTestConn) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+type serverHeaderTestBlock struct {
+	fields       []hpack.HeaderField
+	continuation bool
+	endStream    bool
+}
+
+func encodeServerHeaderBlocks(
+	t *testing.T,
+	blocks ...serverHeaderTestBlock,
+) []byte {
+	t.Helper()
+
+	var wire bytes.Buffer
+	writer := http2.NewFramer(&wire, nil)
+
+	var encoded bytes.Buffer
+	encoder := hpack.NewEncoder(&encoded)
+
+	for i, block := range blocks {
+		encoded.Reset()
+
+		for _, field := range block.fields {
+			if err := encoder.WriteField(field); err != nil {
+				t.Fatalf("failed to encode field: %v", err)
+			}
+		}
+
+		fragment := append([]byte(nil), encoded.Bytes()...)
+		streamID := uint32(1 + 2*i)
+
+		if !block.continuation {
+			if err := writer.WriteHeaders(http2.HeadersFrameParam{
+				StreamID:      streamID,
+				BlockFragment: fragment,
+				EndStream:     block.endStream,
+				EndHeaders:    true,
+			}); err != nil {
+				t.Fatalf("failed to write HEADERS: %v", err)
+			}
+			continue
+		}
+
+		split := len(fragment) / 2
+		if split == 0 {
+			t.Fatal("encoded block is too small to split")
+		}
+
+		if err := writer.WriteHeaders(http2.HeadersFrameParam{
+			StreamID:      streamID,
+			BlockFragment: fragment[:split],
+			EndStream:     block.endStream,
+			EndHeaders:    false,
+		}); err != nil {
+			t.Fatalf("failed to write HEADERS: %v", err)
+		}
+
+		if err := writer.WriteContinuation(
+			streamID,
+			true,
+			fragment[split:],
+		); err != nil {
+			t.Fatalf("failed to write CONTINUATION: %v", err)
+		}
+	}
+
+	return append([]byte(nil), wire.Bytes()...)
+}
+
+func encodeRawServerHeaders(
+	t *testing.T,
+	fragment []byte,
+) []byte {
+	t.Helper()
+
+	var wire bytes.Buffer
+	writer := http2.NewFramer(&wire, nil)
+
+	if err := writer.WriteHeaders(http2.HeadersFrameParam{
+		StreamID:      1,
+		BlockFragment: fragment,
+		EndHeaders:    true,
+	}); err != nil {
+		t.Fatalf("failed to write raw HEADERS: %v", err)
+	}
+
+	return append([]byte(nil), wire.Bytes()...)
+}
+
+func encodeInterruptedServerHeaders(t *testing.T) []byte {
+	t.Helper()
+
+	fields := validServerHeaderFields()
+	var encoded bytes.Buffer
+	encoder := hpack.NewEncoder(&encoded)
+
+	for _, field := range fields {
+		if err := encoder.WriteField(field); err != nil {
+			t.Fatalf("failed to encode field: %v", err)
+		}
+	}
+
+	fragment := encoded.Bytes()
+	split := len(fragment) / 2
+
+	var wire bytes.Buffer
+	writer := http2.NewFramer(&wire, nil)
+
+	if err := writer.WriteHeaders(http2.HeadersFrameParam{
+		StreamID:      1,
+		BlockFragment: fragment[:split],
+		EndHeaders:    false,
+	}); err != nil {
+		t.Fatalf("failed to write HEADERS: %v", err)
+	}
+
+	if err := writer.WriteData(1, false, []byte("not continuation")); err != nil {
+		t.Fatalf("failed to write DATA: %v", err)
+	}
+
+	return append([]byte(nil), wire.Bytes()...)
+}
+
+func validServerHeaderFields() []hpack.HeaderField {
+	return []hpack.HeaderField{
+		{Name: ":method", Value: "POST", Sensitive: true},
+		{Name: ":scheme", Value: "https", Sensitive: true},
+		{Name: ":path", Value: "/service/method", Sensitive: true},
+		{Name: ":authority", Value: "localhost", Sensitive: true},
+		{Name: "content-type", Value: "application/grpc", Sensitive: true},
+		{Name: "te", Value: "trailers", Sensitive: true},
+		{Name: "metadata-key", Value: "metadata-value", Sensitive: true},
+	}
+}
+
+func newServerHeaderTestFramer(
+	wire []byte,
+	maxHeaderListSize uint32,
+) *framer {
+	conn := &serverHeaderTestConn{}
+	conn.Reset(wire)
+
+	return newFramer(
+		conn,
+		0,
+		0,
+		false,
+		maxHeaderListSize,
+		mem.DefaultBufferPool(),
+	)
+}
+
+func describeServerHeaderError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	switch err := err.(type) {
+	case http2.StreamError:
+		return fmt.Sprintf(
+			"stream:%d:%v:%v",
+			err.StreamID,
+			err.Code,
+			err.Cause,
+		)
+
+	case http2.ConnectionError:
+		return fmt.Sprintf("connection:%v", err)
+	}
+
+	return fmt.Sprintf("%T:%v", err, err)
+}
+
+func errorDetailText(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func compareServerHeaderRead(
+	t *testing.T,
+	oldFrame any,
+	oldErr error,
+	oldDetail error,
+	newFrame any,
+	newErr error,
+	newDetail error,
+) {
+	t.Helper()
+
+	if got, want := describeServerHeaderError(newErr),
+		describeServerHeaderError(oldErr); got != want {
+		t.Fatalf("new error %q, want %q", got, want)
+	}
+
+	if got, want := errorDetailText(newDetail),
+		errorDetailText(oldDetail); got != want {
+		t.Fatalf("new error detail %q, want %q", got, want)
+	}
+
+	if (newFrame == nil) != (oldFrame == nil) {
+		t.Fatalf(
+			"new frame nil=%v, want %v",
+			newFrame == nil,
+			oldFrame == nil,
+		)
+	}
+
+	if oldFrame == nil {
+		return
+	}
+
+	oldHeaders, ok := oldFrame.(*http2.MetaHeadersFrame)
+	if !ok {
+		t.Fatalf(
+			"old decoder returned %T, want *http2.MetaHeadersFrame",
+			oldFrame,
+		)
+	}
+
+	newHeaders, ok := newFrame.(*http2.MetaHeadersFrame)
+	if !ok {
+		t.Fatalf(
+			"new decoder returned %T, want *http2.MetaHeadersFrame",
+			newFrame,
+		)
+	}
+
+	oldHeader := oldHeaders.Header()
+	newHeader := newHeaders.Header()
+
+	if newHeader.StreamID != oldHeader.StreamID ||
+		newHeader.Length != oldHeader.Length ||
+		newHeader.Type != oldHeader.Type ||
+		newHeader.Flags != oldHeader.Flags {
+		t.Fatalf(
+			"new frame header %+v, want %+v",
+			newHeader,
+			oldHeader,
+		)
+	}
+
+	if newHeaders.StreamEnded() != oldHeaders.StreamEnded() {
+		t.Fatalf(
+			"new StreamEnded=%v, want %v",
+			newHeaders.StreamEnded(),
+			oldHeaders.StreamEnded(),
+		)
+	}
+
+	if newHeaders.Truncated != oldHeaders.Truncated {
+		t.Fatalf(
+			"new Truncated=%v, want %v",
+			newHeaders.Truncated,
+			oldHeaders.Truncated,
+		)
+	}
+
+	if !reflect.DeepEqual(newHeaders.Fields, oldHeaders.Fields) {
+		t.Fatalf(
+			"new fields %#v, want %#v",
+			newHeaders.Fields,
+			oldHeaders.Fields,
+		)
+	}
+}
+
+func compareServerHeaderWire(
+	t *testing.T,
+	wire []byte,
+	maxHeaderListSize uint32,
+	reads int,
+) {
+	t.Helper()
+
+	oldFramer := newServerHeaderTestFramer(wire, maxHeaderListSize)
+	newFramer := newServerHeaderTestFramer(wire, maxHeaderListSize)
+
+	for i := 0; i < reads; i++ {
+		oldFrame, oldErr := oldFramer.readFrame()
+		oldDetail := oldFramer.errorDetail()
+
+		newFrame, newErr := newFramer.readServerFrame()
+		newDetail := newFramer.errorDetail()
+
+		compareServerHeaderRead(
+			t,
+			oldFrame,
+			oldErr,
+			oldDetail,
+			newFrame,
+			newErr,
+			newDetail,
+		)
+	}
+}
+
+func TestServerHeaderDecoderMatchesHTTP2Framer(t *testing.T) {
+	valid := validServerHeaderFields()
+
+	tests := []struct {
+		name              string
+		fields            []hpack.HeaderField
+		continuation      bool
+		endStream         bool
+		maxHeaderListSize uint32
+		wantError         bool
+		wantTruncated     bool
+	}{
+		{
+			name:      "valid",
+			fields:    valid,
+			endStream: true,
+		},
+		{
+			name:         "continuation",
+			fields:       valid,
+			continuation: true,
+		},
+		{
+			name: "uppercase regular name",
+			fields: append(
+				append([]hpack.HeaderField(nil), valid[:4]...),
+				hpack.HeaderField{
+					Name:      "Uppercase",
+					Value:     "value",
+					Sensitive: true,
+				},
+			),
+			wantError: true,
+		},
+		{
+			name: "invalid regular value",
+			fields: append(
+				append([]hpack.HeaderField(nil), valid...),
+				hpack.HeaderField{
+					Name:      "invalid-value",
+					Value:     "line\nbreak",
+					Sensitive: true,
+				},
+			),
+			wantError: true,
+		},
+		{
+			name: "pseudo after regular",
+			fields: []hpack.HeaderField{
+				{Name: ":method", Value: "POST", Sensitive: true},
+				{Name: "content-type", Value: "application/grpc", Sensitive: true},
+				{Name: ":path", Value: "/service/method", Sensitive: true},
+			},
+			wantError: true,
+		},
+		{
+			name: "duplicate pseudo",
+			fields: []hpack.HeaderField{
+				{Name: ":method", Value: "POST", Sensitive: true},
+				{Name: ":method", Value: "POST", Sensitive: true},
+			},
+			wantError: true,
+		},
+		{
+			name: "mixed pseudo types",
+			fields: []hpack.HeaderField{
+				{Name: ":method", Value: "POST", Sensitive: true},
+				{Name: ":status", Value: "200", Sensitive: true},
+			},
+			wantError: true,
+		},
+		{
+			name: "unknown pseudo",
+			fields: []hpack.HeaderField{
+				{Name: ":unknown", Value: "value", Sensitive: true},
+			},
+			wantError: true,
+		},
+		{
+			name:              "truncated",
+			fields:            valid,
+			maxHeaderListSize: 220,
+			wantTruncated:     true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			wire := encodeServerHeaderBlocks(
+				t,
+				serverHeaderTestBlock{
+					fields:       test.fields,
+					continuation: test.continuation,
+					endStream:    test.endStream,
+				},
+			)
+
+			oldFramer := newServerHeaderTestFramer(
+				wire,
+				test.maxHeaderListSize,
+			)
+			newFramer := newServerHeaderTestFramer(
+				wire,
+				test.maxHeaderListSize,
+			)
+
+			oldFrame, oldErr := oldFramer.readFrame()
+			oldDetail := oldFramer.errorDetail()
+
+			newFrame, newErr := newFramer.readServerFrame()
+			newDetail := newFramer.errorDetail()
+
+			compareServerHeaderRead(
+				t,
+				oldFrame,
+				oldErr,
+				oldDetail,
+				newFrame,
+				newErr,
+				newDetail,
+			)
+
+			if test.wantError != (oldErr != nil) {
+				t.Fatalf(
+					"old error=%v, want error=%v",
+					oldErr,
+					test.wantError,
+				)
+			}
+
+			if test.wantTruncated {
+				headers, ok := oldFrame.(*http2.MetaHeadersFrame)
+				if !ok {
+					t.Fatalf("old frame type %T", oldFrame)
+				}
+				if !headers.Truncated {
+					t.Fatal("old decoder did not truncate")
+				}
+			}
+		})
+	}
+}
+
+func TestServerHeaderDecoderPreservesDynamicTable(t *testing.T) {
+	fields := []hpack.HeaderField{
+		{Name: ":method", Value: "POST"},
+		{Name: ":path", Value: "/service/method"},
+		{Name: "metadata-key", Value: "metadata-value"},
+	}
+
+	wire := encodeServerHeaderBlocks(
+		t,
+		serverHeaderTestBlock{fields: fields},
+		serverHeaderTestBlock{fields: fields},
+	)
+
+	compareServerHeaderWire(t, wire, 0, 2)
+}
+
+func TestServerHeaderDecoderMatchesCompressionError(t *testing.T) {
+	wire := encodeRawServerHeaders(t, []byte{0xff})
+	compareServerHeaderWire(t, wire, 0, 1)
+
+	framer := newServerHeaderTestFramer(wire, 0)
+	_, err := framer.readFrame()
+
+	connectionError, ok := err.(http2.ConnectionError)
+	if !ok {
+		t.Fatalf("error type %T, want http2.ConnectionError", err)
+	}
+	if connectionError != http2.ConnectionError(http2.ErrCodeCompression) {
+		t.Fatalf(
+			"connection error %v, want %v",
+			connectionError,
+			http2.ErrCodeCompression,
+		)
+	}
+}
+
+func TestServerHeaderDecoderMatchesContinuationOrderingError(t *testing.T) {
+	wire := encodeInterruptedServerHeaders(t)
+	compareServerHeaderWire(t, wire, 0, 1)
+}

--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -412,13 +412,14 @@ func (df *parsedDataFrame) StreamEnded() bool {
 }
 
 type framer struct {
-	writer    *bufWriter
-	fr        *http2.Framer
-	headerBuf []byte // cached slice for framer headers to reduce heap allocs.
-	reader    io.Reader
-	dataFrame parsedDataFrame // Cached data frame to avoid heap allocations.
-	pool      mem.BufferPool
-	errDetail error
+	writer       *bufWriter
+	fr           *http2.Framer
+	headerBuf    []byte // cached slice for framer headers to reduce heap allocs.
+	reader       io.Reader
+	dataFrame    parsedDataFrame // Cached data frame to avoid heap allocations.
+	pool         mem.BufferPool
+	errDetail    error
+	serverHeader *serverHeaderDecoder
 }
 
 var ioBufferPoolMap = make(map[int]*imem.SimpleBufferPool)


### PR DESCRIPTION
This adds a server-specific path for reading HTTP/2 HEADERS frames. The server
reuses its header decoder state instead of sending request headers through the
general `http2.Framer.ReadFrame` path. Other frame reads remain unchanged.

The new tests compare the result with `http2.Framer`, including HPACK dynamic
table state, compression errors, and CONTINUATION ordering errors.

On linux/amd64 with Go 1.25.13, the allocation benchmark produced:

| Metadata fields | Before | After |
| ---: | ---: | ---: |
| 0 | 864 B/op, 17 allocs/op | 112 B/op, 8 allocs/op |
| 4 | 1760 B/op, 26 allocs/op | 304 B/op, 16 allocs/op |
| 12 | 3552 B/op, 43 allocs/op | 688 B/op, 32 allocs/op |
| 48 | 8353 B/op, 116 allocs/op | 2416 B/op, 104 allocs/op |

The benchmark was run with:

    go test ./internal/transport -run '^$' \
      -bench '^BenchmarkReadServerHeaders$' -benchmem -count=5

Validation:

    ./scripts/vet.sh
    go test -cpu 1,4 -timeout 7m ./...
    go test -race -cpu 1,4 -timeout 7m ./...

RELEASE NOTES:
* transport: Reduce allocations while decoding request headers on the server.