### PR TITLE
server: Remove service from updates if no streams remain [leakfix]

### DIFF
--- a/health/server.go
+++ b/health/server.go
@@ -108,8 +108,8 @@ func (s *Server) Watch(in *healthpb.HealthCheckRequest, stream healthgrpc.Health
 		s.mu.Lock()
 		delete(s.updates[service], stream)
 		if len(s.updates[service]) == 0 {
-            delete(s.updates, service)
-        }
+			delete(s.updates, service)
+		}
 		s.mu.Unlock()
 	}()
 	s.mu.Unlock()

--- a/health/server.go
+++ b/health/server.go
@@ -107,6 +107,9 @@ func (s *Server) Watch(in *healthpb.HealthCheckRequest, stream healthgrpc.Health
 	defer func() {
 		s.mu.Lock()
 		delete(s.updates[service], stream)
+		if len(s.updates[service]) == 0 {
+            delete(s.updates, service)
+        }
 		s.mu.Unlock()
 	}()
 	s.mu.Unlock()


### PR DESCRIPTION
## The bug

`health/server.go` (v1.73.0, lines 107-111):

```go
defer func() {
    [s.mu](http://s.mu/).Lock()
    delete(s.updates[service], stream)
    [s.mu](http://s.mu/).Unlock()
}()
```
Currently we accept a service name and unconditionally add it as a key to an in memory nested map (that is maintained for the lifetime of the process). Upon receiving an unauthenticated watch request, we immediately add that hitherto unvalidated service name into the map. Upon disconnection, we remove the stream objects from the inner map, but fail to remove the keys from the outer map, leaving behind those unvalidated strings as keys in the outer map for the lifetime of the process..

Potential impact:
Unauthenticated users can leave behind very large strings that the process will maintain references to until the process restarts. The strings can be up to 4 MiB in size per request, leading to very rapid memory exhaustion of the service in the event of an attack from a malicious actor.

## Fix

Delete the inner map when it empties, in the cleanup that already holds the
lock:

```go
defer func() {
    [s.mu](http://s.mu/).Lock()
    delete(s.updates[service], stream)
    if len(s.updates[service]) == 0 {
        delete(s.updates, service)
    }
    [s.mu](http://s.mu/).Unlock()
}()
```

Verified against a patched v1.73.0: the same 200 cycles end at `services=0`
with ~4 MiB of growth, down from 200 and 208.4 MiB.

RELEASE NOTES:
* `health/server.go`: Address resource leak, remove service entry in map when empty.