### PR TITLE
advancedtls: apply client defaults before version check

### DIFF
--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -253,6 +253,14 @@ func (o *Options) clientConfig() (*tls.Config, error) {
 	if o.VerificationType == SkipVerification && o.AdditionalPeerVerification == nil {
 		return nil, fmt.Errorf("client needs to provide custom verification mechanism if choose to skip default verification")
 	}
+	// If the MinTLSVersion isn't set, default to 1.2
+	if o.MinTLSVersion == 0 {
+		o.MinTLSVersion = tls.VersionTLS12
+	}
+	// If the MaxTLSVersion isn't set, default to 1.3
+	if o.MaxTLSVersion == 0 {
+		o.MaxTLSVersion = tls.VersionTLS13
+	}
 	// Make sure users didn't specify more than one fields in
 	// RootCertificateOptions and IdentityCertificateOptions.
 	if num := o.RootOptions.nonNilFieldCount(); num > 1 {
@@ -266,14 +274,6 @@ func (o *Options) clientConfig() (*tls.Config, error) {
 	}
 	if o.MinTLSVersion > o.MaxTLSVersion {
 		return nil, fmt.Errorf("the minimum TLS version is larger than the maximum TLS version")
-	}
-	// If the MinTLSVersion isn't set, default to 1.2
-	if o.MinTLSVersion == 0 {
-		o.MinTLSVersion = tls.VersionTLS12
-	}
-	// If the MaxTLSVersion isn't set, default to 1.3
-	if o.MaxTLSVersion == 0 {
-		o.MaxTLSVersion = tls.VersionTLS13
 	}
 	config := &tls.Config{
 		ServerName: o.serverNameOverride,

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -195,6 +195,17 @@ func (s) TestClientOptionsConfigSuccessCases(t *testing.T) {
 				tls.CurveP256,
 			},
 		},
+		{
+			desc:                   "MaxVersion default is applied when only MinVersion is set",
+			clientVerificationType: CertVerification,
+			IdentityOptions: IdentityCertificateOptions{
+				Certificates: []tls.Certificate{},
+			},
+			RootOptions: RootCertificateOptions{
+				RootProvider: fakeProvider{},
+			},
+			MinVersion: tls.VersionTLS12,
+		},
 	}
 	for _, test := range tests {
 		test := test


### PR DESCRIPTION
Fixes #9402

Prior to this change, creating an Options like

    tlsOpts := &advancedtls.Options{
        IdentityOptions: advancedtls.IdentityCertificateOptions{IdentityProvider: certProvider},
        // Note: Only MinTLSVersion is set, not MaxTLSVersion
        MinTLSVersion: tls.VersionTLS13,
    }

and passing it to NewClientCreds fails with:

    the minimum TLS version is larger than the maximum TLS version

The Options docs say MaxTLSVersion defaults to TLS 1.3, but on the client side the default was applied after the MinTLSVersion > MaxTLSVersion check, so an unset MaxTLSVersion was still zero at that point. The defaults are now applied first, the same way #8684 fixed serverConfig.

RELEASE NOTES:
* advancedtls: Fix `NewClientCreds` failing with "the minimum TLS version is larger than the maximum TLS version" when `MinTLSVersion` is set without `MaxTLSVersion`.
