### PR TITLE
xds: reject ring_hash cluster with out-of-range or inverted ring size

### DIFF
--- a/internal/xds/xdsclient/xdsresource/unmarshal_cds.go
+++ b/internal/xds/xdsclient/xdsresource/unmarshal_cds.go
@@ -137,6 +137,15 @@ func validateClusterAndConstructClusterUpdate(cluster *v3clusterpb.Cluster, serv
 		if max := rhc.GetMaximumRingSize(); max != nil {
 			maxSize = max.GetValue()
 		}
+		if minSize > ringHashSizeUpperBound {
+			return ClusterUpdate{}, fmt.Errorf("ring_hash_lb_config.minimum_ring_size %d is greater than upper bound %d in response: %+v", minSize, ringHashSizeUpperBound, cluster)
+		}
+		if maxSize > ringHashSizeUpperBound {
+			return ClusterUpdate{}, fmt.Errorf("ring_hash_lb_config.maximum_ring_size %d is greater than upper bound %d in response: %+v", maxSize, ringHashSizeUpperBound, cluster)
+		}
+		if minSize > maxSize {
+			return ClusterUpdate{}, fmt.Errorf("ring_hash_lb_config.minimum_ring_size %d is greater than maximum_ring_size %d in response: %+v", minSize, maxSize, cluster)
+		}
 
 		rhLBCfg := []byte(fmt.Sprintf("{\"minRingSize\": %d, \"maxRingSize\": %d}", minSize, maxSize))
 		lbPolicy = []byte(fmt.Sprintf(`[{"ring_hash_experimental": %s}]`, rhLBCfg))

--- a/internal/xds/xdsclient/xdsresource/unmarshal_cds_test.go
+++ b/internal/xds/xdsclient/xdsresource/unmarshal_cds_test.go
@@ -166,10 +166,43 @@ func (s) TestValidateCluster_Failure(t *testing.T) {
 		{
 			name: "ring-hash-max-bound-greater-than-upper-bound",
 			cluster: &v3clusterpb.Cluster{
+				Name:                 clusterName,
+				ClusterDiscoveryType: &v3clusterpb.Cluster_Type{Type: v3clusterpb.Cluster_EDS},
+				EdsClusterConfig: &v3clusterpb.Cluster_EdsClusterConfig{
+					EdsConfig: &v3corepb.ConfigSource{
+						ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{
+							Ads: &v3corepb.AggregatedConfigSource{},
+						},
+					},
+					ServiceName: serviceName,
+				},
 				LbPolicy: v3clusterpb.Cluster_RING_HASH,
 				LbConfig: &v3clusterpb.Cluster_RingHashLbConfig_{
 					RingHashLbConfig: &v3clusterpb.Cluster_RingHashLbConfig{
 						MaximumRingSize: wrapperspb.UInt64(ringHashSizeUpperBound + 1),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "ring-hash-min-greater-than-max",
+			cluster: &v3clusterpb.Cluster{
+				Name:                 clusterName,
+				ClusterDiscoveryType: &v3clusterpb.Cluster_Type{Type: v3clusterpb.Cluster_EDS},
+				EdsClusterConfig: &v3clusterpb.Cluster_EdsClusterConfig{
+					EdsConfig: &v3corepb.ConfigSource{
+						ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{
+							Ads: &v3corepb.AggregatedConfigSource{},
+						},
+					},
+					ServiceName: serviceName,
+				},
+				LbPolicy: v3clusterpb.Cluster_RING_HASH,
+				LbConfig: &v3clusterpb.Cluster_RingHashLbConfig_{
+					RingHashLbConfig: &v3clusterpb.Cluster_RingHashLbConfig{
+						MinimumRingSize: wrapperspb.UInt64(5000),
+						MaximumRingSize: wrapperspb.UInt64(100),
 					},
 				},
 			},

--- a/internal/xds/xdsclient/xdsresource/unmarshal_cds_test.go
+++ b/internal/xds/xdsclient/xdsresource/unmarshal_cds_test.go
@@ -59,7 +59,7 @@ func (s) TestValidateCluster_Failure(t *testing.T) {
 	tests := []struct {
 		name    string
 		cluster *v3clusterpb.Cluster
-		wantErr bool
+		wantErr string
 	}{
 		{
 			name: "non-supported-cluster-type-static",
@@ -74,7 +74,7 @@ func (s) TestValidateCluster_Failure(t *testing.T) {
 				},
 				LbPolicy: v3clusterpb.Cluster_LEAST_REQUEST,
 			},
-			wantErr: true,
+			wantErr: "unsupported cluster type",
 		},
 		{
 			name: "non-supported-cluster-type-original-dst",
@@ -89,7 +89,7 @@ func (s) TestValidateCluster_Failure(t *testing.T) {
 				},
 				LbPolicy: v3clusterpb.Cluster_LEAST_REQUEST,
 			},
-			wantErr: true,
+			wantErr: "unsupported cluster type",
 		},
 		{
 			name: "no-eds-config",
@@ -97,7 +97,7 @@ func (s) TestValidateCluster_Failure(t *testing.T) {
 				ClusterDiscoveryType: &v3clusterpb.Cluster_Type{Type: v3clusterpb.Cluster_EDS},
 				LbPolicy:             v3clusterpb.Cluster_ROUND_ROBIN,
 			},
-			wantErr: true,
+			wantErr: "CDS's EDS config source is not ADS or Self",
 		},
 		{
 			name: "no-ads-config-source",
@@ -106,7 +106,7 @@ func (s) TestValidateCluster_Failure(t *testing.T) {
 				EdsClusterConfig:     &v3clusterpb.Cluster_EdsClusterConfig{},
 				LbPolicy:             v3clusterpb.Cluster_ROUND_ROBIN,
 			},
-			wantErr: true,
+			wantErr: "CDS's EDS config source is not ADS or Self",
 		},
 		{
 			name: "unsupported-lb-policy",
@@ -121,7 +121,7 @@ func (s) TestValidateCluster_Failure(t *testing.T) {
 				},
 				LbPolicy: v3clusterpb.Cluster_MAGLEV,
 			},
-			wantErr: true,
+			wantErr: "unexpected lbPolicy MAGLEV",
 		},
 		{
 			name: "logical-dns-multiple-localities",
@@ -137,7 +137,7 @@ func (s) TestValidateCluster_Failure(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: "load_assignment for LOGICAL_DNS cluster must have exactly one locality",
 		},
 		{
 			name: "ring-hash-hash-function-not-xx-hash",
@@ -149,19 +149,19 @@ func (s) TestValidateCluster_Failure(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: "unsupported ring_hash hash function MURMUR_HASH_2",
 		},
 		{
 			name: "least-request-choice-count-less-than-two",
 			cluster: &v3clusterpb.Cluster{
-				LbPolicy: v3clusterpb.Cluster_RING_HASH,
+				LbPolicy: v3clusterpb.Cluster_LEAST_REQUEST,
 				LbConfig: &v3clusterpb.Cluster_LeastRequestLbConfig_{
 					LeastRequestLbConfig: &v3clusterpb.Cluster_LeastRequestLbConfig{
 						ChoiceCount: wrapperspb.UInt32(1),
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: "Cluster_LeastRequestLbConfig.ChoiceCount must be >= 2",
 		},
 		{
 			name: "ring-hash-max-bound-greater-than-upper-bound",
@@ -183,7 +183,7 @@ func (s) TestValidateCluster_Failure(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: "ring_hash_lb_config.maximum_ring_size 8388609 is greater than upper bound 8388608",
 		},
 		{
 			name: "ring-hash-min-greater-than-max",
@@ -206,7 +206,7 @@ func (s) TestValidateCluster_Failure(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: "ring_hash_lb_config.minimum_ring_size 5000 is greater than maximum_ring_size 100",
 		},
 		{
 			name: "ring-hash-max-bound-greater-than-upper-bound-load-balancing-policy",
@@ -235,7 +235,7 @@ func (s) TestValidateCluster_Failure(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: "error converting LoadBalancingPolicy",
 		},
 		{
 			name: "least-request-unsupported-in-converter-since-env-var-unset",
@@ -260,7 +260,7 @@ func (s) TestValidateCluster_Failure(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: "no supported policy found in policy list",
 		},
 		{
 			name: "aggregate-nil-clusters",
@@ -274,7 +274,7 @@ func (s) TestValidateCluster_Failure(t *testing.T) {
 				},
 				LbPolicy: v3clusterpb.Cluster_ROUND_ROBIN,
 			},
-			wantErr: true,
+			wantErr: "aggregate cluster has empty clusters field",
 		},
 		{
 			name: "aggregate-empty-clusters",
@@ -290,14 +290,18 @@ func (s) TestValidateCluster_Failure(t *testing.T) {
 				},
 				LbPolicy: v3clusterpb.Cluster_ROUND_ROBIN,
 			},
-			wantErr: true,
+			wantErr: "aggregate cluster has empty clusters field",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if update, err := validateClusterAndConstructClusterUpdate(test.cluster, nil); err == nil {
-				t.Errorf("validateClusterAndConstructClusterUpdate(%+v) = %v, wanted error", test.cluster, update)
+			update, err := validateClusterAndConstructClusterUpdate(test.cluster, nil)
+			if err == nil {
+				t.Fatalf("validateClusterAndConstructClusterUpdate(%+v) = %v, wanted error containing %q", test.cluster, update, test.wantErr)
+			}
+			if !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("validateClusterAndConstructClusterUpdate(%+v) returned err: %v, wanted error containing %q", test.cluster, err, test.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
The legacy `Cluster.lb_policy: RING_HASH` field is parsed with no ring-size validation:

    validateClusterAndConstructClusterUpdate(... ring_hash_lb_config:{maximum_ring_size:{value:8388609}})            -> err=<nil>
    validateClusterAndConstructClusterUpdate(... ring_hash_lb_config:{minimum_ring_size:{value:5000} maximum_ring_size:{value:100}}) -> err=<nil>

Both should be NACKed: A50 caps the ring size at 8M, and the minimum must not exceed the maximum. The new-style `load_balancing_policy` path already rejects these at parse time because it round-trips the generated config through `BalancerConfig` (and so the ring_hash balancer's `parseConfig`). The legacy path stores the JSON unvalidated, so the cluster is ACKed and only fails later when the balancer builds, leaving it without a working picker while the management server sees the config as accepted.

Wire up the already-declared but unused `ringHashSizeUpperBound` and apply the same checks the balancer's `parseConfig` uses.

The existing `ring-hash-max-bound-greater-than-upper-bound` failure case never exercised this path: with no cluster discovery type set it errored on `unsupported cluster type (STATIC)` before reaching the ring-size logic. It now uses a valid EDS cluster, and a min>max case is added.

RELEASE NOTES: 
- xdsresource: Fix a bug where CDS resource with incorrect min and max ring sizes for ring hash endpoint policy is not NACKed