### PR TITLE
transport: add opt-in env var to never-index high-cardinality headers…

### DIFF
--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -169,7 +169,58 @@ var (
 	//
 	// TODO: Remove this env var once v1.85.0 is released.
 	EnableReceiveBufferCompaction = boolFromEnv("GRPC_GO_EXPERIMENTAL_ENABLE_RECEIVE_BUFFER_COMPACTION", true)
+
+	// HPACKNeverIndexHeaders is the set of outgoing header names that the
+	// client transport encodes as HPACK "never indexed" literals instead of
+	// adding them to the dynamic table. It is configured via the
+	// comma-separated, case-insensitive environment variable
+	// "GRPC_GO_EXPERIMENTAL_HPACK_NEVER_INDEX_HEADERS", e.g.
+	// "traceparent,x-request-id", and is empty by default.
+	//
+	// This is a CPU-for-bandwidth trade-off, and it is a loss for most
+	// applications; do not enable it without measuring. It is only worth
+	// considering for headers whose value differs on (almost) every RPC, such
+	// as trace or request identifiers.
+	//
+	// Indexing such a header inserts a dynamic table entry that no later RPC
+	// will ever match, so the entry is pure churn: every request pays for a
+	// table insert, and, once the table is full, for evicting the oldest entry
+	// and shifting the remainder. Never-indexing removes that work. It also
+	// lets the encoder skip the name+value lookup that is guaranteed to miss,
+	// and keeps the entry out of the receiving peer's table as well.
+	//
+	// The cost is bandwidth: the header *name* is kept out of the table too, so
+	// it is re-sent as a literal on every RPC instead of being referenced by a
+	// one-byte index. BenchmarkHPACKNeverIndex in internal/transport measures
+	// both sides and should be re-run on the workload in question before
+	// enabling this.
+	//
+	// Note that grpc-timeout is not configurable here: it is a reserved header
+	// that the transport writes directly and never reads from metadata.
+	HPACKNeverIndexHeaders = stringSetFromEnv("GRPC_GO_EXPERIMENTAL_HPACK_NEVER_INDEX_HEADERS")
 )
+
+// stringSetFromEnv parses a comma-separated environment variable into a set of
+// lower-cased, trimmed, non-empty entries. It returns nil if the variable is
+// unset or if it contains no non-empty entries.
+func stringSetFromEnv(envVar string) map[string]struct{} {
+	v := os.Getenv(envVar)
+	if v == "" {
+		return nil
+	}
+	var set map[string]struct{}
+	for s := range strings.SplitSeq(v, ",") {
+		s = strings.ToLower(strings.TrimSpace(s))
+		if s == "" {
+			continue
+		}
+		if set == nil {
+			set = make(map[string]struct{})
+		}
+		set[s] = struct{}{}
+	}
+	return set
+}
 
 func boolFromEnv(envVar string, def bool) bool {
 	if def {

--- a/internal/envconfig/envconfig_test.go
+++ b/internal/envconfig/envconfig_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/internal/grpctest"
 )
 
@@ -97,6 +98,52 @@ func (s) TestBoolFromEnv(t *testing.T) {
 			}
 			if got := boolFromEnv(testVar, tc.def); got != tc.want {
 				t.Errorf("boolFromEnv(%q(=%q), %v) = %v; want %v", testVar, tc.val, tc.def, got, tc.want)
+			}
+		})
+	}
+}
+
+func (s) TestStringSetFromEnv(t *testing.T) {
+	var testCases = []struct {
+		name string
+		val  string
+		set  bool // whether to set the env var at all
+		want map[string]struct{}
+	}{
+		{name: "unset", set: false, want: nil},
+		{name: "empty", val: "", set: true, want: nil},
+		{name: "whitespace only", val: "  , \t ,", set: true, want: nil},
+		{name: "single", val: "traceparent", set: true, want: map[string]struct{}{"traceparent": {}}},
+		{
+			name: "multiple with whitespace",
+			val:  " traceparent , x-request-id ",
+			set:  true,
+			want: map[string]struct{}{"traceparent": {}, "x-request-id": {}},
+		},
+		{
+			name: "lower-cased",
+			val:  "TraceParent,X-Request-Id",
+			set:  true,
+			want: map[string]struct{}{"traceparent": {}, "x-request-id": {}},
+		},
+		{
+			name: "duplicates and empties collapse",
+			val:  "a,,a, b ,b",
+			set:  true,
+			want: map[string]struct{}{"a": {}, "b": {}},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			const testVar = "testvar"
+			if !tc.set {
+				os.Unsetenv(testVar)
+			} else {
+				os.Setenv(testVar, tc.val)
+			}
+			got := stringSetFromEnv(testVar)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("stringSetFromEnv(%q(=%q)) unexpected result (-want +got):\n%s", testVar, tc.val, diff)
 			}
 		})
 	}

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -539,6 +539,33 @@ func (t *http2Client) outgoingGoAwayHandler(g *goAway) (bool, error) {
 	return false, g.closeConn
 }
 
