### PR TITLE
server: release mutex while waiting for handlers in stop()

### DIFF
--- a/server.go
+++ b/server.go
@@ -1719,7 +1719,13 @@ func (s *Server) stop(graceful bool) {
 	}
 
 	if graceful || s.opts.waitForHandlers {
+		// Release the lock while waiting for handlers to finish. Holding it
+		// here would deadlock a concurrent Stop() (the recommended way to abort
+		// a GracefulStop that is taking too long), because Stop() must acquire
+		// s.mu before it can force the server to shut down.
+		s.mu.Unlock()
 		s.handlersWG.Wait()
+		s.mu.Lock()
 	}
 
 	if s.events != nil {

--- a/test/gracefulstop_test.go
+++ b/test/gracefulstop_test.go
@@ -301,6 +301,79 @@ func (s) TestStopAbortsBlockingGRPCCall(t *testing.T) {
 	<-grpcClientCallReturned
 }
 
+// TestStopAfterGracefulStopWithRunningHandler verifies that Stop() returns
+// promptly when called concurrently with an in-progress GracefulStop() that is
+// blocked waiting on a handler which ignores context cancellation. This is the
+// recommended way to abort a GracefulStop that takes too long, and it must not
+// deadlock behind the server mutex.
+func (s) TestStopAfterGracefulStopWithRunningHandler(t *testing.T) {
+	handlerStarted := make(chan struct{})
+	unblockHandler := make(chan struct{})
+	ss := &stubserver.StubServer{
+		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+			close(handlerStarted)
+			// Ignore context cancellation to simulate a handler that does not
+			// promptly return when the server shuts down.
+			<-unblockHandler
+			return nil
+		},
+	}
+	if err := ss.Start(nil); err != nil {
+		t.Fatalf("Error starting endpoint server: %v", err)
+	}
+	defer ss.Stop()
+	handlerUnblocked := false
+	defer func() {
+		if !handlerUnblocked {
+			close(unblockHandler)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	if _, err := ss.Client.FullDuplexCall(ctx); err != nil {
+		t.Fatalf("Error starting FullDuplexCall: %v", err)
+	}
+	<-handlerStarted
+
+	// Close the client connection so the server transport drains while the
+	// handler is still running. GracefulStop will then remove the connection
+	// and block waiting on the running handler.
+	ss.CC.Close()
+
+	gracefulStopReturned := make(chan struct{})
+	go func() {
+		ss.S.GracefulStop()
+		close(gracefulStopReturned)
+	}()
+
+	// Give GracefulStop time to drain the connection and start waiting on the
+	// running handler.
+	time.Sleep(defaultTestShortTimeout)
+
+	stopReturned := make(chan struct{})
+	go func() {
+		ss.S.Stop()
+		close(stopReturned)
+	}()
+
+	select {
+	case <-stopReturned:
+	case <-time.After(defaultTestTimeout):
+		t.Fatal("Stop() did not return; it deadlocked behind GracefulStop() waiting for a running handler")
+	}
+
+	// Let the handler finish so GracefulStop can also return.
+	close(unblockHandler)
+	handlerUnblocked = true
+	select {
+	case <-gracefulStopReturned:
+	case <-time.After(defaultTestTimeout):
+		t.Fatal("GracefulStop() did not return after the handler completed")
+	}
+}
+
 // TestServeHTTP_GracefulStop verifies that calling GracefulStop on a server
 // using ServeHTTP returns properly.
 func (s) TestServeHTTP_GracefulStop(t *testing.T) {

--- a/test/gracefulstop_test.go
+++ b/test/gracefulstop_test.go
@@ -322,6 +322,10 @@ func (s) TestStopAfterGracefulStopWithRunningHandler(t *testing.T) {
 		t.Fatalf("Error starting endpoint server: %v", err)
 	}
 	defer ss.Stop()
+	// The handler blocks until unblockHandler is closed. If the test fails
+	// before reaching the normal unblock point below, this ensures the handler
+	// is released so its goroutine does not leak. handlerUnblocked guards
+	// against closing the channel twice.
 	handlerUnblocked := false
 	defer func() {
 		if !handlerUnblocked {
@@ -335,7 +339,11 @@ func (s) TestStopAfterGracefulStopWithRunningHandler(t *testing.T) {
 	if _, err := ss.Client.FullDuplexCall(ctx); err != nil {
 		t.Fatalf("Error starting FullDuplexCall: %v", err)
 	}
-	<-handlerStarted
+	select {
+	case <-handlerStarted:
+	case <-ctx.Done():
+		t.Fatalf("Timed out waiting for the handler to start: %v", ctx.Err())
+	}
 
 	// Close the client connection so the server transport drains while the
 	// handler is still running. GracefulStop will then remove the connection
@@ -361,7 +369,7 @@ func (s) TestStopAfterGracefulStopWithRunningHandler(t *testing.T) {
 	select {
 	case <-stopReturned:
 	case <-time.After(defaultTestTimeout):
-		t.Fatal("Stop() did not return; it deadlocked behind GracefulStop() waiting for a running handler")
+		t.Fatal("Timed out waiting for Stop() to return")
 	}
 
 	// Let the handler finish so GracefulStop can also return.

--- a/test/gracefulstop_test.go
+++ b/test/gracefulstop_test.go
@@ -310,7 +310,7 @@ func (s) TestStopAfterGracefulStopWithRunningHandler(t *testing.T) {
 	handlerStarted := make(chan struct{})
 	unblockHandler := make(chan struct{})
 	ss := &stubserver.StubServer{
-		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+		FullDuplexCallF: func(_ testgrpc.TestService_FullDuplexCallServer) error {
 			close(handlerStarted)
 			// Ignore context cancellation to simulate a handler that does not
 			// promptly return when the server shuts down.


### PR DESCRIPTION
Fixes #9393

`Stop()` deadlocks when called after `GracefulStop()` while a handler is still running.

#### Root cause

Both `Stop()` and `GracefulStop()` call `stop()`, which acquires `s.mu` and holds it for the entire function, including across `s.handlersWG.Wait()`. If a handler ignores context cancellation, `GracefulStop()` blocks in that wait while still holding `s.mu`. A concurrent `Stop()` (the documented way to abort a `GracefulStop()` that is taking too long) then blocks forever on `s.mu.Lock()` and can never force the server to shut down.

#### Fix

Release `s.mu` around `s.handlersWG.Wait()` and reacquire it afterwards, mirroring the connection-drain loop that already releases the lock via `s.cv.Wait()`.

This is safe because none of the state guarded by `s.mu` is accessed during the wait: by that point listeners are closed, all transports are drained/closed, `s.conns` is `nil`, and the worker channel is closed. `handlersWG.Wait()` only touches the `WaitGroup`, which has its own synchronization and was never guarded by `s.mu`. A concurrent `Stop()` can now acquire the lock and return promptly.

#### Testing

Added `TestStopAfterGracefulStopWithRunningHandler`, which starts a handler that ignores context cancellation, closes the client connection so the transport drains, runs `GracefulStop()` in a goroutine, and asserts that a subsequent `Stop()` returns promptly. Verified the test times out (deadlocks) without the fix and passes with it.



RELEASE NOTES:
* server: fix deadlock where `Stop()` blocks indefinitely when called concurrently with an in-progress `GracefulStop()` waiting on a handler that does not return promptly