### PR TITLE
transport: skip HPACK indexing for per-RPC-unique request headers

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -623,7 +623,15 @@ func (t *http2Client) createHeaderFields(ctx context.Context, callHdr *CallHdr) 
 		if timeout <= 0 {
 			return nil, status.Error(codes.DeadlineExceeded, context.DeadlineExceeded.Error())
 		}
-		headerFields = append(headerFields, hpack.HeaderField{Name: "grpc-timeout", Value: grpcutil.EncodeDuration(timeout)})
+		// grpc-timeout carries the remaining time until the deadline, so its
+		// value is effectively unique on every RPC. Adding it to the HPACK
+		// dynamic table therefore never yields a compression hit on a later
+		// request; it only costs a map insert per RPC and evicts genuinely
+		// reusable entries (e.g. content-type, :authority) from the table.
+		// Marking the field as sensitive keeps the encoder from indexing it,
+		// which lowers CPU spent in the encoder and improves the compression
+		// ratio of the surrounding, reusable fields.
+		headerFields = append(headerFields, hpack.HeaderField{Name: "grpc-timeout", Value: grpcutil.EncodeDuration(timeout), Sensitive: true})
 	}
 	for k, v := range authData {
 		headerFields = append(headerFields, hpack.HeaderField{Name: k, Value: encodeMetadataHeader(k, v)})

--- a/internal/transport/http2_client_header_bench_test.go
+++ b/internal/transport/http2_client_header_bench_test.go
@@ -19,11 +19,14 @@
 package transport
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"testing"
 	"time"
 
+	"golang.org/x/net/http2/hpack"
+	"google.golang.org/grpc/internal/grpcutil"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -92,5 +95,80 @@ func BenchmarkCreateHeaderFields(b *testing.B) {
 				}
 			}
 		})
