### PR TITLE
rls, grpc: inherit parent channel stats handlers and interceptors on the RLS control channel

### DIFF
--- a/balancer/grpclb/grpclb_util.go
+++ b/balancer/grpclb/grpclb_util.go
@@ -91,6 +91,13 @@ func (ccc *lbCacheClientConn) RemoveSubConn(sc balancer.SubConn) {
 	logger.Errorf("RemoveSubConn(%v) called unexpectedly", sc)
 }
 
+// Unwrap returns the ClientConn that this wrapper delegates to. It lets
+// gRPC-internal callers walk past the grpclb subconn-cache layer to reach the
+// underlying parent ClientConn.
+func (ccc *lbCacheClientConn) Unwrap() balancer.ClientConn {
+	return ccc.ClientConn
+}
+
 type lbCacheSubConn struct {
 	balancer.SubConn
 	ccc *lbCacheClientConn

--- a/balancer/ringhash/ringhash.go
+++ b/balancer/ringhash/ringhash.go
@@ -178,6 +178,13 @@ func (b *ringhashBalancer) UpdateState(state balancer.State) {
 	b.updatePickerLocked()
 }
 
+// Unwrap returns the ClientConn that this wrapper delegates to. It lets
+// gRPC-internal callers walk past the ring-hash layer to reach the underlying
+// parent ClientConn.
+func (b *ringhashBalancer) Unwrap() balancer.ClientConn {
+	return b.ClientConn
+}
+
 func (b *ringhashBalancer) UpdateClientConnState(ccs balancer.ClientConnState) error {
 	if b.logger.V(2) {
 		b.logger.Infof("Received update from resolver, balancer config: %+v", pretty.ToJSON(ccs.BalancerConfig))

--- a/balancer/rls/balancer.go
+++ b/balancer/rls/balancer.go
@@ -367,7 +367,7 @@ func (b *rlsBalancer) handleControlChannelUpdate(newCfg *lbConfig) {
 	backToReadyFn := func() {
 		b.updateCh.Put(controlChannelReady{})
 	}
-	ctrlCh, err := newControlChannel(newCfg.lookupService, newCfg.controlChannelServiceConfig, newCfg.lookupServiceTimeout, b.bopts, backToReadyFn)
+	ctrlCh, err := newControlChannel(b.cc, newCfg.lookupService, newCfg.controlChannelServiceConfig, newCfg.lookupServiceTimeout, b.bopts, backToReadyFn)
 	if err != nil {
 		// This is very uncommon and usually represents a non-transient error.
 		// There is not much we can do here other than wait for another update

--- a/balancer/rls/control_channel.go
+++ b/balancer/rls/control_channel.go
@@ -72,7 +72,14 @@ type controlChannel struct {
 // newControlChannel creates a controlChannel to rlsServerName and uses
 // serviceConfig, if non-empty, as the default service config for the underlying
 // gRPC channel.
-func newControlChannel(rlsServerName, serviceConfig string, rpcTimeout time.Duration, bOpts balancer.BuildOptions, backToReadyFunc func()) (*controlChannel, error) {
+//
+// parentCC is the balancer.ClientConn passed to Balancer.Build. It is used to
+// inherit the parent channel's stats handlers and client interceptors so that
+// per-attempt telemetry configured on the parent channel also covers
+// RouteLookup RPCs. A nil parentCC is tolerated (control channel is created
+// without inheriting parent telemetry) for tests that construct the control
+// channel directly.
+func newControlChannel(parentCC balancer.ClientConn, rlsServerName, serviceConfig string, rpcTimeout time.Duration, bOpts balancer.BuildOptions, backToReadyFunc func()) (*controlChannel, error) {
 	ctrlCh := &controlChannel{
 		rpcTimeout:      rpcTimeout,
 		backToReadyFunc: backToReadyFunc,
@@ -84,7 +91,8 @@ func newControlChannel(rlsServerName, serviceConfig string, rpcTimeout time.Dura
 	if err != nil {
 		return nil, err
 	}
-	ctrlCh.cc, err = grpc.NewClient(rlsServerName, dopts...)
+	newChan := internal.NewChannelForBalancer.(func(balancer.ClientConn, string, ...grpc.DialOption) (*grpc.ClientConn, error))
+	ctrlCh.cc, err = newChan(parentCC, rlsServerName, dopts...)
 	if err != nil {
 		return nil, err
 	}

--- a/balancer/rls/control_channel_test.go
+++ b/balancer/rls/control_channel_test.go
@@ -51,7 +51,7 @@ func (s) TestControlChannelThrottled(t *testing.T) {
 	overrideAdaptiveThrottler(t, alwaysThrottlingThrottler())
 
 	// Create a control channel to the fake RLS server.
-	ctrlCh, err := newControlChannel(rlsServer.Address, "", defaultTestTimeout, balancer.BuildOptions{}, nil)
+	ctrlCh, err := newControlChannel(nil, rlsServer.Address, "", defaultTestTimeout, balancer.BuildOptions{}, nil)
 	if err != nil {
 		t.Fatalf("Failed to create control channel to RLS server: %v", err)
 	}
@@ -79,7 +79,7 @@ func (s) TestLookupFailure(t *testing.T) {
 	})
 
 	// Create a control channel to the fake RLS server.
-	ctrlCh, err := newControlChannel(rlsServer.Address, "", defaultTestTimeout, balancer.BuildOptions{}, nil)
+	ctrlCh, err := newControlChannel(nil, rlsServer.Address, "", defaultTestTimeout, balancer.BuildOptions{}, nil)
 	if err != nil {
 		t.Fatalf("Failed to create control channel to RLS server: %v", err)
 	}
@@ -118,7 +118,7 @@ func (s) TestLookupDeadlineExceeded(t *testing.T) {
 	overrideAdaptiveThrottler(t, neverThrottlingThrottler())
 
 	// Create a control channel with a small deadline.
-	ctrlCh, err := newControlChannel(rlsServer.Address, "", defaultTestShortTimeout, balancer.BuildOptions{}, nil)
+	ctrlCh, err := newControlChannel(nil, rlsServer.Address, "", defaultTestShortTimeout, balancer.BuildOptions{}, nil)
 	if err != nil {
 		t.Fatalf("Failed to create control channel to RLS server: %v", err)
 	}
@@ -272,7 +272,7 @@ func testControlChannelCredsSuccess(t *testing.T, sopts []grpc.ServerOption, bop
 	})
 
 	// Create a control channel to the fake server.
-	ctrlCh, err := newControlChannel(rlsServer.Address, "", defaultTestTimeout, bopts, nil)
+	ctrlCh, err := newControlChannel(nil, rlsServer.Address, "", defaultTestTimeout, bopts, nil)
 	if err != nil {
 		t.Fatalf("Failed to create control channel to RLS server: %v", err)
 	}
@@ -360,7 +360,7 @@ func testControlChannelCredsFailure(t *testing.T, sopts []grpc.ServerOption, bop
 	overrideAdaptiveThrottler(t, neverThrottlingThrottler())
 
 	// Create the control channel to the fake server.
-	ctrlCh, err := newControlChannel(rlsServer.Address, "", defaultTestTimeout, bopts, nil)
+	ctrlCh, err := newControlChannel(nil, rlsServer.Address, "", defaultTestTimeout, bopts, nil)
 	if err != nil {
 		t.Fatalf("Failed to create control channel to RLS server: %v", err)
 	}
@@ -457,7 +457,7 @@ func (s) TestNewControlChannelUnsupportedCredsBundle(t *testing.T) {
 	rlsServer, _ := rlstest.SetupFakeRLSServer(t, nil)
 
 	// Create the control channel to the fake server.
-	ctrlCh, err := newControlChannel(rlsServer.Address, "", defaultTestTimeout, balancer.BuildOptions{CredsBundle: &unsupportedCredsBundle{}}, nil)
+	ctrlCh, err := newControlChannel(nil, rlsServer.Address, "", defaultTestTimeout, balancer.BuildOptions{CredsBundle: &unsupportedCredsBundle{}}, nil)
 	if err == nil {
 		ctrlCh.close()
 		t.Fatal("newControlChannel succeeded when expected to fail")

--- a/balancer/rls/metrics_test.go
+++ b/balancer/rls/metrics_test.go
@@ -373,3 +373,63 @@ func (s) TestRLSFailedRPCMetric(t *testing.T) {
 		}
 	}
 }
+
+// TestRLSControlChannelAttemptDurationMetric verifies that per-attempt
+// telemetry configured on the parent channel (grpc.client.attempt.duration)
+// also covers the RouteLookup RPC issued by the RLS balancer's control
+// channel. Regression test for the plumbing that inherits parent stats
+// handlers and interceptors onto balancer-owned control channels.
+func (s) TestRLSControlChannelAttemptDurationMetric(t *testing.T) {
+	rlsServer, _ := rlstest.SetupFakeRLSServer(t, nil)
+	rlsConfig := buildBasicRLSConfigWithChildPolicy(t, t.Name(), rlsServer.Address)
+	backend := &stubserver.StubServer{
+		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
+			return &testpb.Empty{}, nil
+		},
+	}
+	if err := backend.StartServer(); err != nil {
+		t.Fatalf("Failed to start backend: %v", err)
+	}
+	defer backend.Stop()
+	rlsConfig.RouteLookupConfig.DefaultTarget = backend.Address
+
+	r := startManualResolverWithConfig(t, rlsConfig)
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
+	mo := opentelemetry.MetricsOptions{MeterProvider: provider}
+	cc, err := grpc.NewClient(r.Scheme()+":///", grpc.WithResolvers(r), grpc.WithTransportCredentials(insecure.NewCredentials()), opentelemetry.DialOption(opentelemetry.Options{MetricsOptions: mo}))
+	if err != nil {
+		t.Fatalf("Failed to dial local test server: %v", err)
+	}
+	defer cc.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := testgrpc.NewTestServiceClient(cc).EmptyCall(ctx, &testpb.Empty{}); err != nil {
+		t.Fatalf("client.EmptyCall failed: %v", err)
+	}
+
+	const rlsMethod = "grpc.lookup.v1.RouteLookupService/RouteLookup"
+	md, ok := metricsDataFromReader(ctx, reader)["grpc.client.attempt.duration"]
+	if !ok {
+		t.Fatal("grpc.client.attempt.duration metric not recorded")
+	}
+	hist, ok := md.Data.(metricdata.Histogram[float64])
+	if !ok {
+		t.Fatalf("grpc.client.attempt.duration has unexpected data type %T, want Histogram[float64]", md.Data)
+	}
+	for _, dp := range hist.DataPoints {
+		if v, ok := dp.Attributes.Value("grpc.method"); ok && v.AsString() == rlsMethod {
+			return
+		}
+	}
+	t.Fatalf("grpc.client.attempt.duration did not record a data point for method %q; got attribute sets %v", rlsMethod, attributeSets(hist.DataPoints))
+}
+
+func attributeSets(dps []metricdata.HistogramDataPoint[float64]) []attribute.Set {
+	out := make([]attribute.Set, 0, len(dps))
+	for _, dp := range dps {
+		out = append(out, dp.Attributes)
+	}
+	return out
+}

--- a/clientconn.go
+++ b/clientconn.go
@@ -790,6 +790,67 @@ func init() {
 	internal.ExitIdleModeForTesting = func(cc *ClientConn) {
 		cc.idlenessMgr.ExitIdleMode()
 	}
+	internal.NewChannelForBalancer = newChannelForBalancer
+}
+
+// newChannelForBalancer creates a new ClientConn that inherits parent's stats
+// handlers and client interceptors. Used by LB policies that open their own
+// control-plane channels (e.g. RLS) so per-attempt telemetry configured on the
+// parent channel also covers those control-plane RPCs. Inherited options are
+// prepended to opts, so callers may still override them by passing their own
+// stats handlers or interceptors in opts.
+//
+// The balancer.ClientConn handed to Balancer.Build is often wrapped several
+// layers deep in xDS/DirectPath configs (gracefulswitch, balancer group,
+// cluster_impl, outlier_detection, ...). Every wrapping layer exposes its
+// delegate via Unwrap() balancer.ClientConn (see the same-named methods on
+// those types); walk that chain until we find the underlying
+// *ccBalancerWrapper that holds the parent *ClientConn. If none is found,
+// fall back to a plain NewClient so the caller still gets a working channel.
+func newChannelForBalancer(parent balancer.ClientConn, target string, opts ...DialOption) (*ClientConn, error) {
+	type unwrapper interface{ Unwrap() balancer.ClientConn }
+	var ccb *ccBalancerWrapper
+	seen := make(map[balancer.ClientConn]struct{})
+	for cur := parent; cur != nil; {
+		if c, ok := cur.(*ccBalancerWrapper); ok {
+			ccb = c
+			break
+		}
+		if _, dup := seen[cur]; dup {
+			break
+		}
+		seen[cur] = struct{}{}
+		u, ok := cur.(unwrapper)
+		if !ok {
+			break
+		}
+		next := u.Unwrap()
+		if next == nil || next == cur {
+			break
+		}
+		cur = next
+	}
+	if ccb == nil || ccb.cc == nil {
+		return NewClient(target, opts...)
+	}
+	pd := ccb.cc.dopts
+	inherited := make([]DialOption, 0, len(pd.copts.StatsHandlers)+4)
+	for _, sh := range pd.copts.StatsHandlers {
+		inherited = append(inherited, WithStatsHandler(sh))
+	}
+	if pd.unaryInt != nil {
+		inherited = append(inherited, WithUnaryInterceptor(pd.unaryInt))
+	}
+	if len(pd.chainUnaryInts) > 0 {
+		inherited = append(inherited, WithChainUnaryInterceptor(pd.chainUnaryInts...))
+	}
+	if pd.streamInt != nil {
+		inherited = append(inherited, WithStreamInterceptor(pd.streamInt))
+	}
+	if len(pd.chainStreamInts) > 0 {
+		inherited = append(inherited, WithChainStreamInterceptor(pd.chainStreamInts...))
+	}
+	return NewClient(target, append(inherited, opts...)...)
 }
 
 func (cc *ClientConn) maybeApplyDefaultServiceConfig() {

--- a/internal/balancer/gracefulswitch/gracefulswitch.go
+++ b/internal/balancer/gracefulswitch/gracefulswitch.go
@@ -302,6 +302,13 @@ type balancerWrapper struct {
 	subconns  map[balancer.SubConn]bool // subconns created by this balancer
 }
 
+// Unwrap returns the ClientConn that this wrapper delegates to. It lets
+// gRPC-internal callers walk past the graceful-switch layer to reach the
+// underlying parent ClientConn.
+func (bw *balancerWrapper) Unwrap() balancer.ClientConn {
+	return bw.ClientConn
+}
+
 // Close closes the underlying LB policy and shuts down the subconns it
 // created. bw must not be referenced via balancerCurrent or balancerPending in
 // gsb when called. gsb.mu must not be held.  Does not panic with a nil

--- a/internal/balancergroup/balancergroup.go
+++ b/internal/balancergroup/balancergroup.go
@@ -73,6 +73,13 @@ type subBalancerWrapper struct {
 	balancer *gracefulswitch.Balancer
 }
 
+// Unwrap returns the ClientConn that this wrapper delegates to. It lets
+// gRPC-internal callers walk past the balancer-group layer to reach the
+// underlying parent ClientConn.
+func (sbc *subBalancerWrapper) Unwrap() balancer.ClientConn {
+	return sbc.ClientConn
+}
+
 // UpdateState overrides balancer.ClientConn, to keep state and picker.
 func (sbc *subBalancerWrapper) UpdateState(state balancer.State) {
 	sbc.mu.Lock()

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -143,6 +143,14 @@ var (
 	// provided grpc.ClientConn.
 	SubscribeToConnectivityStateChanges any // func(*grpc.ClientConn, grpcsync.Subscriber)
 
+	// NewChannelForBalancer creates a new grpc.ClientConn that inherits the
+	// parent ClientConn's stats handlers and client interceptors. It is meant
+	// to be used by LB policies that open their own control-plane channels
+	// (for example, RLS) so that per-attempt telemetry configured on the
+	// parent channel also covers those control-plane RPCs. The parent argument
+	// must be the balancer.ClientConn that gRPC passed to Balancer.Build.
+	NewChannelForBalancer any // func(parent balancer.ClientConn, target string, opts ...grpc.DialOption) (*grpc.ClientConn, error)
+
 	// NewXDSResolverWithConfigForTesting creates a new xds resolver builder using
 	// the provided xds bootstrap config instead of the global configuration from
 	// the supported environment variables.  The resolver.Builder is meant to be

--- a/internal/xds/balancer/clusterimpl/clusterimpl.go
+++ b/internal/xds/balancer/clusterimpl/clusterimpl.go
@@ -390,6 +390,13 @@ func (b *clusterImplBalancer) handleSecurityConfig(config *xdsresource.SecurityC
 	return nil
 }
 
+// Unwrap returns the ClientConn that this wrapper delegates to. It lets
+// gRPC-internal callers walk past the cluster_impl layer to reach the
+// underlying parent ClientConn.
+func (b *clusterImplBalancer) Unwrap() balancer.ClientConn {
+	return b.ClientConn
+}
+
 func (b *clusterImplBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
 	defer clientConnUpdateHook()
 

--- a/internal/xds/balancer/outlierdetection/balancer.go
+++ b/internal/xds/balancer/outlierdetection/balancer.go
@@ -233,6 +233,13 @@ type outlierDetectionBalancer struct {
 	pickerUpdateCh *buffer.Unbounded[any]
 }
 
+// Unwrap returns the ClientConn that this wrapper delegates to. It lets
+// gRPC-internal callers walk past the outlier-detection layer to reach the
+// underlying parent ClientConn.
+func (b *outlierDetectionBalancer) Unwrap() balancer.ClientConn {
+	return b.ClientConn
+}
+
 // noopConfig returns whether this balancer is configured with a logical no-op
 // configuration or not.
 //

--- a/internal/xds/balancer/priority/ignore_resolve_now.go
+++ b/internal/xds/balancer/priority/ignore_resolve_now.go
@@ -48,3 +48,10 @@ func (i *ignoreResolveNowClientConn) ResolveNow(o resolver.ResolveNowOptions) {
 	}
 	i.ClientConn.ResolveNow(o)
 }
+
+// Unwrap returns the ClientConn that this wrapper delegates to. It lets
+// gRPC-internal callers walk past the priority layer to reach the underlying
+// parent ClientConn.
+func (i *ignoreResolveNowClientConn) Unwrap() balancer.ClientConn {
+	return i.ClientConn
+}


### PR DESCRIPTION
> **Stacked on #9363.** This PR depends on #9363 (adds `Unwrap()` to the balancer.ClientConn-embedding wrappers). Please review #9363 first. Once it merges, this PR will be rebased onto master and its diff will shrink to just the changes below.

## Summary

RouteLookup RPCs issued on the RLS balancer's control channel were invisible to any stats handler configured on the parent `ClientConn` (e.g. OpenTelemetry's `grpc.client.attempt.duration` histogram), because the control channel was created via a bare `grpc.NewClient` call that had no way to see the parent channel's stats handlers or client interceptors.

## Approach

Introduce an internal hook `internal.NewChannelForBalancer` (populated in `clientconn.go` init, mirroring `SubscribeToConnectivityStateChanges` and other existing internal-hook patterns). It creates a new `ClientConn` while inheriting the parent's stats handlers and unary/stream interceptors (single and chained).

The parent is reached by walking the `balancer.ClientConn` wrapping chain via the `Unwrap() balancer.ClientConn` contract that every embedding wrapper implements after #9363. A `seen` set guards against cycles. No reflection — all wrapper hops are explicit.

RLS now dials via this hook (`balancer/rls/control_channel.go`) instead of `grpc.NewClient`; `rlsBalancer` passes its `b.cc` through.

## No public API change

No new fields on `balancer.BuildOptions`, no new methods on `balancer.ClientConn` — the mechanism is entirely internal, keeping the API surface stable.

## Verification

- Existing test suite passes: `./balancer/...`, `./stats/opentelemetry/...`, `./internal/balancer/...`, `./internal/balancergroup/...`, root grpc.
- New regression test `TestRLSControlChannelAttemptDurationMetric` in `balancer/rls/metrics_test.go` asserts a `grpc.client.attempt.duration` data point is recorded with `grpc.method=grpc.lookup.v1.RouteLookupService/RouteLookup` after a real dial with `opentelemetry.DialOption` triggers a RouteLookup via the RLS balancer.
- End-to-end verified against a real Bigtable DirectPath workload (~110s of traffic): RouteLookup attempts to `dns:///bigtablerls.googleapis.com` show up in `grpc.client.attempt.duration` with method, target, and status labels populated correctly.

## Test plan

- [ ] Confirm `go test ./...` passes in CI
- [ ] Confirm no regressions in xDS integration tests

RELEASE NOTES:
* rls: RouteLookup RPCs issued on the RLS balancer's control channel now inherit stats handlers and client interceptors configured on the parent ClientConn, so per-attempt telemetry (e.g. grpc.client.attempt.duration) covers RouteLookup RPCs.
