### PR TITLE
grpc: place defaultStreamInterceptor after user interceptors

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -553,7 +553,7 @@ func chainStreamClientInterceptors(cc *ClientConn) {
 	if cc.dopts.streamInt != nil {
 		interceptors = append([]StreamClientInterceptor{cc.dopts.streamInt}, interceptors...)
 	}
-	interceptors = append([]StreamClientInterceptor{defaultStreamInterceptor}, interceptors...)
+	interceptors = append(interceptors, defaultStreamInterceptor)
 	var chainedInt StreamClientInterceptor
 	if len(interceptors) == 0 {
 		chainedInt = nil

--- a/stream.go
+++ b/stream.go
@@ -176,10 +176,12 @@ func (w *clientStreamWrapper) SendMsg(m any) error {
 	if err != nil {
 		return err
 	}
-	// CloseSend is needed because in some scenarios (e.g., xDS), the same
-	// interceptors are used to process both unary and streaming RPCs. Calling
-	// CloseSend signals to those interceptors that no more messages are on the
-	// way.
+	// In some scenarios (e.g., xDS), the same interceptors process both unary and
+	// streaming RPCs, relying on CloseSend to signal that no more messages are on
+	// the way. Although protobuf-generated stubs already invoke CloseSend for
+	// server-streaming RPCs, it is explicitly called here to ensure downstream
+	// interceptors are also notified when callers interact with the ClientStream
+	// API directly.
 	if err := w.ClientStream.CloseSend(); err != nil && err != io.EOF {
 		return err
 	}

--- a/stream.go
+++ b/stream.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"google.golang.org/grpc/balancer"
@@ -152,7 +153,18 @@ type ClientStream interface {
 // RecvMsg parities based on the nature of stream.
 type clientStreamWrapper struct {
 	ClientStream
-	desc *StreamDesc
+	desc            *StreamDesc
+	closeSendCalled atomic.Bool
+}
+
+// CloseSend closes the send direction of the stream. The implementation ensures
+// that CloseSend is only called once on the underlying ClientStream, even if
+// CloseSend is called multiple times on the wrapper.
+func (w *clientStreamWrapper) CloseSend() error {
+	if w.closeSendCalled.Swap(true) {
+		return nil
+	}
+	return w.ClientStream.CloseSend()
 }
 
 // SendMsg sends message m across the stream. For RPCs where client can call
@@ -182,7 +194,7 @@ func (w *clientStreamWrapper) SendMsg(m any) error {
 	// server-streaming RPCs, it is explicitly called here to ensure downstream
 	// interceptors are also notified when callers interact with the ClientStream
 	// API directly.
-	if err := w.ClientStream.CloseSend(); err != nil && err != io.EOF {
+	if err := w.CloseSend(); err != nil && err != io.EOF {
 		return err
 	}
 	return nil

--- a/stream_test.go
+++ b/stream_test.go
@@ -151,8 +151,8 @@ func (s) TestUnaryClient_ServerStreamingMismatch(t *testing.T) {
 // CloseSend hooks across downstream interceptors.
 type interceptorStream struct {
 	grpc.ClientStream
-	recvMsgCount int
-	closeSend    bool
+	recvMsgCount   int
+	closeSendCount int
 }
 
 func (s *interceptorStream) RecvMsg(m any) error {
@@ -161,14 +161,15 @@ func (s *interceptorStream) RecvMsg(m any) error {
 }
 
 func (s *interceptorStream) CloseSend() error {
-	s.closeSend = true
+	s.closeSendCount++
 	return s.ClientStream.CloseSend()
 }
 
-// TestDefaultStreamInterceptor verifies that defaultStreamInterceptor
-// automatically triggers CloseSend on non-client-streaming RPCs right after
-// SendMsg, and calls RecvMsg a second time on non-server-streaming RPCs to
-// consume trailers and io.EOF.
+// TestDefaultStreamInterceptor verifies that defaultStreamInterceptor's
+// behavior of automatically triggering CloseSend on non-client-streaming RPCs
+// right after SendMsg, and calling RecvMsg a second time on
+// non-server-streaming RPCs to consume trailers and io.EOF, are not visible to
+// user-defined interceptors.
 func (s) TestDefaultStreamInterceptor(t *testing.T) {
 	var iStream *interceptorStream
 	// Define a client-side stream interceptor that wraps the ClientStream to
@@ -207,10 +208,11 @@ func (s) TestDefaultStreamInterceptor(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
-	// Make a client-streaming RPC. When CloseAndRecv invokes RecvMsg once to get
-	// the single reply message on a non-server-streaming RPC,
+	// Make a client-streaming RPC. When CloseAndRecv invokes RecvMsg once to
+	// get the single reply message on a non-server-streaming RPC,
 	// defaultStreamInterceptor automatically calls a second RecvMsg on the
-	// underlying client stream to consume io.EOF and receive trailers.
+	// underlying client stream to consume io.EOF and receive trailers. But this
+	// should not be visible to user interceptors.
 	stream, err := ss.Client.StreamingInputCall(ctx)
 	if err != nil {
 		t.Fatal("Error calling StreamingInputCall:", err)
@@ -221,17 +223,21 @@ func (s) TestDefaultStreamInterceptor(t *testing.T) {
 	if _, err := stream.CloseAndRecv(); err != nil {
 		t.Fatal("Error running CloseAndRecv:", err)
 	}
-	if iStream.recvMsgCount != 2 {
-		t.Fatalf("StreamingInputCall RecvMsg was called %v times, want 2 times", iStream.recvMsgCount)
+	if iStream.recvMsgCount != 1 {
+		t.Fatalf("RecvMsg was called %v times on user interceptor stream, want 1 time", iStream.recvMsgCount)
 	}
 
 	// Make a server-streaming RPC. Since StreamingOutputCall is not
-	// client-streaming, defaultStreamInterceptor immediately invokes CloseSend
-	// right after sending the request message to signal downstream interceptors.
+	// client-streaming, the proto generated code invokes CloseSend after
+	// sending the single message. defaultStreamInterceptor also invokes
+	// CloseSend right after sending the request message (to handle cases where
+	// the user is using the ClientStream API instead of the proto generated
+	// code) to signal downstream interceptors, which in this case are xDS
+	// filters. The user interceptor should not see this CloseSend call.
 	if _, err := ss.Client.StreamingOutputCall(ctx, &testpb.StreamingOutputCallRequest{}); err != nil {
 		t.Fatal("Error calling StreamingOutputCall:", err)
 	}
-	if !iStream.closeSend {
-		t.Fatal("CloseSend not called after SendMsg on non-client-streaming RPC")
+	if iStream.closeSendCount != 1 {
+		t.Fatalf("CloseSend called %v times on user interceptor stream, want 1 times", iStream.closeSendCount)
 	}
 }

--- a/test/xds/xds_client_filter_e2e_test.go
+++ b/test/xds/xds_client_filter_e2e_test.go
@@ -139,91 +139,101 @@ func (s) TestDefaultStreamInterceptor_InteractionWithXDSFilters(t *testing.T) {
 		t.Fatalf("Failed to create a gRPC client: %v", err)
 	}
 	defer cc.Close()
-
-	// Make a unary RPC.
 	client := testgrpc.NewTestServiceClient(cc)
-	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
-		t.Fatalf("EmptyCall() failed: %v", err)
-	}
-	if got, want := filterBuilder.recvMsgCount.Load(), int32(2); got != want { // One for the request, one for the trailers.
-		t.Fatalf("%d calls to RecvMsg(), want %d", got, want)
-	}
-	if got, want := filterBuilder.sendMsgCount.Load(), int32(1); got != want { // One for the response.
-		t.Fatalf("%d calls to SendMsg(), want %d", got, want)
-	}
-	if got, want := filterBuilder.closeSendCount.Load(), int32(1); got != want { // CloseSend() is called once for the unary RPC.
-		t.Fatalf("%d calls to CloseSend(), want %d", got, want)
+
+	tests := []struct {
+		name          string
+		run           func(ctx context.Context, client testgrpc.TestServiceClient)
+		wantSendMsg   int32
+		wantRecvMsg   int32
+		wantCloseSend int32
+	}{
+		{
+			name: "unary",
+			run: func(ctx context.Context, client testgrpc.TestServiceClient) {
+				if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
+					t.Fatalf("EmptyCall() failed: %v", err)
+				}
+			},
+			wantSendMsg:   1, // 1 request
+			wantRecvMsg:   2, // 1 response + 1 trailers
+			wantCloseSend: 1, // CloseSend called by invoke
+		},
+		{
+			name: "client_streaming",
+			run: func(ctx context.Context, client testgrpc.TestServiceClient) {
+				stream, err := client.StreamingInputCall(ctx)
+				if err != nil {
+					t.Fatalf("StreamingInputCall() failed: %v", err)
+				}
+				for i := 0; i < 2; i++ {
+					if err := stream.Send(&testpb.StreamingInputCallRequest{}); err != nil {
+						t.Fatalf("Send() failed: %v", err)
+					}
+				}
+				if _, err := stream.CloseAndRecv(); err != nil {
+					t.Fatalf("CloseAndRecv() failed: %v", err)
+				}
+			},
+			wantSendMsg:   2, // 2 requests
+			wantRecvMsg:   2, // 1 response + 1 trailers
+			wantCloseSend: 1, // CloseSend called by CloseAndRecv
+		},
+		{
+			name: "server_streaming",
+			run: func(ctx context.Context, client testgrpc.TestServiceClient) {
+				stream, err := client.StreamingOutputCall(ctx, &testpb.StreamingOutputCallRequest{})
+				if err != nil {
+					t.Fatalf("StreamingOutputCall() failed: %v", err)
+				}
+				if _, err := stream.Recv(); err != nil {
+					t.Fatalf("Recv() failed: %v", err)
+				}
+			},
+			wantSendMsg:   1, // 1 request
+			wantRecvMsg:   1, // 1 response (trailers not yet consumed since stream not read to EOF)
+			wantCloseSend: 2, // 1 from defaultStreamInterceptor + 1 from proto generated code
+		},
+		{
+			name: "bidi_streaming",
+			run: func(ctx context.Context, client testgrpc.TestServiceClient) {
+				stream, err := client.FullDuplexCall(ctx)
+				if err != nil {
+					t.Fatalf("FullDuplexCall() failed: %v", err)
+				}
+				if err := stream.Send(&testpb.StreamingOutputCallRequest{}); err != nil {
+					t.Fatalf("Send() failed: %v", err)
+				}
+				if _, err := stream.Recv(); err != nil {
+					t.Fatalf("Recv() failed: %v", err)
+				}
+				if err := stream.CloseSend(); err != nil {
+					t.Fatalf("CloseSend() failed: %v", err)
+				}
+			},
+			wantSendMsg:   1, // 1 request
+			wantRecvMsg:   1, // 1 response
+			wantCloseSend: 1, // 1 explicit CloseSend
+		},
 	}
 
-	// Make a client-streaming RPC, sending two messages and receiving one.
-	clientStreamingRPC, err := client.StreamingInputCall(ctx)
-	if err != nil {
-		t.Fatalf("StreamingInputCall() failed: %v", err)
-	}
-	if err := clientStreamingRPC.Send(&testpb.StreamingInputCallRequest{}); err != nil {
-		t.Fatalf("Send() failed: %v", err)
-	}
-	if err := clientStreamingRPC.Send(&testpb.StreamingInputCallRequest{}); err != nil {
-		t.Fatalf("Send() failed: %v", err)
-	}
-	if _, err := clientStreamingRPC.CloseAndRecv(); err != nil {
-		t.Fatalf("CloseAndRecv() failed: %v", err)
-	}
-	if got, want := filterBuilder.recvMsgCount.Load(), int32(4); got != want { // One for the request, one for the trailers.
-		t.Fatalf("%d calls to RecvMsg(), want %d", got, want)
-	}
-	if got, want := filterBuilder.sendMsgCount.Load(), int32(3); got != want { // Two for responses.
-		t.Fatalf("%d calls to SendMsg(), want %d", got, want)
-	}
-	if got, want := filterBuilder.closeSendCount.Load(), int32(2); got != want { // CloseSend() is called as part of CloseAndRecv().
-		t.Fatalf("%d calls to CloseSend(), want %d", got, want)
-	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			filterBuilder.sendMsgCount.Store(0)
+			filterBuilder.recvMsgCount.Store(0)
+			filterBuilder.closeSendCount.Store(0)
 
-	// Make a server-streaming RPC, sending one message and receiving one.
-	serverStreamingRPC, err := client.StreamingOutputCall(ctx, &testpb.StreamingOutputCallRequest{})
-	if err != nil {
-		t.Fatalf("StreamingOutputCall() failed: %v", err)
-	}
-	if _, err := serverStreamingRPC.Recv(); err != nil {
-		t.Fatalf("Recv() failed: %v", err)
-	}
-	if got, want := filterBuilder.recvMsgCount.Load(), int32(5); got != want { // One for the request, none for the trailers.
-		t.Fatalf("%d calls to RecvMsg(), want %d", got, want)
-	}
-	if got, want := filterBuilder.sendMsgCount.Load(), int32(4); got != want { // One for the response.
-		t.Fatalf("%d calls to SendMsg(), want %d", got, want)
-	}
-	// CloseSend() is invoked by the proto generated code after sending the
-	// request message. It is also invoked by the defaultStreamInterceptor to
-	// handle cases where the user is using the ClientStream API instead of the
-	// proto generated code.
-	if got, want := filterBuilder.closeSendCount.Load(), int32(4); got != want {
-		t.Fatalf("%d calls to CloseSend(), want %d", got, want)
-	}
+			tc.run(ctx, client)
 
-	// Make a bidirectional-streaming RPC, sending one message and receiving one.
-	bidiStreamingRPC, err := client.FullDuplexCall(ctx)
-	if err != nil {
-		t.Fatalf("FullDuplexCall() failed: %v", err)
-	}
-	if err := bidiStreamingRPC.Send(&testpb.StreamingOutputCallRequest{}); err != nil {
-		t.Fatalf("Send() failed: %v", err)
-	}
-	if _, err := bidiStreamingRPC.Recv(); err != nil {
-		t.Fatalf("Recv() failed: %v", err)
-	}
-	if got, want := filterBuilder.recvMsgCount.Load(), int32(6); got != want { // One for the request, none for the trailers.
-		t.Fatalf("%d calls to RecvMsg(), want %d", got, want)
-	}
-	if got, want := filterBuilder.sendMsgCount.Load(), int32(5); got != want { // One for the response.
-		t.Fatalf("%d calls to SendMsg(), want %d", got, want)
-	}
-	// Bidi stream is still open, so CloseSend() is yet to be called.
-	if got, want := filterBuilder.closeSendCount.Load(), int32(4); got != want {
-		t.Fatalf("%d calls to CloseSend(), want %d", got, want)
-	}
-	bidiStreamingRPC.CloseSend()
-	if got, want := filterBuilder.closeSendCount.Load(), int32(5); got != want {
-		t.Fatalf("%d calls to CloseSend(), want %d", got, want)
+			if got := filterBuilder.sendMsgCount.Load(); got != tc.wantSendMsg {
+				t.Fatalf("SendMsg() count = %d, want %d", got, tc.wantSendMsg)
+			}
+			if got := filterBuilder.recvMsgCount.Load(); got != tc.wantRecvMsg {
+				t.Fatalf("RecvMsg() count = %d, want %d", got, tc.wantRecvMsg)
+			}
+			if got := filterBuilder.closeSendCount.Load(); got != tc.wantCloseSend {
+				t.Fatalf("CloseSend() count = %d, want %d", got, tc.wantCloseSend)
+			}
+		})
 	}
 }

--- a/test/xds/xds_client_filter_e2e_test.go
+++ b/test/xds/xds_client_filter_e2e_test.go
@@ -1,0 +1,229 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package xds_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	v3xdsxdstypepb "github.com/cncf/xds/go/xds/type/v3"
+	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	v3endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal/stubserver"
+	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/internal/testutils/xds/e2e"
+	"google.golang.org/grpc/internal/testutils/xds/e2e/setup"
+	"google.golang.org/grpc/internal/xds/httpfilter"
+
+	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	testpb "google.golang.org/grpc/interop/grpc_testing"
+)
+
+func (s) TestDefaultStreamInterceptor_InteractionWithXDSFilters(t *testing.T) {
+	// Register a custom xDS filter builder for the test.
+	testFilterTypeURL := t.Name()
+	filterBuilder := newTrackingHTTPFilterBuilder(testFilterTypeURL)
+	httpfilter.Register(filterBuilder)
+	defer httpfilter.UnregisterForTesting(testFilterTypeURL)
+
+	// Setup a test backend implementing both all four RPC types.
+	testServer := &stubserver.StubServer{
+		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
+			return &testpb.Empty{}, nil
+		},
+		StreamingOutputCallF: func(_ *testpb.StreamingOutputCallRequest, stream testgrpc.TestService_StreamingOutputCallServer) error {
+			return stream.Send(&testpb.StreamingOutputCallResponse{})
+		},
+		StreamingInputCallF: func(stream testgrpc.TestService_StreamingInputCallServer) error {
+			for {
+				_, err := stream.Recv()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					return err
+				}
+			}
+			return stream.SendAndClose(&testpb.StreamingInputCallResponse{})
+		},
+		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+			for {
+				_, err := stream.Recv()
+				if err == io.EOF {
+					return nil
+				}
+				if err != nil {
+					return err
+				}
+				if err := stream.Send(&testpb.StreamingOutputCallResponse{}); err != nil {
+					return err
+				}
+			}
+		},
+	}
+	if err := testServer.Start(nil); err != nil {
+		t.Fatal("Error starting server:", err)
+	}
+	defer testServer.Stop()
+
+	// Start an xDS management server.
+	mgmtServer, nodeID, _, xdsResolver := setup.ManagementServerAndResolver(t)
+
+	const serviceName = "my-service-xds"
+	clusterSpec := &v3routepb.RouteAction_Cluster{Cluster: "cluster-A"}
+	hcm := &v3httppb.HttpConnectionManager{
+		RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
+			RouteConfig: &v3routepb.RouteConfiguration{
+				Name: "route-" + serviceName,
+				VirtualHosts: []*v3routepb.VirtualHost{{
+					Domains: []string{serviceName},
+					Routes: []*v3routepb.Route{{
+						Match: &v3routepb.RouteMatch{PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: ""}},
+						Action: &v3routepb.Route_Route{Route: &v3routepb.RouteAction{
+							ClusterSpecifier: clusterSpec,
+						}},
+					}},
+				}},
+			},
+		},
+		HttpFilters: []*v3httppb.HttpFilter{
+			{
+				Name: "tracking-filter",
+				ConfigType: &v3httppb.HttpFilter_TypedConfig{
+					TypedConfig: testutils.MarshalAny(t, &v3xdsxdstypepb.TypedStruct{
+						TypeUrl: testFilterTypeURL,
+					}),
+				},
+			},
+			e2e.RouterHTTPFilter,
+		},
+	}
+	resources := e2e.UpdateOptions{
+		NodeID:    nodeID,
+		Listeners: []*v3listenerpb.Listener{{Name: serviceName, ApiListener: &v3listenerpb.ApiListener{ApiListener: testutils.MarshalAny(t, hcm)}}},
+		Clusters:  []*v3clusterpb.Cluster{e2e.DefaultCluster("cluster-A", "cluster-A", e2e.SecurityLevelNone)},
+		Endpoints: []*v3endpointpb.ClusterLoadAssignment{e2e.DefaultEndpoint("cluster-A", "localhost", []uint32{testutils.ParsePort(t, testServer.Address)})},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(xdsResolver))
+	if err != nil {
+		t.Fatalf("Failed to create a gRPC client: %v", err)
+	}
+	defer cc.Close()
+
+	// Make a unary RPC.
+	client := testgrpc.NewTestServiceClient(cc)
+	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
+		t.Fatalf("EmptyCall() failed: %v", err)
+	}
+	if got, want := filterBuilder.recvMsgCount.Load(), int32(2); got != want { // One for the request, one for the trailers.
+		t.Fatalf("%d calls to RecvMsg(), want %d", got, want)
+	}
+	if got, want := filterBuilder.sendMsgCount.Load(), int32(1); got != want { // One for the response.
+		t.Fatalf("%d calls to SendMsg(), want %d", got, want)
+	}
+	if got, want := filterBuilder.closeSendCount.Load(), int32(1); got != want { // CloseSend() is called once for the unary RPC.
+		t.Fatalf("%d calls to CloseSend(), want %d", got, want)
+	}
+
+	// Make a client-streaming RPC, sending two messages and receiving one.
+	clientStreamingRPC, err := client.StreamingInputCall(ctx)
+	if err != nil {
+		t.Fatalf("StreamingInputCall() failed: %v", err)
+	}
+	if err := clientStreamingRPC.Send(&testpb.StreamingInputCallRequest{}); err != nil {
+		t.Fatalf("Send() failed: %v", err)
+	}
+	if err := clientStreamingRPC.Send(&testpb.StreamingInputCallRequest{}); err != nil {
+		t.Fatalf("Send() failed: %v", err)
+	}
+	if _, err := clientStreamingRPC.CloseAndRecv(); err != nil {
+		t.Fatalf("CloseAndRecv() failed: %v", err)
+	}
+	if got, want := filterBuilder.recvMsgCount.Load(), int32(4); got != want { // One for the request, one for the trailers.
+		t.Fatalf("%d calls to RecvMsg(), want %d", got, want)
+	}
+	if got, want := filterBuilder.sendMsgCount.Load(), int32(3); got != want { // Two for responses.
+		t.Fatalf("%d calls to SendMsg(), want %d", got, want)
+	}
+	if got, want := filterBuilder.closeSendCount.Load(), int32(2); got != want { // CloseSend() is called as part of CloseAndRecv().
+		t.Fatalf("%d calls to CloseSend(), want %d", got, want)
+	}
+
+	// Make a server-streaming RPC, sending one message and receiving one.
+	serverStreamingRPC, err := client.StreamingOutputCall(ctx, &testpb.StreamingOutputCallRequest{})
+	if err != nil {
+		t.Fatalf("StreamingOutputCall() failed: %v", err)
+	}
+	if _, err := serverStreamingRPC.Recv(); err != nil {
+		t.Fatalf("Recv() failed: %v", err)
+	}
+	if got, want := filterBuilder.recvMsgCount.Load(), int32(5); got != want { // One for the request, none for the trailers.
+		t.Fatalf("%d calls to RecvMsg(), want %d", got, want)
+	}
+	if got, want := filterBuilder.sendMsgCount.Load(), int32(4); got != want { // One for the response.
+		t.Fatalf("%d calls to SendMsg(), want %d", got, want)
+	}
+	// CloseSend() is invoked by the proto generated code after sending the
+	// request message. It is also invoked by the defaultStreamInterceptor to
+	// handle cases where the user is using the ClientStream API instead of the
+	// proto generated code.
+	if got, want := filterBuilder.closeSendCount.Load(), int32(4); got != want {
+		t.Fatalf("%d calls to CloseSend(), want %d", got, want)
+	}
+
+	// Make a bidirectional-streaming RPC, sending one message and receiving one.
+	bidiStreamingRPC, err := client.FullDuplexCall(ctx)
+	if err != nil {
+		t.Fatalf("FullDuplexCall() failed: %v", err)
+	}
+	if err := bidiStreamingRPC.Send(&testpb.StreamingOutputCallRequest{}); err != nil {
+		t.Fatalf("Send() failed: %v", err)
+	}
+	if _, err := bidiStreamingRPC.Recv(); err != nil {
+		t.Fatalf("Recv() failed: %v", err)
+	}
+	if got, want := filterBuilder.recvMsgCount.Load(), int32(6); got != want { // One for the request, none for the trailers.
+		t.Fatalf("%d calls to RecvMsg(), want %d", got, want)
+	}
+	if got, want := filterBuilder.sendMsgCount.Load(), int32(5); got != want { // One for the response.
+		t.Fatalf("%d calls to SendMsg(), want %d", got, want)
+	}
+	// Bidi stream is still open, so CloseSend() is yet to be called.
+	if got, want := filterBuilder.closeSendCount.Load(), int32(4); got != want {
+		t.Fatalf("%d calls to CloseSend(), want %d", got, want)
+	}
+	bidiStreamingRPC.CloseSend()
+	if got, want := filterBuilder.closeSendCount.Load(), int32(5); got != want {
+		t.Fatalf("%d calls to CloseSend(), want %d", got, want)
+	}
+}

--- a/test/xds/xds_client_filter_e2e_test.go
+++ b/test/xds/xds_client_filter_e2e_test.go
@@ -42,6 +42,11 @@ import (
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
 
+// Tests the interaction between the defaultStreamInterceptor and xDS filters.
+// It verifies that the SendMsg, RecvMsg, and CloseSend methods are called the
+// expected number of times for different RPC types (unary, client streaming,
+// server streaming, and bidi streaming) when an xDS filter is registered and
+// used in the call chain.
 func (s) TestDefaultStreamInterceptor_InteractionWithXDSFilters(t *testing.T) {
 	// Register a custom xDS filter builder for the test.
 	testFilterTypeURL := t.Name()

--- a/test/xds/xds_client_filter_e2e_test.go
+++ b/test/xds/xds_client_filter_e2e_test.go
@@ -147,11 +147,10 @@ func (s) TestDefaultStreamInterceptor_InteractionWithXDSFilters(t *testing.T) {
 	client := testgrpc.NewTestServiceClient(cc)
 
 	tests := []struct {
-		name          string
-		run           func(ctx context.Context, client testgrpc.TestServiceClient)
-		wantSendMsg   int32
-		wantRecvMsg   int32
-		wantCloseSend int32
+		name        string
+		run         func(ctx context.Context, client testgrpc.TestServiceClient)
+		wantSendMsg int32
+		wantRecvMsg int32
 	}{
 		{
 			name: "unary",
@@ -160,9 +159,8 @@ func (s) TestDefaultStreamInterceptor_InteractionWithXDSFilters(t *testing.T) {
 					t.Fatalf("EmptyCall() failed: %v", err)
 				}
 			},
-			wantSendMsg:   1, // 1 request
-			wantRecvMsg:   2, // 1 response + 1 trailers
-			wantCloseSend: 1, // CloseSend called by invoke
+			wantSendMsg: 1, // 1 request
+			wantRecvMsg: 2, // 1 response + 1 trailers
 		},
 		{
 			name: "client_streaming",
@@ -180,9 +178,8 @@ func (s) TestDefaultStreamInterceptor_InteractionWithXDSFilters(t *testing.T) {
 					t.Fatalf("CloseAndRecv() failed: %v", err)
 				}
 			},
-			wantSendMsg:   2, // 2 requests
-			wantRecvMsg:   2, // 1 response + 1 trailers
-			wantCloseSend: 1, // CloseSend called by CloseAndRecv
+			wantSendMsg: 2, // 2 requests
+			wantRecvMsg: 2, // 1 response + 1 trailers
 		},
 		{
 			name: "server_streaming",
@@ -195,9 +192,8 @@ func (s) TestDefaultStreamInterceptor_InteractionWithXDSFilters(t *testing.T) {
 					t.Fatalf("Recv() failed: %v", err)
 				}
 			},
-			wantSendMsg:   1, // 1 request
-			wantRecvMsg:   1, // 1 response (trailers not yet consumed since stream not read to EOF)
-			wantCloseSend: 2, // 1 from defaultStreamInterceptor + 1 from proto generated code
+			wantSendMsg: 1, // 1 request
+			wantRecvMsg: 1, // 1 response (trailers not yet consumed since stream not read to EOF)
 		},
 		{
 			name: "bidi_streaming",
@@ -216,9 +212,8 @@ func (s) TestDefaultStreamInterceptor_InteractionWithXDSFilters(t *testing.T) {
 					t.Fatalf("CloseSend() failed: %v", err)
 				}
 			},
-			wantSendMsg:   1, // 1 request
-			wantRecvMsg:   1, // 1 response
-			wantCloseSend: 1, // 1 explicit CloseSend
+			wantSendMsg: 1, // 1 request
+			wantRecvMsg: 1, // 1 response
 		},
 	}
 
@@ -236,8 +231,8 @@ func (s) TestDefaultStreamInterceptor_InteractionWithXDSFilters(t *testing.T) {
 			if got := filterBuilder.recvMsgCount.Load(); got != tc.wantRecvMsg {
 				t.Fatalf("RecvMsg() count = %d, want %d", got, tc.wantRecvMsg)
 			}
-			if got := filterBuilder.closeSendCount.Load(); got != tc.wantCloseSend {
-				t.Fatalf("CloseSend() count = %d, want %d", got, tc.wantCloseSend)
+			if got := filterBuilder.closeSendCount.Load(); got != 1 {
+				t.Fatalf("CloseSend() count = %d, want 1", got)
 			}
 		})
 	}

--- a/test/xds/xds_server_filter_state_retention_test.go
+++ b/test/xds/xds_server_filter_state_retention_test.go
@@ -30,12 +30,11 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
+	iresolver "google.golang.org/grpc/internal/resolver"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
 	"google.golang.org/grpc/internal/testutils/xds/e2e/setup"
 	"google.golang.org/grpc/internal/xds/httpfilter"
-	testgrpc "google.golang.org/grpc/interop/grpc_testing"
-	testpb "google.golang.org/grpc/interop/grpc_testing"
 	"google.golang.org/grpc/xds"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -47,6 +46,8 @@ import (
 	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	v3routerpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
 
 const filterCfgPathFieldName = "path"
@@ -87,6 +88,7 @@ type trackingHTTPFilterBuilder struct {
 	interceptRPCCount     atomic.Int32
 	recvMsgCount          atomic.Int32
 	sendMsgCount          atomic.Int32
+	closeSendCount        atomic.Int32
 	typeURL               string
 	pathCh                chan string
 	interceptRPCFunc      func(ss grpc.ServerStream) (grpc.ServerStream, error)
@@ -117,6 +119,7 @@ func (t *trackingHTTPFilterBuilder) Close() {
 	t.filtersDestroyed.Add(1)
 }
 
+var _ httpfilter.ClientFilterBuilder = &trackingHTTPFilterBuilder{}
 var _ httpfilter.ServerFilterBuilder = &trackingHTTPFilterBuilder{}
 
 func (t *trackingHTTPFilterBuilder) BuildServerInterceptor(config, override httpfilter.FilterConfig) (httpfilter.ServerInterceptor, error) {
@@ -131,7 +134,7 @@ func (t *trackingHTTPFilterBuilder) BuildServerInterceptor(config, override http
 		return nil, fmt.Errorf("unexpected missing config")
 	}
 
-	interceptor := &trackingInterceptor{
+	interceptor := &trackingServerInterceptor{
 		parent:   t,
 		pathCh:   t.pathCh,
 		basePath: effectiveCfg.path,
@@ -139,13 +142,13 @@ func (t *trackingHTTPFilterBuilder) BuildServerInterceptor(config, override http
 	return interceptor, nil
 }
 
-type trackingInterceptor struct {
+type trackingServerInterceptor struct {
 	parent   *trackingHTTPFilterBuilder
 	pathCh   chan string
 	basePath string
 }
 
-func (i *trackingInterceptor) InterceptRPC(ss grpc.ServerStream) (grpc.ServerStream, error) {
+func (i *trackingServerInterceptor) InterceptRPC(ss grpc.ServerStream) (grpc.ServerStream, error) {
 	i.parent.interceptRPCCount.Add(1)
 	if i.pathCh != nil {
 		i.pathCh <- i.basePath
@@ -159,7 +162,7 @@ func (i *trackingInterceptor) InterceptRPC(ss grpc.ServerStream) (grpc.ServerStr
 	}, nil
 }
 
-func (i *trackingInterceptor) Close() {
+func (i *trackingServerInterceptor) Close() {
 	i.parent.interceptorsDestroyed.Add(1)
 }
 
@@ -200,6 +203,56 @@ func newHTTPFilter(t *testing.T, name, typeURL, path string) *v3httppb.HttpFilte
 			}),
 		},
 	}
+}
+
+func (t *trackingHTTPFilterBuilder) BuildClientFilter(httpfilter.ClientFilterOptions) httpfilter.ClientFilter {
+	t.filtersCreated.Add(1)
+	return t
+}
+
+func (t *trackingHTTPFilterBuilder) BuildClientInterceptor(_, _ httpfilter.FilterConfig) (httpfilter.ClientInterceptor, error) {
+	t.interceptorsCreated.Add(1)
+	return &trackingClientInterceptor{parent: t}, nil
+}
+
+type trackingClientInterceptor struct {
+	parent *trackingHTTPFilterBuilder
+}
+
+func (i *trackingClientInterceptor) NewStream(ctx context.Context, _ iresolver.RPCInfo, newStream func(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStream, error), opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	s, err := newStream(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &wrappedClientStream{
+		ClientStream: s,
+		parent:       i.parent,
+	}, nil
+}
+
+func (i *trackingClientInterceptor) Close() {
+	i.parent.interceptorsDestroyed.Add(1)
+}
+
+type wrappedClientStream struct {
+	grpc.ClientStream
+	parent *trackingHTTPFilterBuilder
+}
+
+func (w *wrappedClientStream) RecvMsg(m any) error {
+	w.parent.recvMsgCount.Add(1)
+	return w.ClientStream.RecvMsg(m)
+}
+
+func (w *wrappedClientStream) SendMsg(m any) error {
+	w.parent.sendMsgCount.Add(1)
+	return w.ClientStream.SendMsg(m)
+}
+
+func (w *wrappedClientStream) CloseSend() error {
+	w.parent.closeSendCount.Add(1)
+	return w.ClientStream.CloseSend()
 }
 
 // Tests the filter state retention behavior when filter configs in the existing


### PR DESCRIPTION
The `defaultStreamInterceptor` was introduced in #9226.

This change places the `defaultStreamInterceptor` which performs certain common logic for all non-unary RPCs to live after the user interceptors and before the xDS filters. This ensures that the work of the `defaultStreamInterceptor` stays invisible to the user interceptors. Specifically, it calls `RecvMsg` twice for non server-streaming RPCs and calls `CloseSend` after sending the only message for non client-streaming RPCs.

RELEASE NOTES: none