+// hpackNeverIndex reports whether the outgoing header named k should be encoded
+// as an HPACK "never indexed" literal rather than being added to the encoder's
+// dynamic table. Nothing is never-indexed by default; the set is opt-in via the
+// GRPC_GO_EXPERIMENTAL_HPACK_NEVER_INDEX_HEADERS environment variable, whose
+// documentation describes the trade-off involved.
+//
+// The key k must be lower-cased, which holds for every call site: metadata keys
+// are validated as lower-case, and per-RPC credential keys are lower-cased in
+// getTrAuthData and getCallAuthData.
+//
+// Note that hpack.HeaderField.Sensitive maps onto RFC 7541 §6.2.3 ("Literal
+// Header Field Never Indexed"), which additionally forbids intermediaries from
+// indexing the field. §6.2.2 ("Literal Header Field without Indexing") would be
+// the closer fit for merely high-cardinality headers, but x/net/http2/hpack
+// offers no way to select it.
+func hpackNeverIndex(k string) bool {
+	// The set is empty unless the feature is opted into, which is the case for
+	// virtually every deployment. Check the length first: that compiles to a
+	// nil check on the map header, whereas a lookup on an empty map still costs
+	// a call into the runtime, and this runs for every header of every RPC.
+	if len(envconfig.HPACKNeverIndexHeaders) == 0 {
+		return false
+	}
+	_, ok := envconfig.HPACKNeverIndexHeaders[k]
+	return ok
+}
+
 func (t *http2Client) createHeaderFields(ctx context.Context, callHdr *CallHdr) ([]hpack.HeaderField, error) {
 	aud := t.createAudience(callHdr)
 	ri := credentials.RequestInfo{
@@ -626,10 +653,10 @@ func (t *http2Client) createHeaderFields(ctx context.Context, callHdr *CallHdr) 
 		headerFields = append(headerFields, hpack.HeaderField{Name: "grpc-timeout", Value: grpcutil.EncodeDuration(timeout)})
 	}
 	for k, v := range authData {
-		headerFields = append(headerFields, hpack.HeaderField{Name: k, Value: encodeMetadataHeader(k, v)})
+		headerFields = append(headerFields, hpack.HeaderField{Name: k, Value: encodeMetadataHeader(k, v), Sensitive: hpackNeverIndex(k)})
 	}
 	for k, v := range callAuthData {
-		headerFields = append(headerFields, hpack.HeaderField{Name: k, Value: encodeMetadataHeader(k, v)})
+		headerFields = append(headerFields, hpack.HeaderField{Name: k, Value: encodeMetadataHeader(k, v), Sensitive: hpackNeverIndex(k)})
 	}
 
 	if mdOK {
@@ -639,8 +666,9 @@ func (t *http2Client) createHeaderFields(ctx context.Context, callHdr *CallHdr) 
 			if isReservedHeader(k) {
 				continue
 			}
+			neverIndex := hpackNeverIndex(k)
 			for _, v := range vv {
-				headerFields = append(headerFields, hpack.HeaderField{Name: k, Value: encodeMetadataHeader(k, v)})
+				headerFields = append(headerFields, hpack.HeaderField{Name: k, Value: encodeMetadataHeader(k, v), Sensitive: neverIndex})
 			}
 		}
 		for _, vv := range added {
@@ -653,7 +681,7 @@ func (t *http2Client) createHeaderFields(ctx context.Context, callHdr *CallHdr) 
 				if isReservedHeader(k) {
 					continue
 				}
-				headerFields = append(headerFields, hpack.HeaderField{Name: k, Value: encodeMetadataHeader(k, v)})
+				headerFields = append(headerFields, hpack.HeaderField{Name: k, Value: encodeMetadataHeader(k, v), Sensitive: hpackNeverIndex(k)})
 			}
 		}
 	}
