### PR TITLE
stream: group bool fields at tail of csAttempt to reduce allocator size class 240B→224B

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -753,10 +753,8 @@ type csAttempt struct {
 	parser          parser
 	pickResult      balancer.PickResult
 
-	finished        bool
-	decompressorV0  Decompressor
-	decompressorV1  encoding.Compressor
-	decompressorSet bool
+	decompressorV0 Decompressor
+	decompressorV1 encoding.Compressor
 
 	mu sync.Mutex // guards trInfo.tr
 	// trInfo may be nil (if EnableTracing is false).
@@ -767,10 +765,18 @@ type csAttempt struct {
 	statsHandler stats.Handler
 	beginTime    time.Time
 
-	// set for newStream errors that may be transparently retried
-	allowTransparentRetry bool
-	// set for pick errors that are returned as a status
-	drop bool
+	// Bool fields are grouped at the tail to eliminate the alignment padding
+	// that would otherwise follow each bool when the next field is pointer- or
+	// int-sized. See https://github.com/grpc/grpc-go/issues/9347 for benchmarks.
+	// Add new bool fields here, not inline above.
+
+	// Not guarded by mu.
+	decompressorSet       bool
+	allowTransparentRetry bool // set for newStream errors that may be transparently retried
+	drop                  bool // set for pick errors that are returned as a status
+
+	// Guarded by mu.
+	finished bool
 }
 
 func (cs *clientStream) commitAttemptLocked() {


### PR DESCRIPTION
Reorder \`csAttempt\` fields so all 4 bool fields are grouped at the tail of the struct.

## Why

\`csAttempt\` had 4 \`bool\` fields scattered among pointer- and interface-sized fields. Each bool was followed by alignment padding before the next field:

| Field | Padding after |
|-------|--------------|
| \`finished\` | 7 B (before 16B-aligned interface) |
| \`decompressorSet\` | 3 B (before \`sync.Mutex\`, align 4) |
| \`allowTransparentRetry\` + \`drop\` (together) | 6 B tail |

Total: 16 B wasted. \`decompressorSet\` (offset 160) also shared a 64-byte cache line with \`mu\` (offset 164), causing false-sharing overhead on \`mu.Lock()\` under concurrent load — see benchmarks in #9347.

Grouping all bools at the tail eliminates the padding, reducing \`csAttempt\` from **232 B → 216 B** and dropping it from the **240 B to the 224 B** allocator size class: 16 B saved per RPC attempt unconditionally.

After grouping, \`mu\` falls at offset 152 (cache line 2: 128–191) and the tail bools start at offset 208 (cache line 3: 192–255), so the cache-line conflict is eliminated without any additional field move.

**Benchmark — \`mu.Lock()\` latency with stressor goroutines writing \`decompressorSet\` concurrently:**

| Stressors | Original layout | After tail-group |
|---|---|---|
| 0 | 3.9 ns | 3.8 ns |
| 1 | 18.0 ns (4.6×) | 3.7 ns (~1×) |
| 2 | 37.9 ns (9.6×) | 3.7 ns (~1×) |
| 4 | 78.3 ns (19.9×) | 3.7 ns (~1×) |

## Code clarity

Lock discipline is preserved explicitly: the bool group is split into \`// Not guarded by mu\` (\`decompressorSet\`, \`allowTransparentRetry\`, \`drop\`) and \`// Guarded by mu\` (\`finished\`) sections with per-field comments matching the original.

Closes #9347

RELEASE NOTES:
- core: reorder \`csAttempt\` bool fields to reduce struct size from the 240-byte to the 224-byte allocator size class (saving 16 bytes per RPC attempt) and eliminate cache-line false sharing between \`decompressorSet\` and \`mu\` (up to 20× \`mu.Lock()\` speedup under concurrent load).