### PR TITLE
transport : cancel ctx after swapping the state in server's cancelStream and finishStream

### DIFF
--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -1013,7 +1013,11 @@ func (t *http2Server) streamContextErr(s *ServerStream) error {
 		return ErrConnClosing
 	default:
 	}
-	return ContextErr(s.ctx.Err())
+	err := s.ctx.Err()
+	if err == nil {
+		err = context.Canceled
+	}
+	return ContextErr(err)
 }
 
 // WriteHeader sends the header metadata md back to the client.
@@ -1359,15 +1363,16 @@ func (t *http2Server) finishStream(s *ServerStream, rst bool, rstCode http2.ErrC
 
 // closeStream clears the footprint of a stream when the stream is not needed any more.
 func (t *http2Server) closeStream(s *ServerStream, rst bool, rstCode http2.ErrCode, eosReceived bool) {
+	// We can't return early even if the stream's state is "done" as the state
+	// might have been set by the `finishStream` method. Deleting the stream via
+	// `finishStream` can get blocked on flow control.
+	s.swapState(streamDone)
+
 	// In case stream sending and receiving are invoked in separate
 	// goroutines (e.g., bi-directional streaming), cancel needs to be
 	// called to interrupt the potential blocking on other goroutines.
 	s.cancel()
 
-	// We can't return early even if the stream's state is "done" as the state
-	// might have been set by the `finishStream` method. Deleting the stream via
-	// `finishStream` can get blocked on flow control.
-	s.swapState(streamDone)
 	t.deleteStream(s, eosReceived)
 
 	t.controlBuf.put(&cleanupStream{

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -1015,6 +1015,12 @@ func (t *http2Server) streamContextErr(s *ServerStream) error {
 	}
 	err := s.ctx.Err()
 	if err == nil {
+		// In closeStream and finishStream, the stream state is transitioned to
+		// streamDone before s.cancel() is invoked so that concurrent operations
+		// immediately observe the terminal state. A concurrent caller (such as
+		// write or writeHeader) can see streamDone and invoke streamContextErr
+		// before s.cancel() runs or propagates to s.ctx. Default to
+		// context.Canceled rather than passing nil to ContextErr.
 		err = context.Canceled
 	}
 	return ContextErr(err)
@@ -1339,16 +1345,17 @@ func (t *http2Server) deleteStream(s *ServerStream, eosReceived bool) {
 
 // finishStream closes the stream and puts the trailing headerFrame into controlbuf.
 func (t *http2Server) finishStream(s *ServerStream, rst bool, rstCode http2.ErrCode, hdr *serverHeaders, eosReceived bool) {
-	// In case stream sending and receiving are invoked in separate
-	// goroutines (e.g., bi-directional streaming), cancel needs to be
-	// called to interrupt the potential blocking on other goroutines.
-	s.cancel()
 
 	oldState := s.swapState(streamDone)
 	if oldState == streamDone {
 		// If the stream was already done, return.
 		return
 	}
+
+	// In case stream sending and receiving are invoked in separate
+	// goroutines (e.g., bi-directional streaming), cancel needs to be
+	// called to interrupt the potential blocking on other goroutines.
+	s.cancel()
 
 	hdr.cleanup = &cleanupStream{
 		streamID: s.id,


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/5344

Race condition :
In [http2Server.closeStream](https://github.com/grpc/grpc-go/blob/4793ad0474669eafbd5346c8a3d098fdfa542498/internal/transport/http2_server.go#L1355), s.cancel() was invoked before s.swapState(streamDone) and [deleteStream](https://github.com/grpc/grpc-go/blob/master/internal/transport/http2_server.go#L1310).

When a stream was aborted remotely (e.g., via an HTTP/2 RST_STREAM frame upon client cancellation), the frame reader invoked [closeStream(eosReceived=false)](https://github.com/grpc/grpc-go/blob/master/internal/transport/http2_server.go#L1355).
Calling s.cancel() at the beginning of closeStream immediately closed s.ctxDone and unblocked the server application handler waiting in stream.Recv().

If the unblocked server handler reached [writeStatus](https://github.com/grpc/grpc-go/blob/master/internal/transport/http2_server.go#L1140) -> [finishStream](https://github.com/grpc/grpc-go/blob/master/internal/transport/http2_server.go#L1331) before closeStream completed s.swapState(streamDone) and deleteStream, [finishStream](https://github.com/grpc/grpc-go/blob/master/internal/transport/http2_server.go#L1331) swapped the stream state first and queued a completion with eosReceived=true. Consequently, StreamsSucceeded was incremented instead of StreamsFailed, causing flaky test failures in TestCZServerSocketMetricsStreamsAndMessagesCount.

Additionally, because s.swapState(streamDone) is now executed before s.cancel(), a concurrent writer (such as a server handler invoking stream.Send() or stream.SetHeader()) could observe s.getState() == streamDone during the microsecond window before s.cancel() executes. In that window, [http2Server.streamContextErr](https://github.com/grpc/grpc-go/blob/master/internal/transport/http2_server.go#L1004) was called while s.ctx.Err() was still nil. Passing nil into [ContextErr](https://github.com/grpc/grpc-go/blob/master/internal/transport/transport.go#L864) caused it to fall through to status.Errorf(codes.Internal, "Unexpected error from context packet: <nil>") instead of returning codes.Canceled.

Fix :
Reordered operations in [http2Server.closeStream](https://github.com/grpc/grpc-go/blob/master/internal/transport/http2_server.go#L1355) so that s.cancel() is called after s.swapState(streamDone) and t.deleteStream(s, eosReceived).

Updated [http2Server.streamContextErr](https://github.com/grpc/grpc-go/blob/master/internal/transport/http2_server.go#L1004) to fall back to context.Canceled when s.ctx.Err() is nil. This guarantees that if a concurrent write operation is rejected because the stream is marked streamDone, it safely and consistently returns codes.Canceled rather than an unexpected codes.Internal error.

RELEASE NOTES: None