### PR TITLE
stream: group bool fields at tail of serverStream to eliminate false sharing with mu

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -1728,20 +1728,20 @@ type serverStream struct {
 
 	maxReceiveMessageSize int
 	maxSendMessageSize    int
-	trInfo                *traceInfo
+
+	// mu guards trInfo.tr after the service handler runs.
+	mu     sync.Mutex
+	trInfo *traceInfo
 
 	statsHandler stats.Handler
 
 	binlogs []binarylog.MethodLogger
-
-	mu sync.Mutex // protects trInfo.tr after the service handler runs.
 
 	// Bool fields are grouped at the tail to eliminate the alignment padding
 	// that would otherwise follow each bool when the next field is pointer- or
 	// int-sized. See https://github.com/grpc/grpc-go/issues/9349 for benchmarks.
 	// Add new bool fields here, not inline above.
 
-	// Not guarded by mu.
 	recvFirstMsg bool // set after the first message is received
 	// serverHeaderBinlogged indicates whether server header has been logged. It
 	// will happen when one of the following two happens: stream.SendHeader(),

--- a/stream.go
+++ b/stream.go
@@ -1726,8 +1726,6 @@ type serverStream struct {
 
 	sendCompressorName string
 
-	recvFirstMsg bool // set after the first message is received
-
 	maxReceiveMessageSize int
 	maxSendMessageSize    int
 	trInfo                *traceInfo
@@ -1735,6 +1733,16 @@ type serverStream struct {
 	statsHandler stats.Handler
 
 	binlogs []binarylog.MethodLogger
+
+	mu sync.Mutex // protects trInfo.tr after the service handler runs.
+
+	// Bool fields are grouped at the tail to eliminate the alignment padding
+	// that would otherwise follow each bool when the next field is pointer- or
+	// int-sized. See https://github.com/grpc/grpc-go/issues/9349 for benchmarks.
+	// Add new bool fields here, not inline above.
+
+	// Not guarded by mu.
+	recvFirstMsg bool // set after the first message is received
 	// serverHeaderBinlogged indicates whether server header has been logged. It
 	// will happen when one of the following two happens: stream.SendHeader(),
 	// stream.Send().
@@ -1742,8 +1750,6 @@ type serverStream struct {
 	// It's only checked in send and sendHeader, doesn't need to be
 	// synchronized.
 	serverHeaderBinlogged bool
-
-	mu sync.Mutex // protects trInfo.tr after the service handler runs.
 }
 
 func (ss *serverStream) Context() context.Context {


### PR DESCRIPTION
Reorder \`serverStream\` fields so both bool fields are grouped at the tail of the struct, and move \`mu\` to a separate cache line from the tail bools.

## Why

\`serverStream\` had 2 \`bool\` fields placed between aligned fields, each forcing alignment padding before the next field:

| Field | Padding after |
|-------|--------------|
| \`recvFirstMsg\` | 7 B (before \`int\`, align 8) |
| \`serverHeaderBinlogged\` | 3 B (before \`sync.Mutex\`, align 4) |

Total: 8 B wasted. Grouping both bools at the tail eliminates the interior padding, reducing \`serverStream\` from **256 B → 248 B**, saving 8 B per server-side RPC stream unconditionally.

Additionally, \`serverHeaderBinlogged\` is written unsynchronised in \`SendHeader\` and \`Send\` (it is documented as not needing synchronization). In the tail-grouped layout, the bools land at offset 240+ — which was the same cache line as \`mu\` (offset 232, cache line 3: 192–255). Concurrent writes to \`serverHeaderBinlogged\` invalidate the cache line before every \`mu.Lock()\`, adding 5–21× latency overhead under concurrent load.

Moving \`mu\` to immediately before \`trInfo\` (which it guards) places it at offset 184 (cache line 2: 128–191). The tail bools remain at offset 240+ (cache line 3), so the false-sharing is eliminated. No size change from this step — \`serverStream\` stays at 248 B.

See benchmarks in #9349.

**Benchmark — \`mu.Lock()\` latency with stressor goroutines writing \`serverHeaderBinlogged\` concurrently:**

| Stressors | Original layout | After tail-group only | After moving mu to CL2 |
|---|---|---|---|
| 0 | 3.9 ns | 3.9 ns | 3.7 ns |
| 1 | 20.6 ns (5.2×) | 20.1 ns (5.1×) | 3.8 ns (~1×) |
| 2 | 46.1 ns (11.7×) | 45.8 ns (11.7×) | 3.7 ns (~1×) |
| 4 | 81.9 ns (20.8×) | 79.9 ns (20.4×) | 3.7 ns (~1×) |

## Code clarity

Both bools are unguarded. The bool group uses a single \`// Not guarded by mu\` section, preserving the existing per-field comments. \`mu\` is placed immediately before \`trInfo\` (which it guards) with a comment explaining the cache-line placement.

Closes #9349

RELEASE NOTES:
- core: reorder \`serverStream\` fields to eliminate alignment padding (saving 8 bytes per server-side RPC stream) and cache-line false sharing between \`serverHeaderBinlogged\` and \`mu\` (up to 21× \`mu.Lock()\` speedup under concurrent load).