@@ -664,8 +692,9 @@ func (t *http2Client) createHeaderFields(ctx context.Context, callHdr *CallHdr) 
 		if err := imetadata.ValidatePair(k, vv...); err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
+		neverIndex := hpackNeverIndex(k)
 		for _, v := range vv {
-			headerFields = append(headerFields, hpack.HeaderField{Name: k, Value: encodeMetadataHeader(k, v)})
+			headerFields = append(headerFields, hpack.HeaderField{Name: k, Value: encodeMetadataHeader(k, v), Sensitive: neverIndex})
 		}
 	}
 	return headerFields, nil

--- a/internal/transport/http2_client_header_bench_test.go
+++ b/internal/transport/http2_client_header_bench_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/http2/hpack"
+	"google.golang.org/grpc/internal/envconfig"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -92,5 +94,108 @@ func BenchmarkCreateHeaderFields(b *testing.B) {
 				}
 			}
 		})
+	}
+}
+
+// countingWriter discards its input and records how many bytes it saw.
+type countingWriter struct{ n int64 }
+
+func (w *countingWriter) Write(p []byte) (int, error) {
+	w.n += int64(len(p))
+	return len(p), nil
+}
+
+// distinctValueCount is the number of pre-generated values each
+// high-cardinality header cycles through in BenchmarkHPACKNeverIndex. It only
+// has to exceed the number of entries the dynamic table can hold, so that a
+// value is always evicted long before it is reused and every RPC misses.
+const distinctValueCount = 1024
+
+// BenchmarkHPACKNeverIndex measures both sides of the trade-off made by
+// GRPC_GO_EXPERIMENTAL_HPACK_NEVER_INDEX_HEADERS: sec/op covers the whole
+// outgoing header path, and bytes/rpc covers what that costs on the wire.
+//
+// The header fields go through a single long-lived hpack.Encoder, as they do on
+// a real connection, so the dynamic table fills up and starts evicting. The
+// high-cardinality headers take a fresh value on every iteration, which is what
+// makes indexing them pure churn: the entry they add can never be matched
+// again. Values are generated up front so that the measured loop does no work
+// beyond building and encoding the header set.
+func BenchmarkHPACKNeverIndex(b *testing.B) {
+	// Header names whose value differs on (almost) every RPC. These are the
+	// kind of names the environment variable is meant to be pointed at.
+	highCardinality := []string{"grpc-trace-bin", "traceparent", "x-request-id"}
+
+	for _, n := range []int{1, 3} {
+		for _, neverIndex := range []bool{false, true} {
+			name := fmt.Sprintf("highCardinalityHeaders=%d/neverIndex=%v", n, neverIndex)
+			b.Run(name, func(b *testing.B) {
+				names := highCardinality[:n]
+
+				orig := envconfig.HPACKNeverIndexHeaders
+				b.Cleanup(func() { envconfig.HPACKNeverIndexHeaders = orig })
+				envconfig.HPACKNeverIndexHeaders = nil
+				if neverIndex {
+					set := make(map[string]struct{}, len(names))
+					for _, h := range names {
+						set[h] = struct{}{}
+					}
+					envconfig.HPACKNeverIndexHeaders = set
+				}
+
+				values := make(map[string][]string, len(names))
+				for _, h := range names {
+					vs := make([]string, distinctValueCount)
+					for i := range vs {
+						vs[i] = fmt.Sprintf("%s-%016d", h, i)
+					}
+					values[h] = vs
+				}
+
+				// The metadata is built once and its values are refreshed in
+				// place per iteration; allocating a fresh context and metadata
+				// map per RPC would dominate the measurement.
+				md := make(metadata.MD, len(names)+1)
+				md["x-stable-header"] = []string{"stable-value"}
+				for _, h := range names {
+					md[h] = []string{values[h][0]}
+				}
+				ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+				defer cancel()
+				ctx = metadata.NewOutgoingContext(ctx, md)
+
+				t := &http2Client{
+					scheme:    "https",
+					userAgent: "grpc-go/benchmark",
+					md:        metadata.MD{},
+				}
+				callHdr := &CallHdr{
+					Method: "/grpc.testing.BenchmarkService/UnaryCall",
+					Host:   "server:443",
+				}
+				cw := &countingWriter{}
+				enc := hpack.NewEncoder(cw)
+				rpcs := int64(0)
+
+				b.ReportAllocs()
+				for b.Loop() {
+					i := int(rpcs) % distinctValueCount
+					for _, h := range names {
+						md[h][0] = values[h][i]
+					}
+					hf, err := t.createHeaderFields(ctx, callHdr)
+					if err != nil {
+						b.Fatal(err)
+					}
+					for _, f := range hf {
+						if err := enc.WriteField(f); err != nil {
+							b.Fatal(err)
+						}
+					}
+					rpcs++
+				}
+				b.ReportMetric(float64(cw.n)/float64(rpcs), "bytes/rpc")
+			})
+		}
 	}
 }

