### PR TITLE
Add `OnUpdate` callback to pemfile.

### DIFF
--- a/credentials/tls/certprovider/pemfile/watcher.go
+++ b/credentials/tls/certprovider/pemfile/watcher.go
@@ -71,6 +71,10 @@ type Options struct {
 	// for updates in the specified files.
 	// Optional. If not set, a default value (1 hour) will be used.
 	RefreshDuration time.Duration
+	// Callback invoked after files have been checked for updates, including
+	// on initial update. This is called even if the files are unchanged.
+	// Optional.
+	OnUpdate func(certprovider.Provider)
 }
 
 func (o Options) canonical() []byte {
@@ -254,6 +258,9 @@ func (w *watcher) run(ctx context.Context) {
 	for {
 		w.updateIdentityDistributor()
 		w.updateRootDistributor()
+		if w.opts.OnUpdate != nil {
+			w.opts.OnUpdate(w)
+		}
 		select {
 		case <-ctx.Done():
 			ticker.Stop()


### PR DESCRIPTION
Small addition to allow `pemfile` users to detect when a refresh has happened.

Our usecase is exporting a metric containing the current `NotAfter` expiry time of the watched certificates. We could have a polling loop that gets the `KeyMaterial` every minute and exports that, but it's not ideal. Adding this callback lets us update the metric only when the material on disk has just been checked (default every hour).

I looked into adding tests for this callback but it's unexpectedly much more complicated than it seems to do without race conditions: the `OnUpdate` callback is invoked after [`wrappedDistributor.Set`](https://github.com/grpc/grpc-go/blob/e4711283ae08b8ec0fb7378c0ff58a130c366bcd/credentials/tls/certprovider/pemfile/watcher_test.go#L161-L164), which doesn't matter in real operation, but in the tests means that it might not have been called by the time the test case continues after the [channel receive](https://github.com/grpc/grpc-go/blob/e4711283ae08b8ec0fb7378c0ff58a130c366bcd/credentials/tls/certprovider/pemfile/watcher_test.go#L331), so will be flaky. Because of the structure of the provider/distributor wrapping, this isn't easy to workaround, and doing this properly synchronised would require rewriting lots of the test harness. So for this tiny addition, I've just skipped adding tests.

RELEASE NOTES:
* `authz`: add an `OnUpdate` callback to `pemfile.Options`