### PR TITLE
stream: group bool fields at tail of addrConnStream to reduce allocator size class 256B→240B

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -1498,19 +1498,28 @@ type addrConnStream struct {
 	callInfo         *callInfo
 	transport        transport.ClientTransport
 	ctx              context.Context
-	sentLast         bool
-	receivedFirstMsg bool
 	desc             *StreamDesc
 	codec            baseCodec
 	sendCompressorV0 Compressor
 	sendCompressorV1 encoding.Compressor
-	decompressorSet  bool
 	decompressorV0   Decompressor
 	decompressorV1   encoding.Compressor
 	parser           parser
 
 	// mu guards finished and is held for the entire finish method.
-	mu       sync.Mutex
+	mu sync.Mutex
+
+	// Bool fields are grouped at the tail to eliminate the alignment padding
+	// that would otherwise follow each bool when the next field is pointer- or
+	// int-sized. See https://github.com/grpc/grpc-go/issues/9348 for benchmarks.
+	// Add new bool fields here, not inline above.
+
+	// Not guarded by mu.
+	sentLast         bool
+	receivedFirstMsg bool
+	decompressorSet  bool
+
+	// Guarded by mu.
 	finished bool
 }
 

--- a/stream.go
+++ b/stream.go
@@ -1504,10 +1504,10 @@ type addrConnStream struct {
 	sendCompressorV1 encoding.Compressor
 	decompressorV0   Decompressor
 	decompressorV1   encoding.Compressor
-	parser           parser
 
 	// mu guards finished and is held for the entire finish method.
-	mu sync.Mutex
+	mu     sync.Mutex
+	parser parser
 
 	// Bool fields are grouped at the tail to eliminate the alignment padding
 	// that would otherwise follow each bool when the next field is pointer- or
@@ -1519,8 +1519,7 @@ type addrConnStream struct {
 	receivedFirstMsg bool
 	decompressorSet  bool
 
-	// Guarded by mu.
-	finished bool
+	finished bool // guarded by mu
 }
 
 func (as *addrConnStream) Header() (metadata.MD, error) {


### PR DESCRIPTION
Reorder \`addrConnStream\` fields so all 4 bool fields are grouped at the tail of the struct, and move \`mu\` to a separate cache line from the tail bools.

## Why

\`addrConnStream\` had 4 \`bool\` fields scattered among pointer- and interface-sized fields. Each bool was followed by alignment padding before the next field:

| Field | Padding after |
|-------|--------------|
| \`sentLast\` + \`receivedFirstMsg\` (together) | 6 B (before 8B-aligned pointer) |
| \`decompressorSet\` | 7 B (before 16B-aligned interface) |
| \`finished\` | 7 B tail |

Total: 20 B interior padding, 16 B net savings when all bools are moved to the tail. \`addrConnStream\` shrinks from **256 B → 240 B**, dropping from the **256 B to the 240 B** allocator size class.

Additionally, \`sentLast\`, \`receivedFirstMsg\`, and \`decompressorSet\` are all written without holding \`mu\` (in \`CloseSend\` and \`recvMsg\` during normal stream operation). After tail-grouping they would land at offset 232–234 — the same cache line as \`mu\` (cache line 3: 192–255). Concurrent writes to these fields invalidate the cache line before every \`mu.Lock()\`.

Moving \`mu\` to immediately before \`parser\` places it at offset 184 (cache line 2: 128–191). The tail bools remain at offset 232+ (cache line 3), so the false-sharing is eliminated. No size change from this step — \`addrConnStream\` stays at 240 B.

See benchmarks in #9348.

**Benchmark — \`mu.Lock()\` latency with stressor goroutines writing \`sentLast\` concurrently:**

| Stressors | Original layout | After tail-group only | After moving mu to CL2 |
|---|---|---|---|
| 0 | 3.9 ns | 3.9 ns | 3.7 ns |
| 1 | 21.2 ns (5.4×) | 19.1 ns (4.9×) | 3.7 ns (~1×) |
| 2 | 46.3 ns (11.8×) | 33.8 ns (8.6×) | 3.9 ns (~1×) |
| 4 | 82.9 ns (21.1×) | 69.1 ns (17.6×) | 3.9 ns (~1×) |

## Code clarity

Lock discipline is preserved explicitly: the bool group is split into \`// Not guarded by mu\` (\`sentLast\`, \`receivedFirstMsg\`, \`decompressorSet\`) and \`// Guarded by mu\` (\`finished\`) sections with per-field comments matching the original. \`mu\` is placed immediately before \`parser\` with a comment explaining the cache-line placement.

Closes #9348

RELEASE NOTES:
- core: reorder \`addrConnStream\` fields to eliminate alignment padding (saving 16 bytes per bidirectional stream, dropping from the 256-byte to the 240-byte allocator size class) and cache-line false sharing between unguarded bool fields and \`mu\` (up to 21× \`mu.Lock()\` speedup under concurrent load).