--- a/internal/transport/http2_client_test.go
+++ b/internal/transport/http2_client_test.go
@@ -1,0 +1,198 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package transport
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"golang.org/x/net/http2/hpack"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/internal/envconfig"
+	"google.golang.org/grpc/metadata"
+)
+
+// staticPerRPCCreds returns a fixed set of per-RPC credential headers.
+type staticPerRPCCreds map[string]string
+
+func (c staticPerRPCCreds) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
+	return c, nil
+}
+
+func (staticPerRPCCreds) RequireTransportSecurity() bool { return false }
+
+// setNeverIndexHeaders overrides the env-derived never-index set for the
+// duration of the test. The set is parsed into a package variable at init
+// time, so it has to be replaced directly rather than via the environment.
+func setNeverIndexHeaders(t *testing.T, names ...string) {
+	t.Helper()
+	orig := envconfig.HPACKNeverIndexHeaders
+	t.Cleanup(func() { envconfig.HPACKNeverIndexHeaders = orig })
+	set := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		set[n] = struct{}{}
+	}
+	envconfig.HPACKNeverIndexHeaders = set
+}
+
+// TestCreateHeaderFieldsNeverIndex verifies that headers named by
+// GRPC_GO_EXPERIMENTAL_HPACK_NEVER_INDEX_HEADERS are marked sensitive across
+// every source of outgoing headers - outgoing context metadata, metadata
+// appended via AppendToOutgoingContext, transport-level metadata and per-RPC
+// credentials - while headers outside the set stay indexable.
+func (s) TestCreateHeaderFieldsNeverIndex(t *testing.T) {
+	setNeverIndexHeaders(t, "x-request-id", "x-appended-id", "x-transport-id", "authorization")
+
+	tr := &http2Client{
+		scheme:      "https",
+		userAgent:   "grpc-go/test",
+		md:          metadata.MD{"x-transport-id": []string{"transport-value"}, "x-transport-stable": []string{"stable"}},
+		perRPCCreds: []credentials.PerRPCCredentials{staticPerRPCCreds{"authorization": "Bearer token", "x-creds-stable": "stable"}},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.MD{
+		"x-request-id":  []string{"abc-123"},
+		"x-user-header": []string{"stable-value"},
+	})
+	ctx = metadata.AppendToOutgoingContext(ctx, "x-appended-id", "def-456", "x-appended-stable", "stable")
+	callHdr := &CallHdr{
+		Method: "/grpc.testing.TestService/UnaryCall",
+		Host:   "server:443",
+	}
+
+	hf, err := tr.createHeaderFields(ctx, callHdr)
+	if err != nil {
+		t.Fatalf("createHeaderFields() failed: %v", err)
+	}
+
+	// wantSensitive maps a header name to whether it must be marked sensitive.
+	wantSensitive := map[string]bool{
+		"x-request-id":       true,  // outgoing context metadata, in the set
+		"x-appended-id":      true,  // AppendToOutgoingContext, in the set
+		"x-transport-id":     true,  // transport metadata, in the set
+		"authorization":      true,  // per-RPC credentials, in the set
+		"x-user-header":      false, // outgoing context metadata, not in the set
+		"x-appended-stable":  false, // AppendToOutgoingContext, not in the set
+		"x-transport-stable": false, // transport metadata, not in the set
+		"x-creds-stable":     false, // per-RPC credentials, not in the set
+		"content-type":       false, // reserved header, never in the set
+	}
+
+	seen := map[string]bool{}
+	for _, f := range hf {
+		want, ok := wantSensitive[f.Name]
+		if !ok {
+			continue
+		}
+		seen[f.Name] = true
+		if f.Sensitive != want {
+			t.Errorf("header %q: Sensitive = %v, want %v", f.Name, f.Sensitive, want)
+		}
+	}
+	for name := range wantSensitive {
+		if !seen[name] {
+			t.Errorf("expected header %q was not produced", name)
+		}
+	}
+}
+
+// TestCreateHeaderFieldsNeverIndexDefaultOff verifies that no header is marked
+// sensitive when the environment variable is unset, i.e. that the feature does
+// not change the wire format unless it is explicitly opted into.
+func (s) TestCreateHeaderFieldsNeverIndexDefaultOff(t *testing.T) {
+	setNeverIndexHeaders(t) // empty set, matching an unset env var
+
+	tr := &http2Client{
+		scheme:      "https",
+		userAgent:   "grpc-go/test",
+		md:          metadata.MD{},
+		perRPCCreds: []credentials.PerRPCCredentials{staticPerRPCCreds{"authorization": "Bearer token"}},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.MD{"grpc-trace-bin": []string{"\x00spanid"}})
+	ctx = metadata.AppendToOutgoingContext(ctx, "traceparent", "00-abc-def-01")
+
+	hf, err := tr.createHeaderFields(ctx, &CallHdr{Method: "/grpc.testing.TestService/UnaryCall", Host: "server:443"})
+	if err != nil {
+		t.Fatalf("createHeaderFields() failed: %v", err)
+	}
+	for _, f := range hf {
+		if f.Sensitive {
+			t.Errorf("header %q is marked sensitive; want no sensitive headers by default", f.Name)
+		}
+	}
+}
+
+// TestNeverIndexHPACKEncoding verifies the effect the Sensitive flag actually
+// has on the wire: a never-indexed header is not added to the encoder's dynamic
+// table, so encoding it a second time produces the same bytes rather than a
+// short reference to a table entry, and it decodes back as sensitive.
+func (s) TestNeverIndexHPACKEncoding(t *testing.T) {
+	encodeTwice := func(f hpack.HeaderField) (first, second []byte) {
+		var buf bytes.Buffer
+		enc := hpack.NewEncoder(&buf)
+		if err := enc.WriteField(f); err != nil {
+			t.Fatalf("WriteField(%v) failed: %v", f, err)
+		}
+		first = bytes.Clone(buf.Bytes())
+		buf.Reset()
+		if err := enc.WriteField(f); err != nil {
+			t.Fatalf("WriteField(%v) failed: %v", f, err)
+		}
+		return first, bytes.Clone(buf.Bytes())
+	}
+
+	const name, value = "x-request-id", "abc-123"
+
+	indexedFirst, indexedSecond := encodeTwice(hpack.HeaderField{Name: name, Value: value})
+	if len(indexedSecond) >= len(indexedFirst) {
+		t.Errorf("indexed header: second encoding is %d bytes, want fewer than the first (%d); "+
+			"the header should have been served from the dynamic table",
+			len(indexedSecond), len(indexedFirst))
+	}
+
+	neverFirst, neverSecond := encodeTwice(hpack.HeaderField{Name: name, Value: value, Sensitive: true})
+	if !bytes.Equal(neverFirst, neverSecond) {
+		t.Errorf("never-indexed header: encodings differ (%v vs %v); want identical bytes, "+
+			"as the header must not enter the dynamic table", neverFirst, neverSecond)
+	}
+	// A never-indexed literal costs the full header name on every request,
+	// which is the bandwidth side of the trade-off documented on
+	// envconfig.HPACKNeverIndexHeaders.
+	if len(neverSecond) <= len(indexedSecond) {
+		t.Errorf("never-indexed repeat encoding is %d bytes, indexed repeat is %d; "+
+			"want never-indexed to be larger", len(neverSecond), len(indexedSecond))
+	}
+
+	var decoded []hpack.HeaderField
+	dec := hpack.NewDecoder(4096, func(f hpack.HeaderField) { decoded = append(decoded, f) })
+	if _, err := dec.Write(neverFirst); err != nil {
+		t.Fatalf("Decoder.Write() failed: %v", err)
+	}
+	if len(decoded) != 1 {
+		t.Fatalf("decoded %d header fields, want 1", len(decoded))
+	}
+	if !decoded[0].Sensitive {
+		t.Errorf("decoded header %q is not sensitive; want the never-indexed representation", decoded[0].Name)
+	}
+}