+	}
+}
+
+// stableClientHeaderBlock returns the reusable header fields a client sends on
+// every RPC (pseudo-headers, content-type, user-agent, te) plus mdCount pieces
+// of stable metadata. grpc-timeout is intentionally excluded; it is added by
+// the benchmark below with a fresh value per iteration.
+func stableClientHeaderBlock(mdCount int) []hpack.HeaderField {
+	hf := []hpack.HeaderField{
+		{Name: ":method", Value: "POST"},
+		{Name: ":scheme", Value: "https"},
+		{Name: ":path", Value: "/grpc.testing.BenchmarkService/UnaryCall"},
+		{Name: ":authority", Value: "server:443"},
+		{Name: "content-type", Value: "application/grpc"},
+		{Name: "user-agent", Value: "grpc-go/benchmark"},
+		{Name: "te", Value: "trailers"},
+	}
+	for i := 0; i < mdCount; i++ {
+		hf = append(hf, hpack.HeaderField{
+			Name:  fmt.Sprintf("header-%d", i),
+			Value: fmt.Sprintf("value-%d", i),
+		})
+	}
+	return hf
+}
+
+// BenchmarkEncodeGrpcTimeout isolates the HPACK encode path that dominates
+// header CPU on the wire. A single encoder is reused across iterations, exactly
+// as a transport reuses one encoder across every RPC, so the dynamic-table
+// state carries over between requests.
+//
+// grpc-timeout carries the remaining time to the deadline, so its value differs
+// on every RPC. The "indexed" case adds each unique value to the dynamic table
+// (map insert per RPC, and eventual eviction of the reusable entries once the
+// 4KB table fills), while the "sensitive" case skips indexing entirely. The
+// delta between the two is the cost this change removes.
+func BenchmarkEncodeGrpcTimeout(b *testing.B) {
+	for _, mdCount := range []int{0, 4, 12} {
+		for _, sensitive := range []bool{false, true} {
+			mode := "indexed"
+			if sensitive {
+				mode = "sensitive"
+			}
+			b.Run(fmt.Sprintf("mdCount=%d/%s", mdCount, mode), func(b *testing.B) {
+				stable := stableClientHeaderBlock(mdCount)
+				var buf bytes.Buffer
+				enc := hpack.NewEncoder(&buf)
+				start := time.Now()
+
+				b.ReportAllocs()
+				var i int
+				for b.Loop() {
+					// Advance the deadline so EncodeDuration yields a distinct
+					// value each iteration, mirroring production traffic.
+					timeout := time.Until(start.Add(time.Duration(i) * time.Microsecond))
+					if timeout <= 0 {
+						timeout = time.Duration(i) * time.Microsecond
+					}
+					i++
+					buf.Reset()
+					for _, f := range stable {
+						if err := enc.WriteField(f); err != nil {
+							b.Fatal(err)
+						}
+					}
+					if err := enc.WriteField(hpack.HeaderField{
+						Name:      "grpc-timeout",
+						Value:     grpcutil.EncodeDuration(timeout),
+						Sensitive: sensitive,
+					}); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
 	}
 }

--- a/internal/transport/http2_client_header_test.go
+++ b/internal/transport/http2_client_header_test.go
@@ -1,0 +1,78 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package transport
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/metadata"
+)
+
+// TestCreateHeaderFieldsGrpcTimeoutNeverIndexed verifies that grpc-timeout,
+// whose value is unique on essentially every RPC, is marked sensitive so the
+// HPACK encoder does not add it to its dynamic table, while ordinary reusable
+// headers remain indexable.
+func (s) TestCreateHeaderFieldsGrpcTimeoutNeverIndexed(t *testing.T) {
+	tr := &http2Client{
+		scheme:    "https",
+		userAgent: "grpc-go/test",
+		md:        metadata.MD{},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.MD{
+		"x-user-header": []string{"stable-value"},
+	})
+	callHdr := &CallHdr{
+		Method: "/grpc.testing.TestService/UnaryCall",
+		Host:   "server:443",
+	}
+
+	hf, err := tr.createHeaderFields(ctx, callHdr)
+	if err != nil {
+		t.Fatalf("createHeaderFields() failed: %v", err)
+	}
+
+	// wantSensitive maps a header name to whether it must be marked sensitive.
+	wantSensitive := map[string]bool{
+		"grpc-timeout":  true,  // remaining-time countdown, unique per RPC
+		"x-user-header": false, // ordinary reusable metadata
+		"content-type":  false, // reusable reserved header
+		":path":         false, // reusable across calls to the same method
+	}
+
+	seen := map[string]bool{}
+	for _, f := range hf {
+		want, ok := wantSensitive[f.Name]
+		if !ok {
+			continue
+		}
+		seen[f.Name] = true
+		if f.Sensitive != want {
+			t.Errorf("header %q: Sensitive = %v, want %v", f.Name, f.Sensitive, want)
+		}
+	}
+	for name := range wantSensitive {
+		if !seen[name] {
+			t.Errorf("expected header %q was not produced", name)
+		}
+	}
+}


### PR DESCRIPTION

The client transport shares a single HPACK encoder across every RPC on a
connection, so the encoder's dynamic table state persists between requests.
grpc-timeout carries the remaining time until the deadline, so its value is
effectively unique on every RPC.

Adding such a value to the HPACK dynamic table never yields a compression hit on
a later request: the value is different every time. It only costs a map insert
per RPC and, once the 4KB table fills, evicts genuinely reusable entries such as
content-type and :authority, which then have to be re-added. Marking the field
as sensitive keeps the encoder from indexing it, which lowers CPU spent in the
encoder and keeps the surrounding reusable fields from being evicted.

An isolated encode benchmark (single reused encoder, fresh grpc-timeout per
iteration, Apple M4) shows the encode path getting faster once grpc-timeout is
no longer indexed:

    metadata fields   indexed      never-indexed   delta
    0                 ~380 ns/op   ~294 ns/op       -23%
    4                 ~498 ns/op   ~416 ns/op       -16%
    12                ~765 ns/op   ~697 ns/op        -9%

The sensitive value is still Huffman-encoded, so the bytes on the wire for the
value itself are unchanged; only the dynamic-table entry is dropped. The
"never indexed" literal representation is standard HPACK (RFC 7541 §6.2.3) and
is decoded by any compliant peer.

RELEASE NOTES:
* transport: reduce client CPU by not adding the per-RPC-unique grpc-timeout
  header to the HPACK dynamic table