### PR TITLE
client: register context cancellation callbacks for unary and streaming RPCs using context.AfterFunc

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -523,14 +523,19 @@ func newClientStreamWithParams(ctx context.Context, desc *StreamDesc, cc *Client
 func (cs *clientStream) registerContextCallbacks() {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
-	if !cs.finished {
-		cs.stopCtx = context.AfterFunc(cs.ctx, func() {
-			cs.finish(toRPCErr(cs.ctx.Err()))
-		})
-		cs.stopCC = context.AfterFunc(cs.cc.ctx, func() {
-			cs.finish(ErrClientConnClosing)
-		})
+	if cs.finished {
+		return
 	}
+	onCtxDone := func() {
+		if cs.cc.ctx.Err() != nil {
+			cs.finish(ErrClientConnClosing)
+			return
+		}
+		cs.finish(toRPCErr(cs.ctx.Err()))
+	}
+
+	cs.stopStreamCallback = context.AfterFunc(cs.ctx, onCtxDone)
+	cs.stopClientConnCallback = context.AfterFunc(cs.cc.ctx, onCtxDone)
 }
 
 // newAttemptLocked creates a new csAttempt without a transport or stream.
@@ -714,8 +719,8 @@ type clientStream struct {
 	replayBuffer     []replayOp // operations to replay on retry
 	replayBufferSize int        // current size of replayBuffer
 
-	stopCtx func() bool // stops the callback registered to run on RPC context expiration
-	stopCC  func() bool // stops the callback registered to run on ClientConn context expiration
+	stopStreamCallback     func() bool // stops the callback registered to run on RPC context expiration
+	stopClientConnCallback func() bool // stops the callback registered to run on ClientConn context expiration
 
 	// Bool fields are grouped at the tail to eliminate the alignment padding
 	// that would otherwise follow each bool when the next field is pointer- or
@@ -1199,10 +1204,12 @@ func (cs *clientStream) finish(err error) {
 		return
 	}
 	cs.finished = true
-	stopCtx := cs.stopCtx
-	stopCC := cs.stopCC
-	cs.stopCtx = nil
-	cs.stopCC = nil
+	if cs.stopStreamCallback != nil {
+		cs.stopStreamCallback()
+	}
+	if cs.stopClientConnCallback != nil {
+		cs.stopClientConnCallback()
+	}
 	cs.commitAttemptLocked()
 	attemptCreated := cs.attempt != nil
 	if attemptCreated {
@@ -1216,12 +1223,6 @@ func (cs *clientStream) finish(err error) {
 	}
 
 	cs.mu.Unlock()
-	if stopCtx != nil {
-		stopCtx()
-	}
-	if stopCC != nil {
-		stopCC()
-	}
 	// Only one of cancel or trailer needs to be logged.
 	if len(cs.binlogs) != 0 {
 		switch err {
@@ -1495,17 +1496,24 @@ func newNonRetryClientStream(ctx context.Context, desc *StreamDesc, method strin
 func (as *addrConnStream) registerContextCallbacks() {
 	as.mu.Lock()
 	defer as.mu.Unlock()
-	if !as.finished {
-		as.stopCtx = context.AfterFunc(as.ctx, func() {
-			as.finish(toRPCErr(as.ctx.Err()))
-		})
-		as.ac.mu.Lock()
-		acCtx := as.ac.ctx
-		as.ac.mu.Unlock()
-		as.stopCC = context.AfterFunc(acCtx, func() {
-			as.finish(status.Error(codes.Canceled, "grpc: the SubConn is closing"))
-		})
+	if as.finished {
+		return
 	}
+
+	as.ac.mu.Lock()
+	acCtx := as.ac.ctx
+	as.ac.mu.Unlock()
+
+	onCtxDone := func() {
+		if acCtx.Err() != nil {
+			as.finish(status.Error(codes.Canceled, "grpc: the SubConn is closing"))
+			return
+		}
+		as.finish(toRPCErr(as.ctx.Err()))
+	}
+
+	as.stopStreamCallback = context.AfterFunc(as.ctx, onCtxDone)
+	as.stopClientConnCallback = context.AfterFunc(acCtx, onCtxDone)
 }
 
 type addrConnStream struct {
@@ -1528,8 +1536,8 @@ type addrConnStream struct {
 	mu     sync.Mutex
 	parser parser
 
-	stopCtx func() bool // stops the callback registered to run on RPC context expiration
-	stopCC  func() bool // stops the callback registered to run on SubConn context expiration
+	stopStreamCallback     func() bool // stops the callback registered to run on RPC context expiration
+	stopClientConnCallback func() bool // stops the callback registered to run on SubConn context expiration
 
 	// Bool fields are grouped at the tail to eliminate the alignment padding
 	// that would otherwise follow each bool when the next field is pointer- or
@@ -1672,10 +1680,12 @@ func (as *addrConnStream) finish(err error) {
 		return
 	}
 	as.finished = true
-	stopCtx := as.stopCtx
-	stopCC := as.stopCC
-	as.stopCtx = nil
-	as.stopCC = nil
+	if as.stopStreamCallback != nil {
+		as.stopStreamCallback()
+	}
+	if as.stopClientConnCallback != nil {
+		as.stopClientConnCallback()
+	}
 
 	if err == io.EOF {
 		// Ending a stream with EOF indicates a success.
@@ -1692,13 +1702,6 @@ func (as *addrConnStream) finish(err error) {
 	}
 	as.cancel()
 	as.mu.Unlock()
-
-	if stopCtx != nil {
-		stopCtx()
-	}
-	if stopCC != nil {
-		stopCC()
-	}
 }
 
 // ServerStream defines the server-side behavior of a streaming RPC.

--- a/stream.go
+++ b/stream.go
@@ -514,22 +514,23 @@ func newClientStreamWithParams(ctx context.Context, desc *StreamDesc, cc *Client
 		}
 	}
 
-	if desc != unaryStreamDesc {
-		// Listen on cc and stream contexts to cleanup when the user closes the
-		// ClientConn or cancels the stream context.  In all other cases, an error
-		// should already be injected into the recv buffer by the transport, which
-		// the client will eventually receive, and then we will cancel the stream's
-		// context in clientStream.finish.
-		go func() {
-			select {
-			case <-cc.ctx.Done():
-				cs.finish(ErrClientConnClosing)
-			case <-ctx.Done():
-				cs.finish(toRPCErr(ctx.Err()))
-			}
-		}()
-	}
+	cs.registerContextCallbacks()
 	return cs, nil
+}
+
+// registerContextCallbacks registers callbacks to clean up the stream when the
+// RPC context expires or the ClientConn is closed.
+func (cs *clientStream) registerContextCallbacks() {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	if !cs.finished {
+		cs.stopCtx = context.AfterFunc(cs.ctx, func() {
+			cs.finish(toRPCErr(cs.ctx.Err()))
+		})
+		cs.stopCC = context.AfterFunc(cs.cc.ctx, func() {
+			cs.finish(ErrClientConnClosing)
+		})
+	}
 }
 
 // newAttemptLocked creates a new csAttempt without a transport or stream.
@@ -712,6 +713,9 @@ type clientStream struct {
 	onCommit         func()
 	replayBuffer     []replayOp // operations to replay on retry
 	replayBufferSize int        // current size of replayBuffer
+
+	stopCtx func() bool // stops the callback registered to run on RPC context expiration
+	stopCC  func() bool // stops the callback registered to run on ClientConn context expiration
 
 	// Bool fields are grouped at the tail to eliminate the alignment padding
 	// that would otherwise follow each bool when the next field is pointer- or
@@ -1195,6 +1199,10 @@ func (cs *clientStream) finish(err error) {
 		return
 	}
 	cs.finished = true
+	stopCtx := cs.stopCtx
+	stopCC := cs.stopCC
+	cs.stopCtx = nil
+	cs.stopCC = nil
 	cs.commitAttemptLocked()
 	attemptCreated := cs.attempt != nil
 	if attemptCreated {
@@ -1208,6 +1216,12 @@ func (cs *clientStream) finish(err error) {
 	}
 
 	cs.mu.Unlock()
+	if stopCtx != nil {
+		stopCtx()
+	}
+	if stopCC != nil {
+		stopCC()
+	}
 	// Only one of cancel or trailer needs to be logged.
 	if len(cs.binlogs) != 0 {
 		switch err {
@@ -1472,27 +1486,26 @@ func newNonRetryClientStream(ctx context.Context, desc *StreamDesc, method strin
 	as.transportStream = s
 	as.parser = parser{r: s, bufferPool: ac.dopts.copts.BufferPool}
 	ac.incrCallsStarted()
-	if desc != unaryStreamDesc {
-		// Listen on stream context to cleanup when the stream context is
-		// canceled.  Also listen for the addrConn's context in case the
-		// addrConn is closed or reconnects to a different address.  In all
-		// other cases, an error should already be injected into the recv
-		// buffer by the transport, which the client will eventually receive,
-		// and then we will cancel the stream's context in
-		// addrConnStream.finish.
-		go func() {
-			ac.mu.Lock()
-			acCtx := ac.ctx
-			ac.mu.Unlock()
-			select {
-			case <-acCtx.Done():
-				as.finish(status.Error(codes.Canceled, "grpc: the SubConn is closing"))
-			case <-ctx.Done():
-				as.finish(toRPCErr(ctx.Err()))
-			}
-		}()
-	}
+	as.registerContextCallbacks()
 	return &clientStreamWrapper{ClientStream: as, desc: desc}, nil
+}
+
+// registerContextCallbacks registers callbacks to clean up the stream when the
+// RPC context expires or the SubConn is closed.
+func (as *addrConnStream) registerContextCallbacks() {
+	as.mu.Lock()
+	defer as.mu.Unlock()
+	if !as.finished {
+		as.stopCtx = context.AfterFunc(as.ctx, func() {
+			as.finish(toRPCErr(as.ctx.Err()))
+		})
+		as.ac.mu.Lock()
+		acCtx := as.ac.ctx
+		as.ac.mu.Unlock()
+		as.stopCC = context.AfterFunc(acCtx, func() {
+			as.finish(status.Error(codes.Canceled, "grpc: the SubConn is closing"))
+		})
+	}
 }
 
 type addrConnStream struct {
@@ -1514,6 +1527,9 @@ type addrConnStream struct {
 	// mu guards finished and is held for the entire finish method.
 	mu     sync.Mutex
 	parser parser
+
+	stopCtx func() bool // stops the callback registered to run on RPC context expiration
+	stopCC  func() bool // stops the callback registered to run on SubConn context expiration
 
 	// Bool fields are grouped at the tail to eliminate the alignment padding
 	// that would otherwise follow each bool when the next field is pointer- or
@@ -1656,6 +1672,11 @@ func (as *addrConnStream) finish(err error) {
 		return
 	}
 	as.finished = true
+	stopCtx := as.stopCtx
+	stopCC := as.stopCC
+	as.stopCtx = nil
+	as.stopCC = nil
+
 	if err == io.EOF {
 		// Ending a stream with EOF indicates a success.
 		err = nil
@@ -1671,6 +1692,13 @@ func (as *addrConnStream) finish(err error) {
 	}
 	as.cancel()
 	as.mu.Unlock()
+
+	if stopCtx != nil {
+		stopCtx()
+	}
+	if stopCC != nil {
+		stopCC()
+	}
 }
 
 // ServerStream defines the server-side behavior of a streaming RPC.

--- a/test/context_canceled_test.go
+++ b/test/context_canceled_test.go
@@ -162,3 +162,99 @@ func (s) TestCancelWhileRecvingWithCompression(t *testing.T) {
 		t.Fatalf("Close failed with %v, want nil", err)
 	}
 }
+
+// Test verifies that an in-flight Unary RPC fails promptly when the ClientConn
+// is closed (canceling ClientConn context).
+func (s) TestUnary_ClientConnContextExpires(t *testing.T) {
+	rpcStarted := make(chan struct{})
+	ss := &stubserver.StubServer{
+		EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
+			close(rpcStarted)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	if err := ss.Start(nil); err != nil {
+		t.Fatalf("Error starting endpoint server: %v", err)
+	}
+	defer ss.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	errChan := make(chan error, 1)
+	go func() {
+		_, err := ss.Client.EmptyCall(ctx, &testpb.Empty{})
+		errChan <- err
+	}()
+
+	select {
+	case <-rpcStarted:
+	case <-time.After(defaultTestTimeout):
+		t.Fatal("timed out waiting for RPC to start on server")
+	}
+
+	// Close ClientConn while Unary RPC is in-flight.
+	ss.CC.Close()
+
+	select {
+	case err := <-errChan:
+		if status.Code(err) != codes.Canceled {
+			t.Fatalf("EmptyCall returned error: %v (code: %v), want Canceled", err, status.Code(err))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Unary RPC did not return promptly after ClientConn was closed")
+	}
+}
+
+// Test verifies that an in-flight Streaming RPC fails promptly when the
+// ClientConn is closed (canceling ClientConn context).
+func (s) TestStreaming_ClientConnContextExpires(t *testing.T) {
+	rpcStarted := make(chan struct{})
+	ss := &stubserver.StubServer{
+		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+			close(rpcStarted)
+			<-stream.Context().Done()
+			return stream.Context().Err()
+		},
+	}
+	if err := ss.Start(nil); err != nil {
+		t.Fatalf("Error starting endpoint server: %v", err)
+	}
+	defer ss.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	stream, err := ss.Client.FullDuplexCall(ctx)
+	if err != nil {
+		t.Fatalf("FullDuplexCall failed: %v", err)
+	}
+
+	// Send an initial message so the stream is active on the server.
+	if err := stream.Send(&testpb.StreamingOutputCallRequest{}); err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+
+	select {
+	case <-rpcStarted:
+	case <-time.After(defaultTestTimeout):
+		t.Fatal("timed out waiting for stream to start on server")
+	}
+
+	errChan := make(chan error, 1)
+	go func() {
+		_, err := stream.Recv()
+		errChan <- err
+	}()
+
+	// Close ClientConn while Streaming RPC is waiting in Recv.
+	ss.CC.Close()
+
+	select {
+	case err := <-errChan:
+		if status.Code(err) != codes.Canceled {
+			t.Fatalf("Recv returned error: %v (code: %v), want Canceled", err, status.Code(err))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Streaming RPC did not return promptly after ClientConn was closed")
+	}
+}


### PR DESCRIPTION
Internal issue: b/558772134

#### Root Cause ####
During HTTP/2 flow control starvation (or when a server stalls due to packet loss), client writes block inside writeQuota.get() waiting on <-w.ch or <-w.done. For Unary RPCs, grpc-go did not previously register a context cancellation listener on the client side (unlike streaming RPCs which spawned a dedicated background goroutine), causing Invoke() to block past deadlines until transport teardown.

#### Fix ####
* Replaced background goroutines in stream.go with `context.AfterFunc` for Streaming RPCs across clientStream and addrConnStream.
* Registered callbacks for both RPC context expiration and ClientConn context expiration.
* Added unit tests TestUnary_ClientConnContextExpires and TestStreaming_ClientConnContextExpires in test/context_canceled_test.go. Already have tests for RPC context expiration.

#### Benchmarks ####
#### Streaming RPCs ####

```
streaming-networkMode_Local-bufConn_false-keepalive_false-benchTime_1m0s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_200-reqSize_1B-respSize_1B-compressor_off-channelz_false-preloader_false-clientReadBufferSize_-1-clientWriteBufferSize_-1-serverReadBufferSize_-1-serverWriteBufferSize_-1-sleepBetweenRPCs_0s-connections_1-recvBufferPool_simple-sharedWriteBuffer_true
               Title       Before        After Percentage
            TotalOps     12564155     13176669     4.88%
             SendOps            0            0      NaN%
             RecvOps            0            0      NaN%
            Bytes/op      1089.40      1086.11    -0.28%
           Allocs/op        29.12        29.12     0.00%
             ReqT/op   1675220.67   1756889.20     4.88%
            RespT/op   1675220.67   1756889.20     4.88%
            50th-Lat    948.269µs    935.669µs    -1.33%
            90th-Lat   1.275133ms   1.198625ms    -6.00%
            99th-Lat   2.715684ms   2.189469ms   -19.38%
             Avg-Lat     950.04µs    905.094µs    -4.73%
           GoVersion     go1.25.0     go1.25.0
         GrpcVersion   1.85.0-dev   1.85.0-dev

```

RELEASE NOTES:
* client: remove per-call context monitoring goroutine for streaming RPCs.