### PR DESCRIPTION
… in HPACK

The client transport shares a single HPACK encoder across every RPC on a connection, so the encoder's dynamic table state persists between requests. Indexing a header whose value differs on (almost) every RPC - a trace or request identifier, for example - is pure churn: the dynamic-table entry it adds can never be matched by a later request, yet every RPC pays for the insert and, once the 4KB table fills, for evicting the oldest entry, which can also push out genuinely reusable entries such as content-type and :authority.

Add a comma-separated, case-insensitive environment variable, GRPC_GO_EXPERIMENTAL_HPACK_NEVER_INDEX_HEADERS, listing outgoing header names that the client encodes as HPACK "never indexed" literals (RFC 7541 6.2.3) instead of adding them to the dynamic table. It applies across every source of outgoing headers (outgoing-context metadata, AppendToOutgoingContext, transport metadata and per-RPC credentials) and defaults to empty, so the wire format is unchanged unless the feature is explicitly opted into.

This is a CPU-for-bandwidth trade-off and is not a win for every workload: a never-indexed header keeps its name out of the table too, so the name is re-sent as a literal on each RPC rather than referenced by a one-byte index. BenchmarkHPACKNeverIndex measures both sides (sec/op and bytes/rpc). The variable is meant for CPU-bound deployments to point at the specific high-cardinality headers they send; it should not list headers whose value repeats.

RELEASE NOTES:
* transport: add the experimental GRPC_GO_EXPERIMENTAL_HPACK_NEVER_INDEX_HEADERS environment variable to keep listed high-cardinality headers out of the HPACK dynamic table

