### PR TITLE
grpc: remove unused callInfo field

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -179,7 +179,6 @@ type callInfo struct {
 	contentSubtype              string
 	codec                       baseCodec
 	maxRetryRPCBufferSize       int
-	onFinish                    []func(err error)
 	authority                   string
 	acceptedResponseCompressors []string
 }
@@ -394,8 +393,7 @@ type OnFinishCallOption struct {
 	OnFinish func(error)
 }
 
-func (o OnFinishCallOption) before(c *callInfo) error {
-	c.onFinish = append(c.onFinish, o.OnFinish)
+func (o OnFinishCallOption) before(*callInfo) error {
 	return nil
 }
 


### PR DESCRIPTION
Remove unused "on RPC commit" callbacks from `callInfo`. Callers of `OnFinish` call option type-assert and invoke the closure directly.

RELEASE NOTES: N/A